### PR TITLE
gh-pages: move installation guide to top

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,6 +2,25 @@
 layout: default
 ---
 
+# Installs in seconds
+
+Make sure [PowerShell 5](https://aka.ms/wmf5download) (or later, include [PowerShell Core](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-6))
+and [.NET Framework 4.5](https://www.microsoft.com/net/download) (or later) are installed. Then run:
+
+```powershell
+Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+
+# or shorter
+iwr -useb get.scoop.sh | iex
+```
+
+**Note:** if you get an error you might need to change the execution policy
+(i.e. enable Powershell) with
+
+```powershell
+Set-ExecutionPolicy RemoteSigned -scope CurrentUser
+```
+
 ### Scoop installs the tools you know and love
 
 ```shell
@@ -36,22 +55,3 @@ Not sure whether you need 32-bit or 64-bit? Can&rsquo;t remember that command yo
 </div>
 
 <br>
-
-# Installs in seconds
-
-Make sure [PowerShell 5](https://aka.ms/wmf5download) (or later, include [PowerShell Core](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-6))
-and [.NET Framework 4.5](https://www.microsoft.com/net/download) (or later) are installed. Then run:
-
-```powershell
-Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-
-# or shorter
-iwr -useb get.scoop.sh | iex
-```
-
-**Note:** if you get an error you might need to change the execution policy
-(i.e. enable Powershell) with
-
-```powershell
-Set-ExecutionPolicy RemoteSigned -scope CurrentUser
-```


### PR DESCRIPTION
This is a small change, but I think it would make a big difference. Most websites like this tend to have the installation instructions immediately visible to the user's eyes, because people today have short attention spans and are quick to enter the first thing they see into a terminal. All your fave CLI apps have web pages that tell you how to install them immediately, but for scoop you have to scroll down. So I think it would be much better like this. Thanks so much for this amazing package manager that keeps me sane.