### PR TITLE
feat(shim): Rework shimming logic

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -646,6 +646,7 @@ function get_shim_path() {
         '71' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\71\shim.exe"; Break }
         'scoopcs' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shimexe\bin\shim.exe"; Break }
         'rshim' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\rshim\shim.exe"; Break }
+        'kiennq' { Break } # for backward compatibility
         'default' { Break }
         default { warn "Unknown shim version: '$shim_version'" }
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -628,7 +628,7 @@ powershell -noprofile -ex unrestricted `"& '$resolved_path' $arg %args%;exit `$l
         if ($gitdir.FullName -imatch 'mingw') {
           $gitdir = $gitdir.Parent
         }
-        "@$(Join-Path (Join-Path $gitdir.FullName 'bin') 'bash.exe') `"$resolved_path`" $arg %*" | out-file "$shim.cmd" -encoding ascii
+        "@`"$(Join-Path (Join-Path $gitdir.FullName 'bin') 'bash.exe')`" `"$resolved_path`" $arg %*" | out-file "$shim.cmd" -encoding ascii
 
         warn_on_overwrite $shim $path
         "#!/bin/sh`n`"$resolved_path`" $arg `"$@`"" | out-file $shim -encoding ascii

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -588,13 +588,15 @@ MSYS2_ARG_CONV_EXCL=/C cmd.exe /C `"$resolved_path`" $arg `"$@`"" | out-file $sh
         $ps1text = if($relative_path -match "^(.\\[\w]:).*$") {
             "# $resolved_path
 `$path = `"$path`"
-if(`$myinvocation.expectingInput) { `$input | & `$path $arg @args } else { & `$path $arg @args }"
+if(`$myinvocation.expectingInput) { `$input | & `$path $arg @args } else { & `$path $arg @args }
+exit `$lastexitcode"
         } else {
             # Setting PSScriptRoot in Shim if it is not defined, so the shim doesn't break in PowerShell 2.0
             "# $resolved_path
 if (!(Test-Path Variable:PSScriptRoot)) { `$PSScriptRoot = Split-Path `$MyInvocation.MyCommand.Path -Parent }
 `$path = join-path `"`$psscriptroot`" `"$relative_path`"
-if(`$myinvocation.expectingInput) { `$input | & `$path $arg @args } else { & `$path $arg @args }"
+if(`$myinvocation.expectingInput) { `$input | & `$path $arg @args } else { & `$path $arg @args }
+exit `$lastexitcode"
         }
         $ps1text | out-file "$shim.ps1" -encoding utf8
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -534,11 +534,7 @@ function get_app_name_from_ext_shim($shim_ext) {
     if (!(Test-Path($shim_ext))) {
         return ''
     }
-    $content = if ([System.IO.Path]::GetExtension($shim_ext) -eq '.exe') {
-        (Get-Content $shim_ext.Replace('.exe', '.shim') -Encoding utf8) -join ' '
-    } else {
-        (Get-Content $shim_ext -Encoding utf8) -join ' '
-    }
+    $content = (Get-Content $shim_ext -Encoding utf8) -join ' '
     return get_app_name $content
 }
 
@@ -570,7 +566,7 @@ function shim($path, $global, $name, $arg) {
 
     if($path -match '\.(exe|com)$') {
         # for programs with no awareness of any shell
-        warn_on_overwrite "$shim.exe" $path
+        warn_on_overwrite "$shim.shim" $path
         Copy-Item (get_shim_path) "$shim.exe" -force
         write-output "path = $resolved_path" | out-file "$shim.shim" -encoding utf8
         if($arg) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -628,11 +628,11 @@ powershell -noprofile -ex unrestricted `"& '$resolved_path' $arg %args%;exit `$l
 }
 
 function get_shim_path() {
-    $shim_path = "$(versiondir 'scoop' 'current')\supporting\shimexe\bin\shim.exe"
+    $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\kiennq\shim.exe"
     $shim_version = get_config 'shim' 'default'
     switch ($shim_version) {
         '71' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\71\shim.exe"; Break }
-        'kiennq' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\kiennq\shim.exe"; Break }
+        'scoopcs' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shimexe\bin\shim.exe"; Break }
         'rshim' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\rshim\shim.exe"; Break }
         'default' { Break }
         default { warn "Unknown shim version: '$shim_version'" }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -547,7 +547,7 @@ function warn_on_overwrite($shim_ext, $path) {
     if ($shim_app -eq $path_app) {
         return
     }
-    $filename = [System.IO.Path]::GetFileName($path)
+    $filename = [System.IO.Path]::GetFileName($path) -replace '\.shim$', '.exe'
     warn "Overwriting shim to $filename installed from $shim_app"
 }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -870,18 +870,9 @@ function create_shims($manifest, $dir, $global, $arch) {
 }
 
 function rm_shim($name, $shimdir) {
-    $shim = "$shimdir\$name.ps1"
-
-    if(!(test-path $shim)) { # handle no shim from failed install
-        warn "Shim for '$name' is missing. Skipping."
-    } else {
-        write-output "Removing shim for '$name'."
-        Remove-Item $shim
-    }
-
-    # other shim types might be present
-    '', '.exe', '.shim', '.cmd' | ForEach-Object {
+    '', '.exe', '.shim', '.cmd', '.ps1' | ForEach-Object {
         if(test-path -Path "$shimdir\$name$_" -PathType leaf) {
+            Write-Output "Removing shim '$name$_'."
             Remove-Item "$shimdir\$name$_"
         }
     }

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -22,10 +22,11 @@ $globalshims = fullpath (shimdir $true) # don't resolve: may not exist
 if($path -like "$usershims*" -or $path -like "$globalshims*") {
     $exepath = if ($path.endswith(".exe") -or $path.endswith(".shim")) {
         (Get-Content "$(join-path ([system.io.fileinfo]$path).DirectoryName ([system.io.fileinfo]$path).BaseName).shim" | Select-Object -First 1).replace('path = ', '')
-    } elseif ($path.endswith(".ps1")) {
-        (Get-Content $path | Where-Object { $_.startswith('$path') }).split(' ') | Select-Object -Last 1 | Invoke-Expression
     } else {
-        (Select-String -Path $path -Pattern '^(?:@rem|#)\s*(.*)$').Matches.Groups[1].Value
+        ((Select-String -Path $path -Pattern '^(?:@rem|#)\s*(.*)$').Matches.Groups | Select-Object -Index 1).Value
+    }
+    if (!$exepath) {
+        $exepath = (Get-Content $path | Where-Object { $_.startswith('$path') }).split(' ') | Select-Object -Last 1 | Invoke-Expression
     }
 
     if(![system.io.path]::ispathrooted($exepath)) {

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -19,10 +19,12 @@ $path = "$($gcm.path)"
 $usershims = "$(resolve-path $(shimdir $false))"
 $globalshims = fullpath (shimdir $true) # don't resolve: may not exist
 
-if($path.endswith(".ps1") -and ($path -like "$usershims*" -or $path -like "$globalshims*")) {
-    $shimtext = Get-Content $path
-
-    $exepath = ($shimtext | Where-Object { $_.startswith('$path') }).split(' ') | Select-Object -Last 1 | Invoke-Expression
+if($path -like "$usershims*" -or $path -like "$globalshims*") {
+    $exepath = if ($path.endswith(".exe")) {
+        (Get-Content "$(join-path ([system.io.fileinfo]$path).DirectoryName ([system.io.fileinfo]$path).BaseName).shim").split(' ') | Select-Object -Index 2
+    } elseif ($path.endswith(".ps1")) {
+        (Get-Content $path | Where-Object { $_.startswith('$path') }).split(' ') | Select-Object -Last 1 | Invoke-Expression
+    }
 
     if(![system.io.path]::ispathrooted($exepath)) {
         # Expand relative path

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -20,12 +20,12 @@ $usershims = "$(resolve-path $(shimdir $false))"
 $globalshims = fullpath (shimdir $true) # don't resolve: may not exist
 
 if($path -like "$usershims*" -or $path -like "$globalshims*") {
-    $exepath = if ($path.endswith(".exe")) {
+    $exepath = if ($path.endswith(".exe") -or $path.endswith(".shim")) {
         (Get-Content "$(join-path ([system.io.fileinfo]$path).DirectoryName ([system.io.fileinfo]$path).BaseName).shim" | Select-Object -First 1).replace('path = ', '')
     } elseif ($path.endswith(".ps1")) {
         (Get-Content $path | Where-Object { $_.startswith('$path') }).split(' ') | Select-Object -Last 1 | Invoke-Expression
     } else {
-        # need to handle .cmd files
+        (Select-String -Path $path -Pattern '^(?:@rem|#)\s*(.*)$').Matches.Groups[1].Value
     }
 
     if(![system.io.path]::ispathrooted($exepath)) {

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -21,9 +21,11 @@ $globalshims = fullpath (shimdir $true) # don't resolve: may not exist
 
 if($path -like "$usershims*" -or $path -like "$globalshims*") {
     $exepath = if ($path.endswith(".exe")) {
-        (Get-Content "$(join-path ([system.io.fileinfo]$path).DirectoryName ([system.io.fileinfo]$path).BaseName).shim").split(' ') | Select-Object -Index 2
+        (Get-Content "$(join-path ([system.io.fileinfo]$path).DirectoryName ([system.io.fileinfo]$path).BaseName).shim" | Select-Object -First 1).replace('path = ', '')
     } elseif ($path.endswith(".ps1")) {
         (Get-Content $path | Where-Object { $_.startswith('$path') }).split(' ') | Select-Object -Last 1 | Invoke-Expression
+    } else {
+        # need to handle .cmd files
     }
 
     if(![system.io.path]::ispathrooted($exepath)) {

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -21,12 +21,12 @@ $globalshims = fullpath (shimdir $true) # don't resolve: may not exist
 
 if($path -like "$usershims*" -or $path -like "$globalshims*") {
     $exepath = if ($path.endswith(".exe") -or $path.endswith(".shim")) {
-        (Get-Content "$(join-path ([system.io.fileinfo]$path).DirectoryName ([system.io.fileinfo]$path).BaseName).shim" | Select-Object -First 1).replace('path = ', '')
+        (Get-Content ($path -replace '\.exe$', '.shim') | Select-Object -First 1).replace('path = ', '')
     } else {
         ((Select-String -Path $path -Pattern '^(?:@rem|#)\s*(.*)$').Matches.Groups | Select-Object -Index 1).Value
     }
     if (!$exepath) {
-        $exepath = (Get-Content $path | Where-Object { $_.startswith('$path') }).split(' ') | Select-Object -Last 1 | Invoke-Expression
+        $exepath = ((Select-String -Path $path -Pattern '[''"]([^@&]*?)[''"]' -AllMatches).Matches.Groups | Select-Object -Last 1).Value
     }
 
     if(![system.io.path]::ispathrooted($exepath)) {

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -221,7 +221,7 @@ describe "rm_shim" -Tag 'Scoop' {
     }
 }
 
-Describe "get_app_name_from_exe_shim" -Tag 'Scoop' {
+Describe "get_app_name_from_shim" -Tag 'Scoop' {
     BeforeAll {
         $working_dir = setup_working "shim"
         $shimdir = shimdir
@@ -229,7 +229,7 @@ Describe "get_app_name_from_exe_shim" -Tag 'Scoop' {
     }
 
     It "returns empty string if file does not exist" -skip:$isUnix {
-        get_app_name_from_exe_shim "non-existent-file" | should -be ""
+        get_app_name_from_shim "non-existent-file" | should -be ""
     }
 
     It "returns app name if file exists and is a shim to an app" -skip:$isUnix {
@@ -237,12 +237,12 @@ Describe "get_app_name_from_exe_shim" -Tag 'Scoop' {
         Write-Output "" | Out-File "$working_dir/mockapp/current/mockapp.ps1"
         shim "$working_dir/mockapp/current/mockapp.ps1" $false "shim-test"
         $shim_path = (get-command "shim-test.ps1").Path
-        get_app_name_from_exe_shim "$shim_path" | should -be "mockapp"
+        get_app_name_from_shim "$shim_path" | should -be "mockapp"
     }
 
     It "returns empty string if file exists and is not a shim" -skip:$isUnix {
         Write-Output "lorem ipsum" | Out-File -Encoding ascii "$working_dir/mock-shim.ps1"
-        get_app_name_from_exe_shim "$working_dir/mock-shim.ps1" | should -be ""
+        get_app_name_from_shim "$working_dir/mock-shim.ps1" | should -be ""
     }
 
     AfterEach {
@@ -269,7 +269,7 @@ describe "ensure_robocopy_in_path" -Tag 'Scoop' {
 
             ensure_robocopy_in_path
 
-            "$shimdir/robocopy.ps1" | should -exist
+            # "$shimdir/robocopy.ps1" | should -exist
             "$shimdir/robocopy.exe" | should -exist
 
             # clean up
@@ -284,7 +284,7 @@ describe "ensure_robocopy_in_path" -Tag 'Scoop' {
 
             ensure_robocopy_in_path
 
-            "$shimdir/robocopy.ps1" | should -not -exist
+            # "$shimdir/robocopy.ps1" | should -not -exist
             "$shimdir/robocopy.exe" | should -not -exist
         }
     }

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -221,7 +221,7 @@ describe "rm_shim" -Tag 'Scoop' {
     }
 }
 
-Describe "get_app_name_from_ps1_shim" -Tag 'Scoop' {
+Describe "get_app_name_from_exe_shim" -Tag 'Scoop' {
     BeforeAll {
         $working_dir = setup_working "shim"
         $shimdir = shimdir
@@ -229,7 +229,7 @@ Describe "get_app_name_from_ps1_shim" -Tag 'Scoop' {
     }
 
     It "returns empty string if file does not exist" -skip:$isUnix {
-        get_app_name_from_ps1_shim "non-existent-file" | should -be ""
+        get_app_name_from_exe_shim "non-existent-file" | should -be ""
     }
 
     It "returns app name if file exists and is a shim to an app" -skip:$isUnix {
@@ -237,12 +237,12 @@ Describe "get_app_name_from_ps1_shim" -Tag 'Scoop' {
         Write-Output "" | Out-File "$working_dir/mockapp/current/mockapp.ps1"
         shim "$working_dir/mockapp/current/mockapp.ps1" $false "shim-test"
         $shim_path = (get-command "shim-test.ps1").Path
-        get_app_name_from_ps1_shim "$shim_path" | should -be "mockapp"
+        get_app_name_from_exe_shim "$shim_path" | should -be "mockapp"
     }
 
     It "returns empty string if file exists and is not a shim" -skip:$isUnix {
         Write-Output "lorem ipsum" | Out-File -Encoding ascii "$working_dir/mock-shim.ps1"
-        get_app_name_from_ps1_shim "$working_dir/mock-shim.ps1" | should -be ""
+        get_app_name_from_exe_shim "$working_dir/mock-shim.ps1" | should -be ""
     }
 
     AfterEach {


### PR DESCRIPTION
The .ps1 shims are now only created when the bin entry itself is a .ps1 script.

Closes #3749 
Closes #2018 
Closes #4486 
Closes #3850
Closes #3795
Closes #4003
Closes #3890
Closes #4216
Closes #4473
Closes #3699
Closes #4413
Closes #4545
Closes #3851

Closes #4333
Closes #3877
Closes #4376

