### PR TITLE
refactor(core): Get rid of 'fullpath'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - **helper:** Remove 7zip's fallback '7zip-zstd' ([#5548](https://github.com/ScoopInstaller/Scoop/issues/5548))
 - **core:** Cleanup some old codes, e.g., msi section and config migration ([#5715](https://github.com/ScoopInstaller/Scoop/issues/5715), [#5824](https://github.com/ScoopInstaller/Scoop/issues/5824))
 - **core:** Rewrite and separate path-related functions to `system.ps1` ([#5836](https://github.com/ScoopInstaller/Scoop/issues/5836), [#5858](https://github.com/ScoopInstaller/Scoop/issues/5858), [#5864](https://github.com/ScoopInstaller/Scoop/issues/5864))
+- **core:** Get rid of 'fullpath' ([#3533](https://github.com/ScoopInstaller/Scoop/issues/3533))
 
 ### Builds
 

--- a/bin/checkhashes.ps1
+++ b/bin/checkhashes.ps1
@@ -121,7 +121,7 @@ foreach ($current in $MANIFESTS) {
 
         Invoke-CachedDownload $current.app $version $_ $null $null -use_cache:$UseCache
 
-        $to_check = fullpath (cache_path $current.app $version $_)
+        $to_check = cache_path $current.app $version $_
         $actual_hash = (Get-FileHash -Path $to_check -Algorithm $algorithm).Hash.ToLower()
 
         # Append type of algorithm to both expected and actual if it's not sha256
@@ -146,7 +146,7 @@ foreach ($current in $MANIFESTS) {
         Write-Host "$($current.app): " -NoNewline
         Write-Host 'Mismatch found ' -ForegroundColor Red
         $mismatched | ForEach-Object {
-            $file = fullpath (cache_path $current.app $version $current.urls[$_])
+            $file = cache_path $current.app $version $current.urls[$_]
             Write-Host "`tURL:`t`t$($current.urls[$_])"
             if (Test-Path $file) {
                 Write-Host "`tFirst bytes:`t$((get_magic_bytes_pretty $file ' ').ToUpper())"

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -278,7 +278,7 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
         Write-Host "URL $url is not valid" -ForegroundColor DarkRed
         return $null
     }
-    $file = fullpath (cache_path $app $version $url)
+    $file = cache_path $app $version $url
     $hash = (Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower()
     Write-Host 'Computed hash: ' -ForegroundColor DarkYellow -NoNewline
     Write-Host $hash -ForegroundColor Green

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -450,8 +450,8 @@ function Get-CommandPath {
     )
 
     begin {
-        $userShims = Convert-Path (shimdir $false)
-        $globalShims = fullpath (shimdir $true) # don't resolve: may not exist
+        $userShims = shimdir $false
+        $globalShims = shimdir $true
     }
 
     process {
@@ -571,9 +571,33 @@ function ensure($dir) {
     }
     Convert-Path -Path $dir
 }
+function Get-AbsolutePath {
+    <#
+    .SYNOPSIS
+        Get absolute path
+    .DESCRIPTION
+        Get absolute path, even if not existed
+    .PARAMETER Path
+        Path to manipulate
+    .OUTPUTS
+        System.String
+            Absolute path, may or maynot existed
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [string]
+        $Path
+    )
+    process {
+        return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+    }
+}
+
 function fullpath($path) {
-    # should be ~ rooted
-    $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($path)
+    Show-DeprecatedWarning $MyInvocation 'Get-AbsolutePath'
+    return Get-AbsolutePath -Path $path
 }
 function friendly_path($path) {
     $h = (Get-PSProvider 'FileSystem').Home
@@ -1300,7 +1324,7 @@ if ($pathExpected) {
     # ├─shims
     # ├─config.json
     # ```
-    $configPortablePath = fullpath "$coreRoot\..\..\..\config.json"
+    $configPortablePath = Get-AbsolutePath "$coreRoot\..\..\..\config.json"
     if (Test-Path $configPortablePath) {
         $configFile = $configPortablePath
     }
@@ -1308,17 +1332,17 @@ if ($pathExpected) {
 $scoopConfig = load_cfg $configFile
 
 # Scoop root directory
-$scoopdir = $env:SCOOP, (get_config ROOT_PATH), (Resolve-Path "$PSScriptRoot\..\..\..\.."), "$([System.Environment]::GetFolderPath('UserProfile'))\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$scoopdir = $env:SCOOP, (get_config ROOT_PATH), "$PSScriptRoot\..\..\..\..", "$([System.Environment]::GetFolderPath('UserProfile'))\scoop" | Where-Object { $_ } | Select-Object -First 1 | Get-AbsolutePath
 
 # Scoop global apps directory
-$globaldir = $env:SCOOP_GLOBAL, (get_config GLOBAL_PATH), "$([System.Environment]::GetFolderPath('CommonApplicationData'))\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$globaldir = $env:SCOOP_GLOBAL, (get_config GLOBAL_PATH), "$([System.Environment]::GetFolderPath('CommonApplicationData'))\scoop" | Where-Object { $_ } | Select-Object -First 1 | Get-AbsolutePath
 
 # Scoop cache directory
 # Note: Setting the SCOOP_CACHE environment variable to use a shared directory
 #       is experimental and untested. There may be concurrency issues when
 #       multiple users write and access cached files at the same time.
 #       Use at your own risk.
-$cachedir = $env:SCOOP_CACHE, (get_config CACHE_PATH), "$scoopdir\cache" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$cachedir = $env:SCOOP_CACHE, (get_config CACHE_PATH), "$scoopdir\cache" | Where-Object { $_ } | Select-Object -First 1 | Get-AbsolutePath
 
 # OS information
 $WindowsBuild = [System.Environment]::OSVersion.Version.Build

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -81,7 +81,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
 }
 
 function Invoke-CachedDownload ($app, $version, $url, $to, $cookies = $null, $use_cache = $true) {
-    $cached = fullpath (cache_path $app $version $url)
+    $cached = cache_path $app $version $url
 
     if (!(Test-Path $cached) -or !$use_cache) {
         ensure $cachedir | Out-Null
@@ -239,7 +239,7 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
         $data.$url = @{
             'target'    = "$dir\$(url_filename $url)"
             'cachename' = fname (cache_path $app $version $url)
-            'source'    = fullpath (cache_path $app $version $url)
+            'source'    = cache_path $app $version $url
         }
 
         if ((Test-Path $data.$url.source) -and -not((Test-Path "$($data.$url.source).aria2") -or (Test-Path $urlstxt)) -and $use_cache) {
@@ -638,9 +638,7 @@ function cookie_header($cookies) {
 }
 
 function is_in_dir($dir, $check) {
-    $check = "$(fullpath $check)"
-    $dir = "$(fullpath $dir)"
-    $check -match "^$([regex]::Escape("$dir"))([/\\]|`$)"
+    $check -match "^$([regex]::Escape("$dir"))([/\\]|$)"
 }
 
 function ftp_file_size($url) {
@@ -665,7 +663,6 @@ function hash_for_url($manifest, $url, $arch) {
 
 # returns (ok, err)
 function check_hash($file, $hash, $app_name) {
-    $file = fullpath $file
     if (!$hash) {
         warn "Warning: No hash in manifest. SHA256 for '$(fname $file)' is:`n    $((Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower())"
         return $true, $null
@@ -1088,8 +1085,8 @@ function persist_data($manifest, $original_dir, $persist_dir) {
 
             $source = $source.TrimEnd('/').TrimEnd('\\')
 
-            $source = fullpath "$dir\$source"
-            $target = fullpath "$persist_dir\$target"
+            $source = "$dir\$source"
+            $target = "$persist_dir\$target"
 
             # if we have had persist data in the store, just create link and go
             if (Test-Path $target) {

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -46,7 +46,6 @@ function ensure_in_psmodulepath($dir, $global) {
     if (!$global -and $null -eq $path) {
         $path = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules"
     }
-    $dir = fullpath $dir
     if ($path -notmatch [Regex]::Escape($dir)) {
         Write-Output "Adding $(friendly_path $dir) to $(if($global){'global'}else{'your'}) PowerShell module path."
 

--- a/lib/system.ps1
+++ b/lib/system.ps1
@@ -95,7 +95,7 @@ function Add-Path {
     )
 
     if (!$Path.Contains('%')) {
-        $Path = fullpath $Path
+        $Path = Get-AbsolutePath $Path
     }
     # future sessions
     $inPath, $strippedPath = Test-PathLikeEnvVar $Path (Get-EnvVar -Name 'PATH' -Global:$Global)
@@ -117,7 +117,7 @@ function Remove-Path {
     )
 
     if (!$Path.Contains('%')) {
-        $Path = fullpath $Path
+        $Path = Get-AbsolutePath $Path
     }
     # future sessions
     $inPath, $strippedPath = Test-PathLikeEnvVar $Path (Get-EnvVar -Name 'PATH' -Global:$Global)

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -160,7 +160,7 @@ if ($status.installed) {
         $totalPackage = 0
         foreach ($url in @(url $manifest (Get-DefaultArchitecture))) {
             try {
-                if (Test-Path (fullpath (cache_path $app $manifest.version $url))) {
+                if (Test-Path (cache_path $app $manifest.version $url)) {
                     $cached = " (latest version is cached)"
                 } else {
                     $cached = $null

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -8,7 +8,7 @@
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 # check if scoop needs updating
-$currentdir = fullpath $(versiondir 'scoop' 'current')
+$currentdir = versiondir 'scoop' 'current'
 $needs_update = $false
 $bucket_needs_update = $false
 $script:network_failure = $false

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -71,7 +71,7 @@ function Sync-Scoop {
     if (!(Test-GitAvailable)) { abort "Scoop uses Git to update itself. Run 'scoop install git' and try again." }
 
     Write-Host "Updating Scoop..."
-    $currentdir = fullpath $(versiondir 'scoop' 'current')
+    $currentdir = versiondir 'scoop' 'current'
     if (!(Test-Path "$currentdir\.git")) {
         $newdir = "$currentdir\..\new"
         $olddir = "$currentdir\..\old"
@@ -262,7 +262,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
 
             if ($check_hash) {
                 $manifest_hash = hash_for_url $manifest $url $architecture
-                $source = fullpath (cache_path $app $version $url)
+                $source = cache_path $app $version $url
                 $ok, $err = check_hash $source $manifest_hash $(show_app $app $bucket)
 
                 if (!$ok) {

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -38,8 +38,6 @@ Describe 'is_in_dir' -Tag 'Scoop', 'Windows' {
     It 'should work correctly' {
         is_in_dir 'C:\test' 'C:\foo' | Should -BeFalse
         is_in_dir 'C:\test' 'C:\test\foo\baz.zip' | Should -BeTrue
-
-        is_in_dir 'test' "$PSScriptRoot" | Should -BeTrue
         is_in_dir "$PSScriptRoot\..\" "$PSScriptRoot" | Should -BeFalse
     }
 }


### PR DESCRIPTION
Get rid of `fullpath`, just get absolute path when initialing `$globaldir`, `$scoopdir` and `$cachedir`, other dirs are derived from these three root ones.