### PR TITLE
Fix VirusTotal results querying: switch to v3 API and offer links to manually check when things fail

### DIFF
--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -115,7 +115,7 @@ Function Get-VirusTotalResult($hash, $app) {
         }
     }
     $stats = json_path $result $stats_json_path
-    if ($stats -eq $null) {
+    if ($null -eq $stats) {
         # Make sure to include '(404)' in the exception as this is the trigger
         # for the exception handler to attempt submitting the file for analysis
         throw "No data found (404) for $app with hash $hash"

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -83,15 +83,20 @@ $requests = 0
 Function Get-VirusTotalResult($hash, $app) {
     $hash = $hash.ToLower()
     $url = "https://www.virustotal.com/ui/files/$hash"
+    $see_url = "see https://www.virustotal.com/#/file/$hash/detection"
     $wc = New-Object Net.Webclient
     $wc.Headers.Add('User-Agent', (Get-UserAgent))
-    $result = $wc.downloadstring($url)
+    try {
+        $result = $wc.downloadstring($url)
+    } catch {
+        write-host "$app`: $_`n    $see_url"
+        return $_ERR_EXCEPTION
+    }
     $stats = json_path $result '$.data.attributes.last_analysis_stats'
     $malicious = json_path $stats '$.malicious'
     $suspicious = json_path $stats '$.suspicious'
     $undetected = json_path $stats '$.undetected'
     $unsafe = [int]$malicious + [int]$suspicious
-    $see_url = "see https://www.virustotal.com/#/file/$hash/detection"
     switch ($unsafe) {
         0 { if ($undetected -eq 0) { $fg = "Yellow" } else { $fg = "DarkGreen" } }
         1 { $fg = "DarkYellow" }


### PR DESCRIPTION
virustotal started reporting 429 HTTP errors (related to captchas)

Instead of just reporting an error, provide the URL so that the user may easily check for themselves (especially if their terminal allows clicking URLs).

To avoid the 429 HTTP errors, I also upgraded the querying of the VirusTotal to use their v3 REST API when the API key is configured.  This is much more reliable than the old way.