### PR TITLE
Use Symbolic link instead of Junction Point

### DIFF
--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -44,7 +44,7 @@ function do_uninstall($app, $global) {
     run_uninstaller $manifest $architecture $dir
     rm_shims $manifest $global $architecture
 
-    # If a junction was used during install, that will have been used
+    # If a Symbolic link was used during install, that will have been used
     # as the reference directory. Othewise it will just be the version
     # directory.
     $refdir = unlink_current (appdir $app $global)

--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -44,7 +44,7 @@ function do_uninstall($app, $global) {
     run_uninstaller $manifest $architecture $dir
     rm_shims $manifest $global $architecture
 
-    # If a Symbolic link was used during install, that will have been used
+    # If a symbolic link was used during install, that will have been used
     # as the reference directory. Othewise it will just be the version
     # directory.
     $refdir = unlink_current (appdir $app $global)

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1123,15 +1123,15 @@ function persist_data($manifest, $original_dir, $persist_dir) {
                 & "$env:COMSPEC" /c "mklink /d `"$source`" `"$target`"" | out-null
                 attrib $source +R /L
             } else {
-                # target is a file, create symbolic link also works
-                & "$env:COMSPEC" /c "mklink /d `"$source`" `"$target`"" | out-null
+                # target is a file, create hard link
+                & "$env:COMSPEC" /c "mklink /h `"$source`" `"$target`"" | out-null
             }
         }
     }
 }
 
 function unlink_persist_data($dir) {
-    # unlink all symbolic link in the directory
+    # unlink all symbolic / hard link in the directory
     Get-ChildItem -Recurse $dir | ForEach-Object {
         $file = $_
         if ($null -ne $file.LinkType) {
@@ -1140,10 +1140,10 @@ function unlink_persist_data($dir) {
             if ($file -is [System.IO.DirectoryInfo]) {
                 # remove read-only attribute on the link
                 attrib -R /L $filepath
-                # remove the symbolic link (symbolic link supports rm to delete)
+                # remove the symbolic link
                 & "$env:COMSPEC" /c "rmdir /s /q `"$filepath`""
             } else {
-                # remove the symbolic link (symbolic link also supports del to delete)
+                # remove the hard link
                 & "$env:COMSPEC" /c "del `"$filepath`""
             }
         }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -848,7 +848,7 @@ function rm_shims($manifest, $global, $arch) {
     }
 }
 
-# Gets the path for the 'current' directory Symbolic link for
+# Gets the path for the 'current' directory symbolic link for
 # the specified version directory.
 function current_dir($versiondir) {
     $parent = split-path $versiondir
@@ -856,10 +856,10 @@ function current_dir($versiondir) {
 }
 
 
-# Creates or updates the directory Symbolic link for [app]/current,
+# Creates or updates the directory symbolic link for [app]/current,
 # pointing to the specified version directory for the app.
 #
-# Returns the 'current' Symbolic link directory if in use, otherwise
+# Returns the 'current' symbolic link directory if in use, otherwise
 # the version directory.
 function link_current($versiondir) {
     if(get_config NO_JUNCTIONS) { return $versiondir }
@@ -873,7 +873,7 @@ function link_current($versiondir) {
     }
 
     if(test-path $currentdir) {
-        # remove the Symbolic link
+        # remove the symbolic link
         attrib -R /L $currentdir
         & "$env:COMSPEC" /c rmdir $currentdir
     }
@@ -883,10 +883,10 @@ function link_current($versiondir) {
     return $currentdir
 }
 
-# Removes the directory Symbolic link for [app]/current which
+# Removes the directory symbolic link for [app]/current which
 # points to the current version directory for the app.
 #
-# Returns the 'current' Symbolic link directory (if it exists),
+# Returns the 'current' symbolic link directory (if it exists),
 # otherwise the normal version directory.
 function unlink_current($versiondir) {
     if(get_config NO_JUNCTIONS) { return $versiondir }
@@ -898,7 +898,7 @@ function unlink_current($versiondir) {
         # remove read-only attribute on link
         attrib $currentdir -R /L
 
-        # remove the Symbolic link
+        # remove the symbolic link
         & "$env:COMSPEC" /c "rmdir `"$currentdir`""
         return $currentdir
     }
@@ -1119,11 +1119,11 @@ function persist_data($manifest, $original_dir, $persist_dir) {
 
             # create link
             if (is_directory $target) {
-                # target is a directory, create Symbolic link
+                # target is a directory, create symbolic link
                 & "$env:COMSPEC" /c "mklink /d `"$source`" `"$target`"" | out-null
                 attrib $source +R /L
             } else {
-                # target is a file, create Symbolic link also works
+                # target is a file, create symbolic link also works
                 & "$env:COMSPEC" /c "mklink /d `"$source`" `"$target`"" | out-null
             }
         }
@@ -1131,19 +1131,19 @@ function persist_data($manifest, $original_dir, $persist_dir) {
 }
 
 function unlink_persist_data($dir) {
-    # unlink all Symbolic link in the directory
+    # unlink all symbolic link in the directory
     Get-ChildItem -Recurse $dir | ForEach-Object {
         $file = $_
         if ($null -ne $file.LinkType) {
             $filepath = $file.FullName
-            # directory (Symbolic link)
+            # directory (symbolic link)
             if ($file -is [System.IO.DirectoryInfo]) {
                 # remove read-only attribute on the link
                 attrib -R /L $filepath
-                # remove the Symbolic link (Symbolic link supports rm to delete)
+                # remove the symbolic link (symbolic link supports rm to delete)
                 & "$env:COMSPEC" /c "rmdir /s /q `"$filepath`""
             } else {
-                # remove the Symbolic link (Symbolic link also supports del to delete)
+                # remove the symbolic link (symbolic link also supports del to delete)
                 & "$env:COMSPEC" /c "del `"$filepath`""
             }
         }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -848,7 +848,7 @@ function rm_shims($manifest, $global, $arch) {
     }
 }
 
-# Gets the path for the 'current' directory junction for
+# Gets the path for the 'current' directory Symbolic link for
 # the specified version directory.
 function current_dir($versiondir) {
     $parent = split-path $versiondir
@@ -856,10 +856,10 @@ function current_dir($versiondir) {
 }
 
 
-# Creates or updates the directory junction for [app]/current,
+# Creates or updates the directory Symbolic link for [app]/current,
 # pointing to the specified version directory for the app.
 #
-# Returns the 'current' junction directory if in use, otherwise
+# Returns the 'current' Symbolic link directory if in use, otherwise
 # the version directory.
 function link_current($versiondir) {
     if(get_config NO_JUNCTIONS) { return $versiondir }
@@ -873,20 +873,20 @@ function link_current($versiondir) {
     }
 
     if(test-path $currentdir) {
-        # remove the junction
+        # remove the Symbolic link
         attrib -R /L $currentdir
         & "$env:COMSPEC" /c rmdir $currentdir
     }
 
-    & "$env:COMSPEC" /c mklink /j $currentdir $versiondir | out-null
+    & "$env:COMSPEC" /c mklink /d $currentdir $versiondir | out-null
     attrib $currentdir +R /L
     return $currentdir
 }
 
-# Removes the directory junction for [app]/current which
+# Removes the directory Symbolic link for [app]/current which
 # points to the current version directory for the app.
 #
-# Returns the 'current' junction directory (if it exists),
+# Returns the 'current' Symbolic link directory (if it exists),
 # otherwise the normal version directory.
 function unlink_current($versiondir) {
     if(get_config NO_JUNCTIONS) { return $versiondir }
@@ -898,7 +898,7 @@ function unlink_current($versiondir) {
         # remove read-only attribute on link
         attrib $currentdir -R /L
 
-        # remove the junction
+        # remove the Symbolic link
         & "$env:COMSPEC" /c "rmdir `"$currentdir`""
         return $currentdir
     }
@@ -1119,31 +1119,31 @@ function persist_data($manifest, $original_dir, $persist_dir) {
 
             # create link
             if (is_directory $target) {
-                # target is a directory, create junction
-                & "$env:COMSPEC" /c "mklink /j `"$source`" `"$target`"" | out-null
+                # target is a directory, create Symbolic link
+                & "$env:COMSPEC" /c "mklink /d `"$source`" `"$target`"" | out-null
                 attrib $source +R /L
             } else {
-                # target is a file, create hard link
-                & "$env:COMSPEC" /c "mklink /h `"$source`" `"$target`"" | out-null
+                # target is a file, create Symbolic link also works
+                & "$env:COMSPEC" /c "mklink /d `"$source`" `"$target`"" | out-null
             }
         }
     }
 }
 
 function unlink_persist_data($dir) {
-    # unlink all junction / hard link in the directory
+    # unlink all Symbolic link in the directory
     Get-ChildItem -Recurse $dir | ForEach-Object {
         $file = $_
         if ($null -ne $file.LinkType) {
             $filepath = $file.FullName
-            # directory (junction)
+            # directory (Symbolic link)
             if ($file -is [System.IO.DirectoryInfo]) {
                 # remove read-only attribute on the link
                 attrib -R /L $filepath
-                # remove the junction
+                # remove the Symbolic link (Symbolic link supports rm to delete)
                 & "$env:COMSPEC" /c "rmdir /s /q `"$filepath`""
             } else {
-                # remove the hard link
+                # remove the Symbolic link (Symbolic link also supports del to delete)
                 & "$env:COMSPEC" /c "del `"$filepath`""
             }
         }

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -26,7 +26,7 @@ function install_psmodule($manifest, $dir, $global) {
         & "$env:COMSPEC" /c "rmdir `"$linkfrom`""
     }
 
-    & "$env:COMSPEC" /c "mklink /j `"$linkfrom`" `"$dir`"" | out-null
+    & "$env:COMSPEC" /c "mklink /d `"$linkfrom`" `"$dir`"" | out-null
 }
 
 function uninstall_psmodule($manifest, $dir, $global) {

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -79,7 +79,7 @@ if (!$apps) { exit 0 }
     rm_shims $manifest $global $architecture
     rm_startmenu_shortcuts $manifest $global $architecture
 
-    # If a Symbolic link was used during install, that will have been used
+    # If a symbolic link was used during install, that will have been used
     # as the reference directory. Otherwise it will just be the version
     # directory.
     $refdir = unlink_current $dir

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -79,7 +79,7 @@ if (!$apps) { exit 0 }
     rm_shims $manifest $global $architecture
     rm_startmenu_shortcuts $manifest $global $architecture
 
-    # If a junction was used during install, that will have been used
+    # If a Symbolic link was used during install, that will have been used
     # as the reference directory. Otherwise it will just be the version
     # directory.
     $refdir = unlink_current $dir

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -255,7 +255,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     env_rm_path $old_manifest $dir $global
     env_rm $old_manifest $global
 
-    # If a junction was used during install, that will have been used
+    # If a Symbolic link was used during install, that will have been used
     # as the reference directory. Otherwise it will just be the version
     # directory.
     $refdir = unlink_current $dir

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -255,7 +255,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     env_rm_path $old_manifest $dir $global
     env_rm $old_manifest $global
 
-    # If a Symbolic link was used during install, that will have been used
+    # If a symbolic link was used during install, that will have been used
     # as the reference directory. Otherwise it will just be the version
     # directory.
     $refdir = unlink_current $dir


### PR DESCRIPTION
## For Issue

- #3941

## Description

`mklink /j` is used to make junction points and `mklink /d` is used to make symbolic links.

- Shortcuts in the start menu targeting files inside junction points will be lost after a Windows Update while they will persist inside symbolic links. (See #3941 and #2233 )
- Symbolic link is supported above Windows Vista and scoop should be run above Windows 7, so symbolic link stills works on all users.
- ~~Symbolic links DO NOT require to run as administrator and this is the same with junction points.~~
- ~~Symbolic links support directories and files while junction points only support directories.~~(**EDIT: They are same to support directory only.**)

## My blog and references for `mklink` command

- [Compare four different file (folder) links on Windows (NTFS hard links, junction points, symbolic links, and well-known shortcuts)](https://blog.walterlv.com/post/ntfs-link-comparisons-en.html)
- [比较 Windows 上四种不同的文件（夹）链接方式（NTFS 的硬链接、目录联接、符号链接，和大家熟知的快捷方式）](https://blog.walterlv.com/post/ntfs-link-comparisons.html)
