### PR TITLE
fix(install): fallback to default downloader when aria2 fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- **scoop-download|install|update:** Fallback to default downloader when aria2 fails ([#4292](https://github.com/ScoopInstaller/Scoop/issues/4292))
 - **decompress**: `Expand-7zipArchive` only delete temp dir / `$extractDir` if it is empty ([#6092](https://github.com/ScoopInstaller/Scoop/issues/6092))
 
 ### Code Refactoring

--- a/lib/download.ps1
+++ b/lib/download.ps1
@@ -466,7 +466,7 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
                     Invoke-CachedDownload $app $version $url "$($data.$url.target)" $cookies $use_cache
                 }
             } catch {
-                write-host -f darkred $_
+                Write-Host $_ -ForegroundColor DarkRed
                 abort "URL $url is not valid"
             }
         }


### PR DESCRIPTION
Try to fallback to default downloader when aria2 download failed.
This make the download with aria2 more stable since there's some download links that doesn't support multi-connection.

Closes #4472