### PR TITLE
Enable commands in the bucket

### DIFF
--- a/lib/commands.ps1
+++ b/lib/commands.ps1
@@ -1,7 +1,20 @@
+. "$psscriptroot\buckets.ps1"
+
+if ($cmd.Contains('/')) {
+    $bucket, $cmd = $cmd -split ('/');
+    $bucketcmd = "$bucketsdir\$bucket\commands"
+    $bucketcmd_exists = Test-Path $bucketcmd
+}
+
 function command_files {
-    (gci (relpath '..\libexec')) `
-        + (gci "$scoopdir\shims") `
-        | where { $_.name -match 'scoop-.*?\.ps1$' }
+    if ($bucket -and $bucketcmd_exists) {
+        $files = gci ($bucketcmd)
+    }
+    else {
+        $files = (gci (relpath '..\libexec')) + (gci "$scoopdir\shims")        
+    }
+
+    $files | where { $_.name -match 'scoop-.*?\.ps1$' }
 }
 
 function commands {
@@ -13,14 +26,19 @@ function command_name($filename) {
 }
 
 function command_path($cmd) {
-    $cmd_path = relpath "..\libexec\scoop-$cmd.ps1"
+    if ($bucketcmd_exists) {
+        $cmd_path = "$bucketcmd\scoop-$cmd.ps1"
+    }
+    else {
+        $cmd_path = relpath "..\libexec\scoop-$cmd.ps1"        
+    }
 
     # built in commands
     if (!(Test-Path $cmd_path)) {
         # get path from shim
         $shim_path = "$scoopdir\shims\scoop-$cmd.ps1"
         $line = ((gc $shim_path) | where { $_.startswith('$path') })
-        if($line) {
+        if ($line) {
             iex -command "$line"
             $cmd_path = $path
         }

--- a/lib/commands.ps1
+++ b/lib/commands.ps1
@@ -1,6 +1,6 @@
 . "$psscriptroot\buckets.ps1"
 
-if ($cmd.Contains('/')) {
+if ($cmd -and $cmd.Contains('/')) {
     $bucket, $cmd = $cmd -split ('/');
     $bucketcmd = "$bucketsdir\$bucket\commands"
     $bucketcmd_exists = Test-Path $bucketcmd

--- a/lib/commands.ps1
+++ b/lib/commands.ps1
@@ -11,7 +11,7 @@ function command_files {
         $files = gci ($bucketcmd)
     }
     else {
-        $files = (gci (relpath '..\libexec')) + (gci "$scoopdir\shims")        
+        $files = (gci (relpath '..\libexec')) + (gci "$scoopdir\shims")
     }
 
     $files | where { $_.name -match 'scoop-.*?\.ps1$' }
@@ -30,7 +30,7 @@ function command_path($cmd) {
         $cmd_path = "$bucketcmd\scoop-$cmd.ps1"
     }
     else {
-        $cmd_path = relpath "..\libexec\scoop-$cmd.ps1"        
+        $cmd_path = relpath "..\libexec\scoop-$cmd.ps1"
     }
 
     # built in commands


### PR DESCRIPTION
this PR enable bucket commands in the /commands directory
usage:
`scoop php/info $args` 