### PR TITLE
Change `url()` scope to avoid conflict with global aliases (e.g. Pansies)

### DIFF
--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -77,10 +77,10 @@ function script_deps($script) {
 function install_deps($manifest, $arch) {
     $deps = @()
 
-    if (!(Test-HelperInstalled -Helper 7zip) -and (Test-7zipRequirement -URL (url $manifest $arch))) {
+    if (!(Test-HelperInstalled -Helper 7zip) -and (Test-7zipRequirement -URL (script:url $manifest $arch))) {
         $deps += '7zip'
     }
-    if (!(Test-HelperInstalled -Helper Lessmsi) -and (Test-LessmsiRequirement -URL (url $manifest $arch))) {
+    if (!(Test-HelperInstalled -Helper Lessmsi) -and (Test-LessmsiRequirement -URL (script:url $manifest $arch))) {
         $deps += 'lessmsi'
     }
     if (!(Test-HelperInstalled -Helper Innounp) -and $manifest.innosetup) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -200,7 +200,7 @@ function get_filename_from_metalink($file) {
 
 function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $cookies = $null, $use_cache = $true, $check_hash = $true) {
     $data = @{}
-    $urls = @(url $manifest $architecture)
+    $urls = @(script:url $manifest $architecture)
 
     # aria2 input file
     $urlstxt = Join-Path $cachedir "$app.txt"
@@ -526,7 +526,7 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
 
     # can be multiple urls: if there are, then msi or installer should go last,
     # so that $fname is set properly
-    $urls = @(url $manifest $architecture)
+    $urls = @(script:url $manifest $architecture)
 
     # can be multiple cookies: they will be used for all HTTP requests.
     $cookies = $manifest.cookie
@@ -641,7 +641,7 @@ function hash_for_url($manifest, $url, $arch) {
 
     if($hashes.length -eq 0) { return $null }
 
-    $urls = @(url $manifest $arch)
+    $urls = @(script:url $manifest $arch)
 
     $index = [array]::indexof($urls, $url)
     if($index -eq -1) { abort "Couldn't find hash in manifest for '$url'." }


### PR DESCRIPTION
Pansies, a popular PowerShell module, creates an alias from `url` to its [`New-Hyperlink`](https://github.com/PoshCode/Pansies/blob/master/Source/Assembly/Commands/NewHyperlinkCommand.cs) function. This conflicts with usages of the `url` function in [`./lib/manifest.ps1`](https://github.com/lukesampson/scoop/blob/master/lib/manifest.ps1#L114).

This PR specifies the scopes of those usages to the script level so those usages can find the function in the scoop library.

Fixes https://github.com/lukesampson/scoop/issues/4185