### PR TITLE
feat(message):  Add config to disable aria2 warning message

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,12 @@ Scoop can utilize [`aria2`](https://github.com/aria2/aria2) to use multi-connect
 scoop install aria2
 ```
 
+By default, `scoop` displays a warning when running `scoop install` or `scoop update` while `aria2` is enabled. This warning can be suppressed by running `scoop config aria2-warning-enabled false`.
+
 You can tweak the following `aria2` settings with the `scoop config` command:
 
 - aria2-enabled (default: true)
+- aria2-warning-enabled (default: true)
 - [aria2-retry-wait](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-retry-wait) (default: 2)
 - [aria2-split](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-s) (default: 5)
 - [aria2-max-connection-per-server](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-x) (default: 5)

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -119,9 +119,10 @@ $skip | Where-Object { $explicit_apps -contains $_ } | ForEach-Object {
 }
 
 $suggested = @{ };
-if (Test-Aria2Enabled) {
+if ((Test-Aria2Enabled) -and (get_config 'aria2-warning-enabled' $true)) {
     warn "Scoop uses 'aria2c' for multi-connection downloads."
     warn "Should it cause issues, run 'scoop config aria2-enabled false' to disable it."
+    warn "To disable this warning, run 'scoop config aria2-warning-enabled false'."
 }
 $apps | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -319,9 +319,10 @@ if (!$apps) {
             }
         }
 
-        if ($outdated -and (Test-Aria2Enabled)) {
+        if ($outdated -and ((Test-Aria2Enabled) -and (get_config 'aria2-warning-enabled' $true))) {
             warn "Scoop uses 'aria2c' for multi-connection downloads."
             warn "Should it cause issues, run 'scoop config aria2-enabled false' to disable it."
+            warn "To disable this warning, run 'scoop config aria2-warning-enabled false'."
         }
         if ($outdated.Length -gt 1) {
             write-host -f DarkCyan "Updating $($outdated.Length) outdated apps:"


### PR DESCRIPTION
Adds a new config value: `aria2-warning-enabled` (default: true). 

Normally a warning is emitted when running `scoop install` or `scoop install` while `aria2-enabled` is set to true. When `aria2-warning-enabled` is set to false, the warning is suppressed. 

I also added documentation about this new config to the Readme and the warning itself, though I don't know if this might be considered to be cluttering the output even more.

Closes #2482 and the comment on #2479.