### PR TITLE
feat(checkver): improve JSONPath extraction support

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -214,7 +214,7 @@ while ($in_progress -gt 0) {
 
     if ($jsonpath) {
         # Return only a single value if regex is absent
-        $json_path_return_single = [String]::IsNullOrEmpty($regex)
+        $single = [String]::IsNullOrEmpty($regex)
         # If reverse is ON and regex is ON,
         # Then reverse would have no effect because regex handles reverse
         # on its own

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -213,7 +213,14 @@ while ($in_progress -gt 0) {
     }
 
     if ($jsonpath) {
-        $ver = json_path $page $jsonpath
+        # Return only a single value if regex is absent
+        $json_path_return_single = [String]::IsNullOrEmpty($regex)
+        # If reverse is ON and regex is ON,
+        # Then reverse would have no effect because regex handles reverse
+        # on its own
+        # So in this case we have to disable reverse
+        $json_path_reverse = $reverse -and [String]::IsNullOrEmpty($regex)
+        $ver = json_path $page $jsonpath $null $json_path_reverse $json_path_return_single
         if (!$ver) {
             $ver = json_path_legacy $page $jsonpath
         }

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -219,8 +219,7 @@ while ($in_progress -gt 0) {
         # Then reverse would have no effect because regex handles reverse
         # on its own
         # So in this case we have to disable reverse
-        $reverse = $reverse -and $single
-        $ver = json_path $page $jsonpath $null $reverse $single
+        $ver = json_path $page $jsonpath $null ($reverse -and $noregex) $noregex
         if (!$ver) {
             $ver = json_path_legacy $page $jsonpath
         }

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -214,7 +214,7 @@ while ($in_progress -gt 0) {
 
     if ($jsonpath) {
         # Return only a single value if regex is absent
-        $single = [String]::IsNullOrEmpty($regex)
+        $noregex = [String]::IsNullOrEmpty($regex)
         # If reverse is ON and regex is ON,
         # Then reverse would have no effect because regex handles reverse
         # on its own

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -219,8 +219,8 @@ while ($in_progress -gt 0) {
         # Then reverse would have no effect because regex handles reverse
         # on its own
         # So in this case we have to disable reverse
-        $json_path_reverse = $reverse -and [String]::IsNullOrEmpty($regex)
-        $ver = json_path $page $jsonpath $null $json_path_reverse $json_path_return_single
+        $reverse = $reverse -and $single
+        $ver = json_path $page $jsonpath $null $reverse $single
         if (!$ver) {
             $ver = json_path_legacy $page $jsonpath
         }

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -114,7 +114,7 @@ function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitution
             # Convert first value to string
             $result = $result.ToString()
         } else {
-            $result = "$([String]::Join("\n",$result))"
+            $result = "$([String]::Join('\n', $result))"
         }
         return $result
     } catch [Exception] {

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -92,31 +92,33 @@ function ConvertToPrettyJson {
     }
 }
 
-function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitutions) {
+function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitutions, [bool] $reverse, [bool] $returnsingle) {
     Add-Type -Path "$psscriptroot\..\supporting\validator\bin\Newtonsoft.Json.dll"
     if ($null -ne $substitutions) {
         $jsonpath = substitute $jsonpath $substitutions ($jsonpath -like "*=~*")
     }
     try {
-        $obj = [Newtonsoft.Json.Linq.JObject]::Parse($json)
+        $obj = [Newtonsoft.Json.Linq.JValue]::Parse($json)
     } catch [Newtonsoft.Json.JsonReaderException] {
-        try {
-            $obj = [Newtonsoft.Json.Linq.JArray]::Parse($json)
-        } catch [Newtonsoft.Json.JsonReaderException] {
-            return $null
-        }
-    }
-
-    try {
-        try {
-            $result = $obj.SelectToken($jsonpath, $true)
-        } catch [Newtonsoft.Json.JsonException] {
-            return $null
-        }
-        return $result.ToString()
-    } catch [System.Management.Automation.MethodInvocationException] {
-        write-host -f DarkRed $_
         return $null
+    }
+    try {
+        $result = $obj.SelectTokens($jsonpath, $true)
+        if ($reverse) {
+            # Return versions in reverse order
+            $result = [System.Linq.Enumerable]::Reverse($result)
+        }
+        if ($returnsingle) {
+            # Extract First value
+            $result = [System.Linq.Enumerable]::First($result)
+            # Convert first value to string
+            $result = $result.ToString()
+        } else {
+            $result = "$([String]::Join("\n",$result))"
+        }
+        return $result
+    } catch [Exception] {
+        write-host -f DarkRed $_
     }
 
     return $null

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -108,7 +108,7 @@ function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitution
             # Return versions in reverse order
             $result = [System.Linq.Enumerable]::Reverse($result)
         }
-        if ($returnsingle) {
+        if ($single) {
             # Extract First value
             $result = [System.Linq.Enumerable]::First($result)
             # Convert first value to string

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -118,7 +118,7 @@ function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitution
         }
         return $result
     } catch [Exception] {
-        write-host -f DarkRed $_
+        Write-Host $_ -ForegroundColor DarkRed
     }
 
     return $null

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -92,7 +92,7 @@ function ConvertToPrettyJson {
     }
 }
 
-function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitutions, [bool] $reverse, [bool] $returnsingle) {
+function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitutions, [Boolean] $reverse, [Boolean] $single) {
     Add-Type -Path "$psscriptroot\..\supporting\validator\bin\Newtonsoft.Json.dll"
     if ($null -ne $substitutions) {
         $jsonpath = substitute $jsonpath $substitutions ($jsonpath -like "*=~*")


### PR DESCRIPTION
1. Extract multiple versions
2. Reverse versions, especially if regex is absent
3. Support returning single value even if multiple versions were found
This is probably required with regex mode on
4. Simplify data extraction using JValue over JObject/JArray combination. Saves a few function calls