### PR TITLE
fix: cache file names longer than 260

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -279,7 +279,19 @@ function currentdir($app, $global) {
 function persistdir($app, $global) { "$(basedir $global)\persist\$app" }
 function usermanifestsdir { "$(basedir)\workspace" }
 function usermanifest($app) { "$(usermanifestsdir)\$app.json" }
-function cache_path($app, $version, $url) { "$cachedir\$app#$version#$($url -replace '[^\w\.\-]+', '_')" }
+function cache_path($app, $version, $url) {
+    $filename = "$app#$version#$url"
+    if ($filename.Length -ge 260) {
+        $url = $url -replace '\?.*', ''
+        $filename = "$app#$version#$url"
+        if ($filename.Length -ge 260) {
+            $filename = "$app#$version#$(Split-Path $url -leaf)"
+        }
+    }
+    $filename = $filename -replace '[^\w\.\-\#]+', '_'
+    $path = Join-Path $SCOOP_CACHE_DIRECTORY $filename
+    return $path
+}
 
 # apps
 function sanitary_path($path) { return [regex]::replace($path, "[/\\?:*<>|]", "") }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -280,17 +280,8 @@ function persistdir($app, $global) { "$(basedir $global)\persist\$app" }
 function usermanifestsdir { "$(basedir)\workspace" }
 function usermanifest($app) { "$(usermanifestsdir)\$app.json" }
 function cache_path($app, $version, $url) {
-    $filename = "$app#$version#$url"
-    if ($filename.Length -ge 260) {
-        $url = $url -replace '\?.*', ''
-        $filename = "$app#$version#$url"
-        if ($filename.Length -ge 260) {
-            $filename = "$app#$version#$(Split-Path $url -leaf)"
-        }
-    }
-    $filename = $filename -replace '[^\w\.\-\#]+', '_'
-    $path = Join-Path $SCOOP_CACHE_DIRECTORY $filename
-    return $path
+    $sha1 = (Get-FileHash -Algorithm SHA1 -InputStream ([System.IO.MemoryStream]::new([System.Text.Encoding]::UTF8.GetBytes($url)))).Hash.ToLower()
+    return "$cachedir\$app#$version#$sha1"
 }
 
 # apps

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -280,8 +280,9 @@ function persistdir($app, $global) { "$(basedir $global)\persist\$app" }
 function usermanifestsdir { "$(basedir)\workspace" }
 function usermanifest($app) { "$(usermanifestsdir)\$app.json" }
 function cache_path($app, $version, $url) {
-    $sha1 = (Get-FileHash -Algorithm SHA1 -InputStream ([System.IO.MemoryStream]::new([System.Text.Encoding]::UTF8.GetBytes($url)))).Hash.ToLower()
-    return "$cachedir\$app#$version#$sha1"
+    $sha256 = (Get-FileHash -Algorithm SHA256 -InputStream ([System.IO.MemoryStream]::new([System.Text.Encoding]::UTF8.GetBytes($url)))).Hash.ToLower()
+    $extension = [System.IO.Path]::GetExtension($url)
+    return "$cachedir\$app#$version#$sha256$extension"
 }
 
 # apps


### PR DESCRIPTION
Fix: #4327
Normally, this function behaves as before when the cache filename is less than 260 characters long.
The modified program is designed to shorten cached filenames while retaining as much complete URL information as possible.
If the filename is greater than or equal to 260 characters in length, it will first attempt to remove everything after the question mark from the URL, and if it is still greater than 260 in length, only the filename in the URL will be retained.
Tested locally and passed.