### PR TITLE
 Implement SourceForge checkver functionality

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -54,6 +54,7 @@ $queue | ForEach-Object {
     $name, $json = $_
 
     $githubRegex = "\/releases\/tag\/(?:v)?([\d.]+)"
+    $sourceforgeRegex = "(?:.*)?\/(?:v)?([\d.]+)\/"
 
     $url = $json.homepage
     if($json.checkver.url) {
@@ -74,6 +75,34 @@ $queue | ForEach-Object {
     if ($json.checkver.github) {
         $url = $json.checkver.github + "/releases/latest"
         $regex = $githubRegex
+    }
+
+    if ($json.checkver -eq "sourceforge" -or $json.homepage.Contains("sourceforge.net") -or $json.checkver.sourceforge.path) {
+        if ($json.homepage -match "\/\/sourceforge\.net\/projects\/(?<project>([\w-]+$|[\w-]+))(?:[/]?)" -or $json.homepage -match "\/\/(?<project>[\w-]+)\.sourceforge\.net") {
+            $url = "https://sourceforge.net/projects/" + $matches['project'] + "/rss"
+            $regex = "\/\/sourceforge\.net\/projects\/" + $matches['project'] + $sourceforgeRegex
+            if ($json.checkver -ne "sourceforge" -and $json.checkver.GetType() -eq [System.String]) {
+                $regex = $json.checkver
+            }
+        }
+        else {
+            $url = "https://sourceforge.net/projects/" + (strip_ext $name) + "/rss"
+            $regex = "\/\/sourceforge\.net\/projects\/" + (strip_ext $name) + $sourceforgeRegex
+        }
+    }
+
+    if ($json.checkver.sourceforge -and $json.checkver.sourceforge.GetType() -eq [System.String]) {
+        $url = "https://sourceforge.net/projects/" + $json.checkver.sourceforge + "/rss"
+        $regex = "\/\/sourceforge\.net\/projects\/" + $json.checkver.sourceforge + $sourceforgeRegex
+    }
+
+    if ($json.checkver.sourceforge.project) {
+        $url = "https://sourceforge.net/projects/" + $json.checkver.sourceforge.project + "/rss"
+        $regex = "\/\/sourceforge\.net\/projects\/" + $json.checkver.sourceforge.project + $sourceforgeRegex   
+    }
+
+    if ($json.checkver.sourceforge.path) {
+        $url = $url + "?path=" + $json.checkver.sourceforge.path
     }
 
     if($json.checkver.re) {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -98,7 +98,7 @@ $queue | ForEach-Object {
 
     if ($json.checkver.sourceforge.project) {
         $url = "https://sourceforge.net/projects/" + $json.checkver.sourceforge.project + "/rss"
-        $regex = "\/\/sourceforge\.net\/projects\/" + $json.checkver.sourceforge.project + $sourceforgeRegex   
+        $regex = "\/\/sourceforge\.net\/projects\/" + $json.checkver.sourceforge.project + $sourceforgeRegex
     }
 
     if ($json.checkver.sourceforge.path) {

--- a/bucket/astyle.json
+++ b/bucket/astyle.json
@@ -1,14 +1,14 @@
 {
-    "homepage": "http://astyle.sourceforge.net/",
+    "homepage": "http://sourceforge.net/project/astyle",
     "description": "A Free, Fast, and Small Automatic Formatter for C, C++, C++/CLI, Objective‑C, C#, and Java Source Code",
     "version": "3.1",
     "license": "MIT",
-    "url": [
-        "https://sourceforge.net/projects/astyle/files/astyle/astyle%203.1/AStyle_3.1_windows.zip"
-    ],
-    "hash": [
-        "0759d0a3b3ad768e0f1984b6faf22c5d9d53c2e081d1cfbd1cc7d6e955e995cb"
-    ],
-    "bin": "AStyle\\bin\\AStyle.exe",
-    "checkver": "Artistic Style ([\\d.]+)"
+    "url": "https://downloads.sourceforge.net/project/astyle/astyle/astyle%203.1/AStyle_3.1_windows.zip",
+    "hash": "sha1:5372ca57577f252cb6efdde12f889329786a72a2",
+    "extract_dir": "AStyle",
+    "bin": "bin\\AStyle.exe",
+    "checkver": "//sourceforge.net/projects/(?:.*)?/files/(?<path>(?:.*)?/AStyle_([\\d.]+)_windows.zip)/",
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/astyle/$matchPath"
+    }
 }

--- a/bucket/atomicparsley.json
+++ b/bucket/atomicparsley.json
@@ -4,7 +4,12 @@
     "version": "0.9.0",
     "license": "GPL-2.0",
     "url": "https://downloads.sourceforge.net/project/atomicparsley/atomicparsley/AtomicParsley%20v0.9.0/AtomicParsley-win32-0.9.0.zip",
-    "hash": "f363630462ea01d7de948c3e4d231159fa91916d8d7f971a7e8b3bc478dbe846",
+    "hash": "sha1:4cddc997e0372234dff85decb2bfd1a074489404",
     "extract_dir": "AtomicParsley-win32-0.9.0",
-    "bin": "AtomicParsley.exe"
+    "bin": "AtomicParsley.exe",
+    "checkver": "//sourceforge.net/projects/(?:.*)?/files/(?<path>(?:.*)?/AtomicParsley-win32-([\\d.]+).zip)/",
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/atomicparsley/$matchPath",
+        "extract_dir": "AtomicParsley-win32-$version"
+    }
 }

--- a/bucket/bochs.json
+++ b/bucket/bochs.json
@@ -21,10 +21,7 @@
             ]
         }
     },
-    "checkver": {
-        "url": "http://bochs.sourceforge.net/getcurrent.html",
-        "re": "<b>Latest release:<\\/b> Bochs ([\\d.]+)"
-    },
+    "checkver": "sourceforge",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/cdrtools.json
+++ b/bucket/cdrtools.json
@@ -1,4 +1,13 @@
 {
+    "homepage": "https://sourceforge.net/projects/tumagcc/",
+    "license": {
+        "identifier": "CDDL-1.0,GPL-2.0,LGPL-2.1",
+        "url": "https://github.com/jobermayr/cdrtools/blob/master/COPYING"
+    },
+    "description": "Burn and read CDs, DVDs, and Blu-ray discs",
+    "version": "3.01",
+    "url": "https://downloads.sourceforge.net/project/tumagcc/schily-cdrtools-3.01.7z",
+    "hash": "sha1:d922e99638e427ed680069e87f319fc585a99749",
     "architecture": {
         "32bit": {
             "extract_dir": "win32"
@@ -6,9 +15,6 @@
         "64bit": {
             "extract_dir": "win64"
         }
-    },
-    "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/tumagcc/schily-cdrtools-$version.7z"
     },
     "bin": [
         "btcflash.exe",
@@ -26,13 +32,8 @@
         "scgcheck.exe",
         "scgskeleton.exe"
     ],
-    "description": "Burn and read CDs, DVDs, and Blu-ray discs",
-    "hash": "f534062cab7585b82bd764f02bc65fb0c7c27ac1615786bfc81c35880ce4acc6",
-    "homepage": "https://sourceforge.net/projects/tumagcc/",
-    "license": {
-        "identifier": "CDDL-1.0,GPL-2.0,LGPL-2.1",
-        "url": "https://github.com/jobermayr/cdrtools/blob/master/COPYING"
-    },
-    "url": "https://downloads.sourceforge.net/project/tumagcc/schily-cdrtools-3.01.7z",
-    "version": "3.01"
+    "checkver": "//sourceforge.net/projects/(?:.*)?/schily-cdrtools-([\\d.]+).7z/",
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/tumagcc/schily-cdrtools-$version.7z"
+    }
 }

--- a/bucket/ctags.json
+++ b/bucket/ctags.json
@@ -5,7 +5,11 @@
     "url": "https://downloads.sourceforge.net/project/ctags/ctags/5.8/ctags58.zip",
     "extract_dir": "ctags58",
     "bin": "ctags.exe",
-    "hash": "e1f5909ec0c7a58fd2149139fa6a1dc532070a3d919dd183671c57a32f8b243d",
+    "hash": "sha1:93b5c200d788933ce7f3f3b130f285bd2c0137e0",
     "license": "GPL-2.0",
-    "checkver": "Version ([\\d.]+)"
+    "checkver": "sourceforge",
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/ctags/ctags/$version/ctags$cleanVersion.zip",
+        "extract_dir": "ctags$cleanVersion"
+    }
 }

--- a/bucket/dos2unix.json
+++ b/bucket/dos2unix.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/dos2unix/dos2unix/7.4.0/dos2unix-7.4.0-win64.zip",
-            "hash": "1e3db91000c217c2de84f231615a2cc88dad275d8fa0f6698bbfd5f7d0c50a1b"
+            "hash": "sha1:5ce7ab6bcc7973a82a7ac463afefc2595c480cbb"
         },
         "32bit": {
             "url": "https://downloads.sourceforge.net/project/dos2unix/dos2unix/7.4.0/dos2unix-7.4.0-win32.zip",
-            "hash": "12d9188179b0d5526df9044f0e8d3bc11e80201110fd520f21842e27e4ebd4fe"
+            "hash": "sha1:81ef625219c21de67ba4e6ab5b608d292d32eb74"
         }
     },
     "bin": [
@@ -18,5 +18,16 @@
         "bin\\mac2unix.exe",
         "bin\\unix2dos.exe",
         "bin\\unix2mac.exe"
-    ]
+    ],
+    "checkver": "sourceforge",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/dos2unix/dos2unix/$version/dos2unix-$version-win64.zip"
+            },
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/dos2unix/dos2unix/$version/dos2unix-$version-win32.zip"
+            }
+        }
+    }
 }

--- a/bucket/dosbox.json
+++ b/bucket/dosbox.json
@@ -3,7 +3,7 @@
     "version": "0.74",
     "license": "GPL-2.0",
     "url": "https://downloads.sourceforge.net/project/dosbox/dosbox/0.74/DOSBox0.74-win32-installer.exe",
-    "hash": "c149cb85f732beb95bf6564d72bdfdd9306f7050edfd9d2cd475420efe3b84fc",
+    "hash": "sha1:b4d671ed3fc1fc36aaf8abc1341d2ddaaafa8f88",
     "installer": {
         "args": [
             "/S",
@@ -15,5 +15,8 @@
         "SDL.dll",
         "SDL_net.dll"
     ],
-    "checkver": "Latest version:\\s+<a[^>]+>([\\d.]+)"
+    "checkver": "sourceforge",
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/dosbox/dosbox/$version/DOSBox$version-win32-installer.exe"
+    }
 }

--- a/bucket/editorconfig.json
+++ b/bucket/editorconfig.json
@@ -6,8 +6,9 @@
     "hash": "sha1:7c44b819690baec3de22edc0c9f7eb21dc0a7850",
     "bin": "bin/editorconfig.exe",
     "checkver": {
-        "url": "https://sourceforge.net/projects/editorconfig/files/EditorConfig-C-Core/",
-        "re": "title=\"([\\d.]+)\"\\sclass=\"folder"
+        "sourceforge": {
+            "path": "/EditorConfig-C-Core"
+        }
     },
     "autoupdate": {
         "url": "https://downloads.sourceforge.net/project/editorconfig/EditorConfig-C-Core/$version/binary-Windows/editorconfig-$version-Windows-x86.zip",

--- a/bucket/exiftool.json
+++ b/bucket/exiftool.json
@@ -13,7 +13,10 @@
             "exiftool"
         ]
     ],
-    "checkver": "exiftool-([\\d.]+).zip",
+    "checkver": {
+        "sourceforge": "exiftool",
+        "re": "//sourceforge.net/projects/exiftool/files/exiftool-([\\d.]+).zip/"
+    },
     "autoupdate": {
         "url": "https://downloads.sourceforge.net/project/exiftool/exiftool-$version.zip"
     }

--- a/bucket/gcc.json
+++ b/bucket/gcc.json
@@ -5,15 +5,32 @@
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z",
-            "hash": "853970527B5DE4A55EC8CA4D3FD732C00AE1C69974CC930C82604396D43E79F8",
+            "hash": "sha1:5aa456654a6ce77249c27888b5d0f856fc011b9c",
             "extract_dir": "mingw64"
         },
         "32bit": {
             "url": "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-posix/dwarf/i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z",
-            "hash": "ADB84B70094C0225DD30187FF995E311D19424B1EB8F60934C60E4903297F946",
+            "hash": "sha1:dd4f34f473e84c79b6b446adb3a5fac7919ba9cb",
             "extract_dir": "mingw32"
         }
     },
     "env_add_path": "bin",
+    "checkver": {
+        "sourceforge": {
+            "project": "mingw-w64",
+            "path": "/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds"
+        },
+        "re": "/([\\d.]+)/threads-posix/seh/x86_64-(?:[\\d.]+)-release-posix-seh-(?<rev>.*?).7z/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/$version/threads-posix/seh/x86_64-$version-release-posix-seh-$matchRev.7z"
+            },
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/$version/threads-posix/dwarf/i686-$version-release-posix-dwarf-$matchRev.7z"
+            }
+        }
+    },
     "notes": "The 64bit version is built with Structured Exception Handling (SEH), the 32bit is built with DWARF. Both 64bit and 32bit support Posix threading model"
 }

--- a/bucket/gdb.json
+++ b/bucket/gdb.json
@@ -13,5 +13,12 @@
             "extract_dir": "gdb32"
         }
     },
-    "env_add_path": "bin"
+    "env_add_path": "bin",
+    "checkver": {
+        "sourceforge": {
+            "project": "tdm-gcc",
+            "path": "/GDB"
+        },
+        "re": "gdb-([\\d.]+)-tdm"
+    }
 }

--- a/bucket/graphicsmagick-q16.json
+++ b/bucket/graphicsmagick-q16.json
@@ -35,8 +35,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://sourceforge.net/p/graphicsmagick/news/?source=navbar",
-        "re": "GraphicsMagick ([\\d].[\\d].[\\d]+)"
+        "sourceforge": {
+            "project": "graphicsmagick",
+            "path": "/graphicsmagick-binaries"
+        }
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/graphicsmagick-q8.json
+++ b/bucket/graphicsmagick-q8.json
@@ -35,8 +35,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://sourceforge.net/p/graphicsmagick/news/?source=navbar",
-        "re": "GraphicsMagick ([\\d].[\\d].[\\d]+)"
+        "sourceforge": {
+            "project": "graphicsmagick",
+            "path": "/graphicsmagick-binaries"
+        }
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/inadyn-mt.json
+++ b/bucket/inadyn-mt.json
@@ -3,17 +3,13 @@
     "homepage": "https://sourceforge.net/projects/inadyn-mt/files/inadyn-mt/",
     "license": "GPL-3.0",
     "version": "02.28.10",
-    "autoupdate": {
-        "extract_dir": "inadyn-mt.v.$version",
-        "url": "https://downloads.sourceforge.net/project/inadyn-mt/inadyn-mt/inadyn-mt.v.$version/inadyn-mt.v.$version.tar.gz"
-    },
+    "url": "https://downloads.sourceforge.net/project/inadyn-mt/inadyn-mt/inadyn-mt.v.02.28.10/inadyn-mt.v.02.28.10.tar.gz",
     "bin": "bin/win32/inadyn-mt.exe",
-    "checkver": "title=\"/inadyn-mt/inadyn-mt\\.v\\.([\\d.]+)",
     "depends": [
         "sudo"
     ],
     "extract_dir": "inadyn-mt.v.02.28.10",
-    "hash": "f69bea12d96b66f9f662a8df0730c60457b24f5fb5308b109936880ebf7be5ca",
+    "hash": "sha1:176d47ceb2ddf854c3401fd0ae858d38245810a1",
     "notes": [
         "To install and run as a service:",
         "> notepad $dir\\bin\\win32\\inadyn-mt.conf",
@@ -50,5 +46,9 @@
     "uninstaller": {
         "script": "sudo \"$dir/bin/win32/inadyn-mt.exe\" -x"
     },
-    "url": "https://downloads.sourceforge.net/project/inadyn-mt/inadyn-mt/inadyn-mt.v.02.28.10/inadyn-mt.v.02.28.10.tar.gz"
+    "checkver": "//sourceforge.net/projects/(?:.*)?/files/(?<path>(?:.*)?/inadyn-mt.v.([\\d.]+).tar.gz)/",
+    "autoupdate": {
+        "extract_dir": "inadyn-mt.v.$version",
+        "url": "https://downloads.sourceforge.net/project/inadyn-mt/inadyn-mt/inadyn-mt.v.$version/inadyn-mt.v.$version.tar.gz"
+    }
 }

--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,8 +1,11 @@
 {
     "homepage": "http://innounp.sourceforge.net",
     "version": "0.47",
-    "url": "https://github.com/scoopinstaller/binary-mirror/raw/master/innounp/innounp047.rar",
+    "url": "https://downloads.sourceforge.net/project/innounp/innounp/innounp%200.47/innounp047.rar",
     "hash": "sha1:ba0cebf7e3003847d5ed5811620c54d7576146e7",
     "bin": "innounp.exe",
-    "checkver": "Version\\s+([\\d.]+)\\s*<br>"
+    "checkver": "//sourceforge.net/projects/(?:.*)?/files/(?<path>(?:.*)?/innounp%20([\\d.]+)/innounp(?:[\\d]+).rar)/",
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/innounp/innounp/innounp%20$version/innounp$cleanVersion.rar"
+    }
 }

--- a/bucket/msys2.json
+++ b/bucket/msys2.json
@@ -23,7 +23,9 @@
     "env_add_path": ".",
     "notes": "Please run 'msys2' now for the MSYS2 setup to complete!",
     "checkver": {
-        "url": "https://sourceforge.net/projects/msys2/files/Base/x86_64/",
+        "sourceforge": {
+            "path": "/Base"
+        },
         "re": "/msys2-base-x86_64-(\\d+).tar.xz"
     },
     "autoupdate": {

--- a/bucket/optipng.json
+++ b/bucket/optipng.json
@@ -6,7 +6,7 @@
     "hash": "sha1:2a1484d27bf63c7a15c3494eea95a2c804f5bdbc",
     "extract_dir": "optipng-0.7.7-win32",
     "bin": "optipng.exe",
-    "checkver": "([\\d.]+)<\\/b><\\/font> \\(stable\\)",
+    "checkver": "//sourceforge.net/projects/(?:.*)?/OptiPNG/optipng-([\\d.]+)/optipng-(?:[\\d.]+)-win32.zip/",
     "autoupdate": {
         "url": "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-$version/optipng-$version-win32.zip",
         "extract_dir": "optipng-$version-win32"

--- a/bucket/pngcrush.json
+++ b/bucket/pngcrush.json
@@ -16,8 +16,10 @@
         "pngcrush.exe"
     ],
     "checkver": {
-        "url": "https://sourceforge.net/projects/pmt/files/pngcrush-executables/",
-        "re": "title=\"([0-9\\.]+)\""
+        "sourceforge": {
+            "project": "pmt",
+            "path": "/pngcrush-executables"
+        }
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/potrace.json
+++ b/bucket/potrace.json
@@ -15,7 +15,7 @@
         }
     },
     "bin": "potrace.exe",
-    "checkver": "potrace-([\\d.]+)\\.win64\\.zip",
+    "checkver": "sourceforge",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/which.json
+++ b/bucket/which.json
@@ -2,11 +2,15 @@
     "homepage": "http://gnuwin32.sourceforge.net/packages/which.htm",
     "version": "2.20",
     "license": "GPL-2.0",
-    "url": [
-        "https://sourceforge.net/projects/gnuwin32/files/which/2.20/which-2.20-bin.zip"
-    ],
-    "hash": [
-        "035ec15541649f75459fb81f02406c72e1129fc9041b308160938ae712a603a4"
-    ],
-    "bin": "bin\\which.exe"
+    "url": "https://sourceforge.net/projects/gnuwin32/files/which/2.20/which-2.20-bin.zip",
+    "hash": "sha1:385990045d755bb910d2c30b9697faf36d61e37e",
+    "bin": "bin\\which.exe",
+    "checkver": {
+        "sourceforge": {
+            "path": "/which"
+        }
+    },
+    "autoupdate": {
+        "url": "https://sourceforge.net/projects/gnuwin32/files/which/$version/which-$version-bin.zip"
+    }
 }

--- a/bucket/xming.json
+++ b/bucket/xming.json
@@ -2,10 +2,30 @@
     "homepage": "http://www.straightrunning.com/XmingNotes/",
     "version": "6.9.0.31",
     "description": "Run X GUI applications on bash subsystem or linux VM, and have them rendered on Windows Desktop. http://www.pcworld.com/article/3055403/windows/windows-10s-bash-shell-can-run-graphical-linux-applications-with-this-trick.html",
-    "url": "https://downloads.sourceforge.net/project/xming/Xming-mesa/6.9.0.31/Xming-mesa-6-9-0-31-setup.exe?r=scoop",
-    "hash": "md5:E580DEBBF6110CFC4D8FCD20BEB541C1",
+    "url": "https://downloads.sourceforge.net/project/xming/Xming-mesa/6.9.0.31/Xming-mesa-6-9-0-31-setup.exe",
+    "hash": "sha1:026442d1502827735fdb203009026b86f4b842f0",
     "innosetup": true,
+    "shortcuts": [
+        [
+            "Xming.exe",
+            "Xming"
+        ],
+        [
+            "XLaunch.exe",
+            "XLaunch"
+        ]
+    ],
     "bin": [
-        "XLaunch.exe"
-    ]
+        "xming.exe",
+        "xkbcomp.exe",
+        "xlaunch.exe"
+    ],
+    "checkver": {
+        "sourceforge": {
+            "path": "/Xming-mesa"
+        }
+    },
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/xming/Xming-mesa/$version/Xming-mesa-$majorVersion-$minorVersion-$patchVersion-$buildVersion-setup.exe"
+    }
 }

--- a/bucket/xming.json
+++ b/bucket/xming.json
@@ -26,6 +26,6 @@
         }
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/xming/Xming-mesa/$version/Xming-mesa-$majorVersion-$minorVersion-$patchVersion-$buildVersion-setup.exe"
+        "url": "https://downloads.sourceforge.net/project/xming/Xming-mesa/$version/Xming-mesa-$dashVersion-setup.exe"
     }
 }

--- a/bucket/xmlstarlet.json
+++ b/bucket/xmlstarlet.json
@@ -1,18 +1,15 @@
 {
-    "autoupdate": {
-        "extract_dir": "xmlstarlet-$version",
-        "url": "https://downloads.sourceforge.net/project/xmlstar/xmlstarlet/$version/xmlstarlet-$version-win32.zip"
-    },
-    "bin": "xml.exe",
-    "checkver": {
-        "re": "/files/latest/download\\?source=files\"\\s+title=\"/xmlstarlet/([\\d.]+)",
-        "url": "https://sourceforge.net/projects/xmlstar/files/"
-    },
     "description": "Transform, query, validate, and edit XML files",
-    "extract_dir": "xmlstarlet-1.6.1",
-    "hash": "sha1:cc5f5cd17a1f81740e5185a70408ffd6fa2f862d",
     "homepage": "http://xmlstar.sourceforge.net/",
     "license": "MIT",
     "url": "https://downloads.sourceforge.net/project/xmlstar/xmlstarlet/1.6.1/xmlstarlet-1.6.1-win32.zip",
-    "version": "1.6.1"
+    "hash": "sha1:cc5f5cd17a1f81740e5185a70408ffd6fa2f862d",
+    "version": "1.6.1",
+    "extract_dir": "xmlstarlet-1.6.1",
+    "bin": "xml.exe",
+    "checkver": "sourceforge",
+    "autoupdate": {
+        "extract_dir": "xmlstarlet-$version",
+        "url": "https://downloads.sourceforge.net/project/xmlstar/xmlstarlet/$version/xmlstarlet-$version-win32.zip"
+    }
 }

--- a/schema.json
+++ b/schema.json
@@ -221,6 +221,25 @@
                         "replace": {
                             "description": "Allows rearrange the regexp matches",
                             "type": "string"
+                        },
+                        "sourceforge": {
+                            "anyOf": [
+                                {
+                                    "format": "regex",
+                                    "type": "string"
+                                },
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "project": {
+                                            "type": "string"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "type": "object"


### PR DESCRIPTION
In it's most simple form:
```
    "checkver": "sourceforge",
```
This will find the project name from homepage, or if that fails, from the manifest name.

A more comples example:
```
    "checkver": {
        "sourceforge": {
            "project": "pmt",
            "path": "/pngcrush-executables"
        }
    },
```
Here we provide the project name, and a path into the files section (to limit number of downloads). `project` is optional and only needed if `homepage` or manifest name is not equal to the SourceForge project name.

Regex can be applied as normal, on the `checkver` property, or on the `re` property. The default regex is `"(?:.*)?\/(?:v)?([\d.]+)\/"` plus the path to the project.

