### PR TITLE
fix(checkver): Use GitHub token from environment

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -74,7 +74,7 @@ param(
 
 $Dir = Resolve-Path $Dir
 $Search = $App
-$GitHubToken = $env:SCOOP_CHECKVER_TOKEN, (get_config 'checkverToken') | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$GitHubToken = $env:SCOOP_CHECKVER_TOKEN, (get_config 'checkver-token') | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
 
 # get apps to check
 $Queue = @()
@@ -129,7 +129,6 @@ $Queue | ForEach-Object {
     if ($json.checkver.github) {
         $url = $json.checkver.github.TrimEnd('/') + '/releases/latest'
         $regex = $githubRegex
-        # !!!
         if ($json.checkver.PSObject.Properties.Count -eq 1) { $useGithubAPI = $true }
     }
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -74,7 +74,7 @@ param(
 
 $Dir = Resolve-Path $Dir
 $Search = $App
-$GitHubToken = $env:SCOOP_CHECKVER_TOKEN, (get_config 'checkver-token') | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$GitHubToken = $env:SCOOP_CHECKVER_TOKEN, (get_config 'checkver-token') | Where-Object -Property Length -Value 0 -GT | Select-Object -First 1
 
 # get apps to check
 $Queue = @()

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -74,6 +74,7 @@ param(
 
 $Dir = Resolve-Path $Dir
 $Search = $App
+$GitHubToken = $env:SCOOP_CHECKVER_TOKEN, (get_config 'checkverToken') | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
 
 # get apps to check
 $Queue = @()
@@ -114,18 +115,22 @@ $Queue | ForEach-Object {
     $jsonpath = ''
     $xpath = ''
     $replace = ''
+    $useGithubAPI = $false
 
     if ($json.checkver -eq 'github') {
         if (!$json.homepage.StartsWith('https://github.com/')) {
             error "$name checkver expects the homepage to be a github repository"
         }
-        $url = $json.homepage + '/releases/latest'
+        $url = $json.homepage.TrimEnd('/') + '/releases/latest'
         $regex = $githubRegex
+        $useGithubAPI = $true
     }
 
     if ($json.checkver.github) {
-        $url = $json.checkver.github + '/releases/latest'
+        $url = $json.checkver.github.TrimEnd('/') + '/releases/latest'
         $regex = $githubRegex
+        # !!!
+        if ($json.checkver.PSObject.Properties.Count -eq 1) { $useGithubAPI = $true }
     }
 
     if ($json.checkver.re) {
@@ -154,6 +159,13 @@ $Queue | ForEach-Object {
     }
 
     $reverse = $json.checkver.reverse -and $json.checkver.reverse -eq 'true'
+
+    if ($url -like '*api.github.com/*') { $useGithubAPI = $true }
+
+    if ($useGithubAPI -and ($null -ne $GitHubToken)) {
+        $url = $url -replace '//(www\.)?github.com/', '//api.github.com/repos/'
+        $wc.Headers.Add('Authorization', "token $GitHubToken")
+    }
 
     $url = substitute $url $substitutions
 


### PR DESCRIPTION
Blocker for https://github.com/ScoopInstaller/Main/pull/2871

This is intentionally targeted to `master`, because this is an essential fix.

Relates to first part of https://github.com/ScoopInstaller/Main/pull/2871#issuecomment-984977671. I will look at rate-limiting headers some other time. For now, this works fine.

How I tested this:
- Ran checkver on Extras bucket: I get "Too many requests" error for around 450 manifests
- Declared an environment variable $Env:SCOOP_CHECKVER_TOKEN
- Ran checkver on Extras bucket: No errors this time
