### PR TITLE
fix(autoupdate): Update array of arrays correctly

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -346,7 +346,12 @@ function Update-ManifestProperty {
                 }
             } elseif ($Manifest.$currentProperty -and $Manifest.autoupdate.$currentProperty) {
                 # Update other property (global)
-                $newValue = substitute $Manifest.autoupdate.$currentProperty $Substitutions
+                $autoupdateProperty = $Manifest.autoupdate.$currentProperty
+                $newValue = substitute $autoupdateProperty $Substitutions
+                if (($autoupdateProperty.GetType().Name -eq 'Object[]') -and ($autoupdateProperty.Length -eq 1)) {
+                    # Make sure it's an array
+                    $newValue = ,$newValue
+                }
                 $Manifest.$currentProperty, $hasPropertyChanged = PropertyHelper -Property $Manifest.$currentProperty -Value $newValue
                 $hasManifestChanged = $hasManifestChanged -or $hasPropertyChanged
             } elseif ($Manifest.architecture) {
@@ -354,7 +359,12 @@ function Update-ManifestProperty {
                 $Manifest.architecture | Get-Member -MemberType NoteProperty | ForEach-Object {
                     $arch = $_.Name
                     if ($Manifest.architecture.$arch.$currentProperty -and ($Manifest.autoupdate.architecture.$arch.$currentProperty -or $Manifest.autoupdate.$currentProperty)) {
-                        $newValue = substitute (arch_specific $currentProperty $Manifest.autoupdate $arch) $Substitutions
+                        $autoupdateProperty = @(arch_specific $currentProperty $Manifest.autoupdate $arch)
+                        $newValue = substitute $autoupdateProperty $Substitutions
+                        if (($autoupdateProperty.GetType().Name -eq 'Object[]') -and ($autoupdateProperty.Length -eq 1)) {
+                            # Make sure it's an array
+                            $newValue = ,$newValue
+                        }
                         $Manifest.architecture.$arch.$currentProperty, $hasPropertyChanged = PropertyHelper -Property $Manifest.architecture.$arch.$currentProperty -Value $newValue
                         $hasManifestChanged = $hasManifestChanged -or $hasPropertyChanged
                     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -864,7 +864,7 @@ function substitute($entity, [Hashtable] $params, [Bool]$regexEscape = $false) {
                 }
             }
             'Object[]' {
-                $newentity = $entity | ForEach-Object { substitute $_ $params $regexEscape }
+                $newentity = $entity | ForEach-Object { ,(substitute $_ $params $regexEscape) }
             }
             'PSCustomObject' {
                 $newentity.PSObject.Properties | ForEach-Object { $_.Value = substitute $_.Value $params $regexEscape }


### PR DESCRIPTION
Hotfix for #3518, support updating array of arrays correctly.

<details>
<summary>GIMP - autoupdate `bin` and `shortcuts`</summary>

```json
{
    "version": "2.10.28",
    "description": "GNU Image Manipulation Program",
    "homepage": "https://www.gimp.org",
    "license": "GPL-3.0-only",
    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.28-setup.exe",
    "hash": "2c2e081ce541682be1abdd8bc6df13768ad9482d68000b4a7a60c764d6cec74e",
    "innosetup": true,
    "installer": {
        "script": [
            "Push-Location \"$dir\"",
            "Get-ChildItem -Filter '*.debug' -Recurse | Remove-Item -Recurse",
            "if ($architecture -eq '64bit') {",
            "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,3.exe' 'twain.exe'",
            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe'",
            "   Get-ChildItem -Filter '*,1*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
            "   Get-ChildItem -Filter '*,*' -Recurse | Remove-Item",
            "} else {",
            "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe' 'twain.exe'",
            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,3.exe'",
            "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
            "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
            "}",
            "$defpath = \"`nPATH=`${gimp_installation_dir}\\bin`n\"",
            "$defenv = Get-Content 'lib\\gimp\\2.0\\environ\\default.env' -Raw",
            "$defenv += $defpath",
            "$defenv += \"PYTHONPATH=`${gimp_installation_dir}\\lib\\gimp\\2.0\\python;`${gimp_plug_in_dir}\\plug-ins\\python-console\"",
            "$defenv | Set-Content 'lib\\gimp\\2.0\\environ\\default.env'",
            "$pyenv = Get-Content 'lib\\gimp\\2.0\\environ\\pygimp.env' -Raw",
            "$pyenv + '__COMPAT_LAYER=HIGHDPIAWARE' | Set-Content 'lib\\gimp\\2.0\\environ\\pygimp.env'",
            "$pyint = Get-Content 'lib\\gimp\\2.0\\interpreters\\pygimp.interp' -Raw",
            "$pyint = ($pyint -Replace '/mingw32', \"$dir\\bin\") -Replace 'py::python2', 'py::python'",
            "$pyint | Set-Content 'lib\\gimp\\2.0\\interpreters\\pygimp.interp'",
            "Pop-Location"
        ]
    },
    "bin": [
        "bin\\gimp-console-2.10.exe",
        [
            "bin\\gimp-console-2.10.exe",
            "gimp-console"
        ],
        [
            "bin\\gimp-console-2.10.exe",
            "gimp"
        ],
        "bin\\gimptool-2.0.exe",
        [
            "bin\\gimptool-2.0.exe",
            "gimptool"
        ]
    ],
    "shortcuts": [
        [
            "bin\\gimp-2.10.exe",
            "GIMP"
        ]
    ],
    "persist": [
        "etc\\gimp",
        "share\\gimp"
    ],
    "checkver": {
        "url": "https://www.gimp.org/downloads/",
        "regex": "gimp-(?<version>[\\d.]+)-setup(?<build>-\\d)?\\.exe",
        "replace": "${version}${build}"
    },
    "autoupdate": {
        "url": "https://download.gimp.org/mirror/pub/gimp/v$majorVersion.$minorVersion/windows/gimp-$matchHead-setup$matchTail.exe",
        "hash": {
            "url": "$baseurl/SHA256SUMS"
        },
        "bin": [
            "bin\\gimp-console-$majorVersion.$minorVersion.exe",
            [
                "bin\\gimp-console-$majorVersion.$minorVersion.exe",
                "gimp-console"
            ],
            [
                "bin\\gimp-console-$majorVersion.$minorVersion.exe",
                "gimp"
            ],
            "bin\\gimptool-$majorVersion.0.exe",
            [
                "bin\\gimptool-$majorVersion.0.exe",
                "gimptool"
            ]
        ],
        "shortcuts": [
            [
                "bin\\gimp-$majorVersion.$minorVersion.exe",
                "GIMP"
            ]
        ]
    }
}
```

</details>