### PR TITLE
If scoop update fails, scoop itself will not be removed now (fixes #4005)

### DIFF
--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -101,7 +101,7 @@ function add_bucket($name, $repo) {
     write-host 'Checking repo... ' -nonewline
     $out = git_ls_remote $repo 2>&1
     if ($lastexitcode -ne 0) {
-        abort "'$repo' doesn't look like a valid git repository`n`nError given:`n$out"
+        abort "`ngit ls-remote '$repo' failed.`n`nError given:`n$out"
     }
     write-host 'ok'
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -76,11 +76,12 @@ function update_scoop() {
         # check if scoop was successful downloaded
         if (!(test-path "$newdir")) {
             abort 'Scoop update failed.'
+        } else {
+            # replace non-git scoop with the git version
+            Remove-Item -r -force $currentdir -ea stop
+            Move-Item $newdir $currentdir
         }
 
-        # replace non-git scoop with the git version
-        Remove-Item -r -force $currentdir -ea stop
-        Move-Item $newdir $currentdir
     } else {
         Push-Location $currentdir
 


### PR DESCRIPTION
Fixes #4005: If 'scoop update' failed, scoop itself will be removed.