### PR TITLE
Add bucket_file to installer/uninstaller

### DIFF
--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -23,7 +23,7 @@ function do_uninstall($app, $global) {
     $architecture = $install.architecture
 
     echo "Uninstalling '$app'"
-    run_uninstaller $manifest $architecture $dir
+    run_uninstaller $manifest $architecture $dir $install.bucket
     rm_shims $manifest $global $architecture
 
     # If a junction was used during install, that will have been used

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -672,7 +672,7 @@ function run_uninstaller($manifest, $architecture, $dir, $bucket) {
                 $bucketdir = $(bucketdir $bucket)
                 $exe = "$bucketdir\$($uninstaller.bucket_file)"
                 if(!(is_in_dir $bucketdir $exe)) {
-                    warn "Error in manifest: Installer $exe is outside the app directory, skipping."
+                    warn "Error in manifest: Installer $exe is outside the bucket directory, skipping."
                     $exe = $null;
                 }
             } else {

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -56,7 +56,7 @@ $apps | % {
     $install = install_info $app $version $global
     $architecture = $install.architecture
 
-    run_uninstaller $manifest $architecture $dir
+    run_uninstaller $manifest $architecture $dir $install.bucket
     rm_shims $manifest $global $architecture
     rm_startmenu_shortcuts $manifest $global $architecture
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -136,7 +136,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     $dir = versiondir $app $old_version $global
 
     write-host "Uninstalling '$app' ($old_version)"
-    run_uninstaller $old_manifest $architecture $dir
+    run_uninstaller $old_manifest $architecture $dir $bucket
     rm_shims $old_manifest $global $architecture
     env_rm_path $old_manifest $dir $global
     env_rm $old_manifest $global

--- a/schema.json
+++ b/schema.json
@@ -243,6 +243,9 @@
                 "script": {
                     "type": "string"
                 },
+                "bucket_file": {
+                    "type": "string"
+                },
                 "keep": {
                     "type": "boolean"
                 }
@@ -286,6 +289,9 @@
                     "type": "string"
                 },
                 "script": {
+                    "type": "string"
+                },
+                "bucket_file": {
                     "type": "string"
                 }
             },


### PR DESCRIPTION
This allows installers/uninstallers (e.g. powershell scripts) to be stored in the bucket, instead of having to download them twice, or store them in the json file (which VS Code doesn't like).