### PR TITLE
fix(scoop-update): Fix scoop update -a requiring arguments

### DIFF
--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -28,7 +28,7 @@
 
 reset_aliases
 
-$opt, $apps, $err = getopt $args 'gfiksqa:' 'global', 'force', 'independent', 'no-cache', 'skip', 'quiet', 'all'
+$opt, $apps, $err = getopt $args 'gfiksqa' 'global', 'force', 'independent', 'no-cache', 'skip', 'quiet', 'all'
 if ($err) { "scoop update: $err"; exit 1 }
 $global = $opt.g -or $opt.global
 $force = $opt.f -or $opt.force


### PR DESCRIPTION
Fixes #4530 

I misunderstood how `:` acts in `getopt`. I have removed it entirely, I assume that the `-q` parameter was also not supposed to get an argument. The error on `-q` was introduced with #2260.