### PR TITLE
fix(install): allow TLSv1.0/1.1 for aria2

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -222,7 +222,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         "--no-conf=true"
         "--follow-metalink=true"
         "--metalink-preferred-protocol=https"
-        "--min-tls-version=SSLv3"
+        "--min-tls-version=TLSv1"
         "--stop-with-process=$PID"
         "--continue"
     )

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -222,7 +222,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         "--no-conf=true"
         "--follow-metalink=true"
         "--metalink-preferred-protocol=https"
-        "--min-tls-version=TLSv1.2"
+        "--min-tls-version=SSLv3"
         "--stop-with-process=$PID"
         "--continue"
     )


### PR DESCRIPTION
This changes aria2c's argument `--min-tls-version` from **TLSv1.2** to ~SSLv3~ **TLSv1**.

SSLv3 and TLS v1.0/1.1 are deprecated due to security issues, but some sites are still using it. This causes `aria2` to fail for some packages. (such as: https://github.com/lukesampson/scoop-extras/issues/2449) **(SSL/TLS handshake error)**

Scoop does not restrict SSL/TLS version When `aria2` is disabled. Therefore, I don't see a reason to restrict TLS version when using `aria2`.

(Possible options for `--min-tls-version` can be found [here](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-min-tls-version))