### PR TITLE
scoop-help.ps1: keeping only the first found command to print it's re…

### DIFF
--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -26,7 +26,7 @@ function print_summaries {
         $command = command_name $_
         $summary = summary (Get-Content (command_path $command) -raw)
         if(!($summary)) { $summary = '' }
-        $commands.add("$command ", $summary) # add padding
+        if(!($commands["$command "])) { $commands.add("$command ", $summary) } # add padding
     }
 
     $commands.getenumerator() | Sort-Object name | Format-Table -hidetablehead -autosize -wrap


### PR DESCRIPTION
…lated help

I'm wondering if no one else has this error... if so, I may have to many additional commands added ;)
Anyhow, I'm getting the below error message... and with a  quick hack to unsure only the first found "command" Key is kept, all works fine in my case...

ERROR I get:
```powershell
λ  scoop
Usage: scoop <command> [<args>]

Some useful commands are:
MethodInvocationException: C:\Users\<user>\scoop\apps\scoop\current\libexec\scoop-help.ps1:29
Line |
  29 |          $commands.add("$command ", $summary) # add padding
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "Add" with "2" argument(s): "Item has already been added. Key in dictionary: 'search '  Key being added: 'search '"


alias           Manage scoop aliases
bucket          Manage Scoop buckets
bucket-origin   Show the scoop buckets and their "git origin" info
cache           Show or clear the download cache
cache-rm-all    Clear the download cache for all apps
cache-show-all  Show the download cache for all apps
checkup         Check for potential problems
cleanup         Cleanup apps by removing old versions
cleanup-all     Cleanup all apps by removing old versions
config          Get or set configuration values
create          Create a custom app manifest
depends         List dependencies for an app
export          Exports (an importable) list of installed apps
help            Show help for a command
hold            Hold an app to disable updates
home            Opens the app homepage
info            Display information about an app
info-all        Display information about apps in all buckets
install         Install apps
list            List installed apps
list-all        List apps in all buckets
prefix          Returns the path to the specified app
reset           Reset an app to resolve conflicts
search          Search available apps
search-info     Search available apps and display information about each app
status          Show status and check for new app versions
unhold          Unhold an app to enable updates
uninstall       Uninstall an app
update          Update apps, or Scoop itself
update-all      Update all apps and scoop
virustotal      Look for app's hash on virustotal.com
which           Locate a shim/executable (similar to 'which' on Linux)

Type 'scoop help <command>' to get help for a specific command.
```