### PR TITLE
Added zstd archive extraction based on tar installed by git package

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -81,7 +81,7 @@ function Expand-ZstdArchive {
     catch [System.Management.Automation.CommandNotFoundException] {
         abort "Cannot find external Zstd (zstd.exe). Install Zstd (sccop install zstd) manually and try again."
     }
-    
+
     $LogPath = "$(Split-Path $Path)\zstd.log"
     $ArgList = @('-d', '-v',"`"$Path`"" )
 

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -79,7 +79,6 @@ function Expand-ZstdArchive {
     $LogPath = "$(Split-Path $Path)\zstd.log"
     $DestinationPath = $DestinationPath.Replace('\', '/')
     $ArgList = @("-C", "`"$DestinationPath`"", "-xavf", "`"$Path`"", "--force-local")
-  
 
     # if ($Switches) {
     #     $ArgList += (-split $Switches)

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -598,6 +598,8 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
             }
         } elseif(Test-7zipRequirement -File $fname) { # 7zip
             $extract_fn = 'Expand-7zipArchive'
+        }  elseif(Test-ZstdRequirement -File $fname) { # Zstd
+            $extract_fn = 'Expand-ZstdArchive'
         }
 
         if($extract_fn) {

--- a/supporting/shims/kiennq/.gitignore
+++ b/supporting/shims/kiennq/.gitignore
@@ -1,2 +1,2 @@
-*.zip 
-*.bak 
+*.zip
+*.bak


### PR DESCRIPTION
Added new function 'Expand-ZstdArchive'.

The only prerequisite for this to work is the installation of the zstd package.

Accesses the git-provided tar via `"$scoopdir\apps\git\current\usr\bin\tar.exe"`

Neither the native tar that comes with Windows, nor the tar package in scoop support zst extraction; only the git-provided version does.

I still need to put together a test-case for this, but it worked with a tweaked gcc package I have here.