### PR TITLE
feat(shim): ps1 shim hotfix

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -615,9 +615,9 @@ set invalid=`"='
 if !args! == !invalid! ( set args= )
 where /q pwsh.exe
 if %errorlevel% equ 0 (
-    pwsh -noprofile -ex unrestricted `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"
+    pwsh -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"
 ) else (
-    powershell -noprofile -ex unrestricted `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"
+    powershell -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"
 )" | Out-File "$shim.cmd" -Encoding ASCII
 
         warn_on_overwrite $shim $path


### PR DESCRIPTION
`pwsh` has different argument parsing rules than `powershell`, so we need to specify the -Command parameter.