### PR TITLE
refactor(search): Improve search output and ratelimit handling

### DIFF
--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -63,7 +63,6 @@ function search_bucket($bucket, $query) {
         }
 
         foreach ($shortcut in $app.shortcuts) {
-            $shortcut = $_
             if($shortcut -is [Array] -and $shortcut.length -ge 2) {
                 $name = $shortcut[1]
                 if($name -match $query) {

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -106,7 +106,7 @@ function search_remote($bucket, $query) {
                 }
             } else {
                 $response = Invoke-RestMethod -Uri $request_uri
-                $ratelimit_reached = (github_ratelimit_reached)
+                $ratelimit_reached = github_ratelimit_reached
             }
 
             $result = $response.tree | Where-Object {

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -36,7 +36,7 @@ function search_bucket($bucket, $query) {
     }
 
     try {
-        $query = new-object regex $query, 'IgnoreCase'
+        $query = New-Object Regex $query, 'IgnoreCase'
     } catch {
         abort "Invalid regular expression: $($_.exception.innerexception.message)"
     }

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -84,7 +84,7 @@ function search_remote($bucket, $query) {
 
         if((Get-Command Invoke-RestMethod).parameters.ContainsKey('ResponseHeadersVariable')) {
             $response = Invoke-RestMethod -Uri $request_uri -ResponseHeadersVariable headers
-            $ratelimit_reached = (0 -eq $headers['X-RateLimit-Remaining'][0])
+            $ratelimit_reached = (1 -eq $headers['X-RateLimit-Remaining'][0])
         } else {
             $response = Invoke-RestMethod -Uri $request_uri
             $ratelimit_reached = (github_ratelimit_reached)

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -82,7 +82,7 @@ function search_bucket($bucket, $query) {
 }
 
 function github_ratelimit_reached {
-    (Invoke-RestMethod -Uri 'https://api.github.com/rate_limit').rate.remaining -eq 0
+    return (Invoke-RestMethod -Uri 'https://api.github.com/rate_limit').rate.remaining -eq 0
 }
 
 $ratelimit_reached = github_ratelimit_reached

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -44,7 +44,6 @@ function search_bucket($bucket, $query) {
     $result = @()
 
     foreach ($app in $apps) {
-        $app = $_
         if($app.name -match $query -and !$result.Contains($app)) {
             $result += $app
         }

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -132,7 +132,6 @@ Write-Host 'Searching in local buckets ...'
 $local_results = @()
 
 foreach ($bucket in (Get-LocalBucket) {
-    $bucket = $_
     $result = search_bucket $bucket $query
     if(!$result) {
         return

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -4,7 +4,11 @@
 #
 # If used with [query], shows app names that match the query.
 # Without [query], shows all the available apps.
-param($query)
+param(
+    [Parameter(Mandatory = $true)]
+    $Query,
+    [Switch] $Remote
+)
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\install.ps1"
 . "$psscriptroot\..\lib\versions.ps1"
@@ -146,6 +150,7 @@ Get-LocalBucket | ForEach-Object {
 if(!$local_results) {
     error 'No matches found.'
 
+if(!$local_results -or $Remote) {
     if(!$ratelimit_reached) {
         Write-Host 'Searching in remote buckets ...'
         $remote_results = search_remotes $query

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -62,7 +62,7 @@ function search_bucket($bucket, $query) {
             }
         }
 
-        $app.shortcuts | ForEach-Object {
+        foreach ($shortcut in $app.shortcuts) {
             $shortcut = $_
             if($shortcut -is [Array] -and $shortcut.length -ge 2) {
                 $name = $shortcut[1]

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -131,7 +131,7 @@ function search_remotes($query) {
 Write-Host 'Searching in local buckets ...'
 $local_results = @()
 
-Get-LocalBucket | ForEach-Object {
+foreach ($bucket in (Get-LocalBucket) {
     $bucket = $_
     $result = search_bucket $bucket $query
     if(!$result) {

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -43,7 +43,7 @@ function search_bucket($bucket, $query) {
 
     $result = @()
 
-    $apps | Foreach-Object {
+    foreach ($app in $apps) {
         $app = $_
         if($app.name -match $query -and !$result.Contains($app)) {
             $result += $app


### PR DESCRIPTION
- Now displays the description (local bucket only).
- Use `Invoke-RestMethod`
- Show messages if GitHub rate limit is reached
- Handle rate limit on currently running query (using `X-RateLimit-Remaining` returned by GitHub, PowerShell 6 only)
- Improved binary search (now shows all matches, architectures was ignored)


![image](https://user-images.githubusercontent.com/432127/57474793-3d8e3680-7293-11e9-83bb-6e93073dd8eb.png)

![image](https://user-images.githubusercontent.com/432127/57475907-ac6c8f00-7295-11e9-83a7-d684fa492a47.png)

![image](https://user-images.githubusercontent.com/432127/57476229-5fd58380-7296-11e9-9484-2485dfbf4a49.png)


Related #3853