### PR TITLE
[WIP] feature: Add support for ARM64 architecture

### DIFF
--- a/bin/checkurls.ps1
+++ b/bin/checkurls.ps1
@@ -89,6 +89,7 @@ foreach ($man in $Queue) {
     if ($manifest.url) {
         $manifest.url | ForEach-Object { $urls += $_ }
     } else {
+        url $manifest 'arm64' | ForEach-Object { $urls += $_ }
         url $manifest '64bit' | ForEach-Object { $urls += $_ }
         url $manifest '32bit' | ForEach-Object { $urls += $_ }
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -635,6 +635,7 @@ function ensure_architecture($architecture_opt) {
     $architecture_opt = $architecture_opt.ToString().ToLower()
     switch($architecture_opt) {
         { @('64bit', '64', 'x64', 'amd64', 'x86_64', 'x86-64')  -contains $_ } { return '64bit' }
+        { @('arm64', 'aarch64', 'armv8')  -contains $_ } { return 'arm64' }
         { @('32bit', '32', 'x86', 'i386', '386', 'i686')  -contains $_ } { return '32bit' }
         default { throw [System.ArgumentException] "Invalid architecture: '$architecture_opt'"}
     }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -34,6 +34,10 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
         return
     }
 
+    if ((default_architecture -neq "arm64") -and ($architecture -eq "arm64")) {
+        warn "ARM64 application probably won't run on this system."
+    }
+
     write-output "Installing '$app' ($version) [$architecture]"
 
     $dir = ensure (versiondir $app $version $global)

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -14,7 +14,7 @@
 #   -i, --independent         Don't install dependencies automatically
 #   -k, --no-cache            Don't use the download cache
 #   -s, --skip                Skip hash validation (use with caution!)
-#   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
+#   -a, --arch <32bit|64bit|arm64>  Use the specified architecture, if the app supports it
 
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\manifest.ps1"

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -27,7 +27,7 @@
 #       2 & 4 combined
 #
 # Options:
-#   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
+#   -a, --arch <32bit|64bit|arm64>  Use the specified architecture, if the app supports it
 #   -s, --scan For packages where VirusTotal has no information, send download URL
 #              for analysis (and future retrieval).  This requires you to configure
 #              your virustotal_api_key.

--- a/schema.json
+++ b/schema.json
@@ -192,6 +192,22 @@
                                 }
                             },
                             "type": "object"
+                        },
+                        "arm64": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "extract_dir": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "format": "uri",
+                                    "type": "string"
+                                },
+                                "hash": {
+                                    "$ref": "#/definitions/hashExtraction"
+                                }
+                            },
+                            "type": "object"
                         }
                     },
                     "type": "object"
@@ -412,6 +428,9 @@
                     "$ref": "#/definitions/architecture"
                 },
                 "64bit": {
+                    "$ref": "#/definitions/architecture"
+                },
+                "arm64": {
                     "$ref": "#/definitions/architecture"
                 }
             },

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -24,6 +24,10 @@ describe "ensure_architecture" -Tag 'Scoop' {
         ensure_architecture "AMD64" | should -be "64bit"
         ensure_architecture "x86_64" | should -be "64bit"
         ensure_architecture "x86-64" | should -be "64bit"
+
+        ensure_architecture "arm64" | should -be "arm64"
+        ensure_architecture "armv8" | should -be "arm64"
+        ensure_architecture "aarch64" | should -be "arm64"
     }
 
     it "should fallback to the default architecture on empty input" {

--- a/test/Scoop-Manifest.Tests.ps1
+++ b/test/Scoop-Manifest.Tests.ps1
@@ -90,6 +90,11 @@ describe -Tag 'Manifests' "manifest-validation" {
                 $manifest = parse_json $file.fullname
                 $url = arch_specific "url" $manifest "32bit"
                 $url64 = arch_specific "url" $manifest "64bit"
+                $urlarm64 = arch_specific "url" $manifest "arm64"
+                if(!$url) {
+                    $url = $urlarm64
+                }
+
                 if(!$url) {
                     $url = $url64
                 }


### PR DESCRIPTION
I am not 100% sure if it should be done that way, but I've tried myself in adding basic support for ARM64 architecture, apart from "32bit" and "64bit" scoop has already. The discussion was started in https://github.com/lukesampson/scoop/issues/3146.

It requires of course changes to the manifest - apart from two already existing architectures, third one was added, with "arm64" moniker (while "aarch64" and "armv8" are also supported in parameter list).

To recognize if we are running on Windows on ARM (WoA), the `$env:PROCESSOR_ARCHITECTURE` is used, as [WOW64 documentation](https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details?redirectedfrom=MSDN) suggests.

I have added warnings when trying to install ARM64 application on non-ARM system (but there should be nothing to stop the user at all - it's their decision) and when there is no architecture given in manifest - on ARM64 system it will require explicit `scoop install -a 32bit foobar` for example.

I am marking this as WIP at the moment, as checkhashes/checkurls.ps1 has not been yet modified to work with ARM64.

What do you think?