### PR TITLE
Fix install.ps1

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -1,29 +1,42 @@
 # requires -v 3
 
 # remote install:
-#   iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+#   iex (iwr https://get.scoop.sh)
 $old_erroractionpreference = $erroractionpreference
 $erroractionpreference = 'stop' # quit if anything goes wrong
 
+function KillScoopInstall() { 
+    if ($ScoopInstallDontKill) { return }
+    if ($ScoopInstallConfirmKill) {
+        if ((Read-Host -prompt "Continue? [y/N]") -match "^[yY]") { # Continues on anything starting with "y" or "Y"
+            Write-Output "Continuing..."
+            return
+        }
+    }
+    $erroractionpreference = $old_erroractionpreference
+    Remove-Item -path Function:KillScoopInstall # Doesn't make sense to leave it hanging around...
+    throw "A requirement failed and the install was stopped. Please review the output."
+}
+
 if(($PSVersionTable.PSVersion.Major) -lt 3) {
-    Write-Output "PowerShell 3 or greater is required to run Scoop."
-    Write-Output "Upgrade PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell"
-    break
+    Write-Host "PowerShell 3 or greater is required to run Scoop."
+    Write-Host "Upgrade PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell"
+    KillScoopInstall
 }
 
 # show notification to change execution policy:
-if((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
-    Write-Output "PowerShell requires an execution policy of 'RemoteSigned' to run Scoop."
-    Write-Output "To make this change please run:"
-    Write-Output "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"
-    break
+if((Get-ExecutionPolicy) -gt 'RemoteSigned') {
+    Write-Host "PowerShell requires an execution policy of 'RemoteSigned' to run Scoop."
+    Write-Host "To make this change please run:"
+    Write-Host "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"
+    KillScoopInstall
 }
 
 if([System.Enum]::GetNames([System.Net.SecurityProtocolType]) -notcontains 'Tls12') {
-    Write-Output "Scoop requires at least .NET Framework 4.5"
-    Write-Output "Please download and install it first:"
-    Write-Output "https://www.microsoft.com/net/download"
-    break
+    Write-Host "Scoop requires at least .NET Framework 4.5"
+    Write-Host "Please download and install it first:"
+    Write-Host "https://www.microsoft.com/net/download"
+    KillScoopInstall
 }
 
 # get core functions
@@ -33,32 +46,32 @@ Invoke-Expression (new-object net.webclient).downloadstring($core_url)
 
 # prep
 if(installed 'scoop') {
-    write-host "Scoop is already installed. Run 'scoop update' to get the latest version." -f red
-    # don't abort if invoked with iex that would close the PS session
-    if($myinvocation.mycommand.commandtype -eq 'Script') { return } else { exit 1 }
+    Write-Host "Scoop is already installed. Please run 'scoop update' to get the latest version." -f red
+    KillScoopInstall
 }
 $dir = ensure (versiondir 'scoop' 'current')
 
 # download scoop zip
-$zipurl = 'https://github.com/lukesampson/scoop/archive/master.zip'
-$zipfile = "$dir\scoop.zip"
-Write-Output 'Downloading...'
-dl $zipurl $zipfile
+$zip_url = 'https://github.com/lukesampson/scoop/archive/master.zip'
+$zip_file = "$dir\scoop.zip"
+Write-Host 'Downloading...'
+dl $zip_url $zip_file
 
 'Extracting...'
 Add-Type -Assembly "System.IO.Compression.FileSystem"
-[IO.Compression.ZipFile]::ExtractToDirectory($zipfile,"$dir\_tmp")
+[IO.Compression.ZipFile]::ExtractToDirectory($zip_file,"$dir\_tmp")
 Copy-Item "$dir\_tmp\scoop-master\*" $dir -r -force
 Remove-Item "$dir\_tmp" -r -force
-Remove-Item $zipfile
+Remove-Item $zip_file
 
-Write-Output 'Creating shim...'
+Write-Host 'Creating shim...'
 shim "$dir\bin\scoop.ps1" $false
 
 ensure_robocopy_in_path
 ensure_scoop_in_path
 scoop config lastupdate ([System.DateTime]::Now.ToString('o'))
 success 'Scoop was installed successfully!'
-Write-Output "Type 'scoop help' for instructions."
+Write-Host "Type 'scoop help' for instructions."
 
+Remove-Item -path Function:KillScoopInstall # Doesn't make sense to leave it hanging around...
 $erroractionpreference = $old_erroractionpreference # Reset $erroractionpreference to original value

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -25,7 +25,7 @@ if(($PSVersionTable.PSVersion.Major) -lt 3) {
 }
 
 # show notification to change execution policy:
-if((Get-ExecutionPolicy) -gt 'RemoteSigned') {
+if((Get-ExecutionPolicy) -gt 'RemoteSigned' -and (Get-ExecutionPolicy) -ne 'Bypass') {
     Write-Host "PowerShell requires an execution policy of 'RemoteSigned' to run Scoop."
     Write-Host "To make this change please run:"
     Write-Host "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"


### PR DESCRIPTION
## Issue 1: Bypass is accidentally disallowed

This is why I even poked at this script in the first place. The commit where this check was added ([a3cae34](a3cae34)) failed to realize that checking `-or (Get-ExecutionPolicy) -eq "Bypass"` meant that the script would *fail* on Bypass, since if the condition is true, it stops the install instead of continuing it. I've fixed this by replacing it with `-and (Get-ExecutionPolicy) -ne "Bypass"`, meaning if it's greater than RemoteSigned *and* is *not* Bypass, not if it's greater than RemoteSigned or is Bypass.

## Issue 2: Doesn't allow user to force install 

Even though the Bypass thing is silly and should simply be patched out, I think it's worth letting users decide on their own to let the install continue if they really, really want.    
Therefore, `$ScoopInstallDontKill` and `$ScoopInstallConfirmKill` now allow the user to respectively non-interactively and interactively ignore requirements. These probably don't have to be documented anywhere, anyone in a scenario where they make sense would be able to find them on their own or should be asking for help anyway.

## Issue 3: Install failures don't restore environment

Noticed this while working on Issue 2 -- the original script simply returned (or exited, but we'll get to that later)...but success correctly restored a variable. Meaning that the function for ending the install on failure was even more useful. Nice.

## Nitpick: Consistent decisions as to style and commands

It was quite obvious that the one part by one person, and the other wasn't. `$core_file` and `$zipfile`? Write-Host and Write-Output?   
I went ahead and decided Write-Host was correct (scripts that fail should have the human looking over why anyway) and variables should have \_s in them.    
Another decision I made is that there's no reason to check if you're in a script before exiting, as you don't have to -- we already have Error Action set to stop the script, so all we need to do is throw an error and it'll stop. Using "break" is simply hacky.

## Nitpick: remote install

`iex (iwr` works on Powershell 3. Scoop requires Powershell 3. QED. 

---

I realize that this issue comes off as a bit snarky, but it's not meant to be and I apologize if it's rude!! Feel free to point out any issues or such with what I've added.