### PR TITLE
feat(scoop-prefix): remove unused imports and functions

### DIFF
--- a/libexec/scoop-prefix.ps1
+++ b/libexec/scoop-prefix.ps1
@@ -2,14 +2,13 @@
 # Summary: Returns the path to the specified app
 param($app)
 
+if(!$app) { 
+    . "$psscriptroot\..\lib\help.ps1"
+    my_usage
+    exit 1
+}
+
 . "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-
-reset_aliases
-
-if(!$app) { my_usage; exit 1 }
 
 $app_path = versiondir $app 'current' $false
 if(!(Test-Path $app_path)) {


### PR DESCRIPTION
Unused imports removed:-
1. manifest.ps1
2. buckets.ps1

Unused function removed:-
1. reset_aliases:- We do not use aliases here.

Load when required
1. help needs to be loaded only when app is not specified
2. core needs to be loaded only when app is specified

Gains:-
1. Improved speed.