### PR TITLE
install.ps1: Add portableapps.com to strip_filename skips

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -350,7 +350,7 @@ function dl($url, $to, $cookies, $progress) {
     $wreq = [net.webrequest]::create($reqUrl)
     if($wreq -is [net.httpwebrequest]) {
         $wreq.useragent = Get-UserAgent
-        if (-not ($url -imatch "sourceforge\.net")) {
+        if (-not ($url -imatch "sourceforge\.net" -or $url -imatch "portableapps\.com")) {
             $wreq.referer = strip_filename $url
         }
         if($cookies) {


### PR DESCRIPTION
Portableapps.com has switched back to hosting freeware under their own download3.portableapps.com mirror.