### PR TITLE
fix: -a doesn't require an argument

### DIFF
--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -28,7 +28,7 @@
 
 reset_aliases
 
-$opt, $apps, $err = getopt $args 'gfiksqa:' 'global', 'force', 'independent', 'no-cache', 'skip', 'quiet', 'all'
+$opt, $apps, $err = getopt $args 'gfiksqa' 'global', 'force', 'independent', 'no-cache', 'skip', 'quiet', 'all'
 if ($err) { "scoop update: $err"; exit 1 }
 $global = $opt.g -or $opt.global
 $force = $opt.f -or $opt.force


### PR DESCRIPTION
`scoop update -a` demands an argument even though one isn't needed.

Without this fix:
```powershell
> scoop update --all
Updating Scoop... 
Updating 'extras' bucket...                                                                                             
Updating 'main' bucket...                                                                                               
Scoop was updated successfully! 
> scoop update -a
scoop update: Option -a requires an argument.     # <----wtf?
```
with this fix:
```powershell
> scoop update --all
Updating Scoop... 
Updating 'extras' bucket...                                                                                             
Updating 'main' bucket...                                                                                               
Scoop was updated successfully! 
> scoop update -a
Updating Scoop... 
Updating 'extras' bucket...                                                                                             
Updating 'main' bucket...                                                                                               
Scoop was updated successfully! 
```
