### PR TITLE
fix(core): Use '-Encoding ASCII' in 'Out-File'

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -569,9 +569,9 @@ function shim($path, $global, $name, $arg) {
         # for programs with no awareness of any shell
         warn_on_overwrite "$shim.shim" $path
         Copy-Item (get_shim_path) "$shim.exe" -Force
-        Write-Output "path = $resolved_path" | Out-File "$shim.shim" -Encoding UTF8
+        Write-Output "path = $resolved_path" | Out-File "$shim.shim" -Encoding ASCII
         if ($arg) {
-            Write-Output "args = $arg" | Out-File "$shim.shim" -Encoding UTF8 -Append
+            Write-Output "args = $arg" | Out-File "$shim.shim" -Encoding ASCII -Append
         }
     } elseif ($path -match '\.(bat|cmd)$') {
         # shim .bat, .cmd so they can be used by programs with no awareness of PSH
@@ -599,7 +599,7 @@ if (!(Test-Path Variable:PSScriptRoot)) { `$PSScriptRoot = Split-Path `$MyInvoca
 if(`$myinvocation.expectingInput) { `$input | & `$path $arg @args } else { & `$path $arg @args }
 exit `$lastexitcode"
         }
-        $ps1text | Out-File "$shim.ps1" -Encoding UTF8
+        $ps1text | Out-File "$shim.ps1" -Encoding ASCII
 
         # make ps1 accessible from cmd.exe
         warn_on_overwrite "$shim.cmd" $path

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -16,22 +16,22 @@
 #   -v, --verbose   Show alias description and table headers (works only for 'list')
 
 param(
-  [String]$opt,
-  [String]$name,
-  [String]$command,
-  [String]$description,
-  [Switch]$verbose = $false
+    [String]$opt,
+    [String]$name,
+    [String]$command,
+    [String]$description,
+    [Switch]$verbose = $false
 )
 
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\help.ps1"
 . "$psscriptroot\..\lib\install.ps1"
 
-$script:config_alias = "alias"
+$script:config_alias = 'alias'
 
 function init_alias_config {
     $aliases = get_config $script:config_alias
-    if(!$aliases) {
+    if (!$aliases) {
         $aliases = @{}
     }
 
@@ -39,13 +39,13 @@ function init_alias_config {
 }
 
 function add_alias($name, $command) {
-    if(!$command) {
+    if (!$command) {
         abort "Can't create an empty alias."
     }
 
     # get current aliases from config
     $aliases = init_alias_config
-    if($aliases.$name) {
+    if ($aliases.$name) {
         abort "Alias $name already exists."
     }
 
@@ -54,11 +54,11 @@ function add_alias($name, $command) {
     # generate script
     $shimdir = shimdir $false
     $script =
-@"
+    @"
 # Summary: $description
 $command
 "@
-    $script | out-file "$shimdir\$alias_file.ps1" -encoding utf8
+    $script | Out-File "$shimdir\$alias_file.ps1" -Encoding ASCII
 
     # add alias to config
     $aliases | Add-Member -MemberType NoteProperty -Name $name -Value $alias_file
@@ -68,11 +68,11 @@ $command
 
 function rm_alias($name) {
     $aliases = init_alias_config
-    if(!$name) {
-        abort "Which alias should be removed?"
+    if (!$name) {
+        abort 'Which alias should be removed?'
     }
 
-    if($aliases.$name) {
+    if ($aliases.$name) {
         "Removing alias $name..."
 
         rm_shim $aliases.$name (shimdir $false)
@@ -92,24 +92,24 @@ function list_aliases {
         $command = ($content | Select-Object -Skip 1).Trim()
         $summary = (summary $content).Trim()
 
-        $aliases += New-Object psobject -Property @{Name=$_.name; Summary=$summary; Command=$command}
+        $aliases += New-Object psobject -Property @{Name = $_.name; Summary = $summary; Command = $command }
     }
 
-    if(!$aliases.count) {
-        warn "No aliases founds."
+    if (!$aliases.count) {
+        warn 'No aliases founds.'
     }
     $aliases = $aliases.GetEnumerator() | Sort-Object Name
-    if($verbose) {
-        return $aliases | Select-Object Name, Command, Summary | Format-Table -autosize -wrap
+    if ($verbose) {
+        return $aliases | Select-Object Name, Command, Summary | Format-Table -AutoSize -Wrap
     } else {
-        return $aliases | Select-Object Name, Command | Format-Table -autosize -hidetablehead -wrap
+        return $aliases | Select-Object Name, Command | Format-Table -AutoSize -hidetablehead -Wrap
     }
 }
 
-switch($opt) {
-    "add" { add_alias $name $command }
-    "rm" { rm_alias $name }
-    "list" { list_aliases }
+switch ($opt) {
+    'add' { add_alias $name $command }
+    'rm' { rm_alias $name }
+    'list' { list_aliases }
     default { my_usage; exit 1 }
 }
 

--- a/libexec/scoop-create.ps1
+++ b/libexec/scoop-create.ps1
@@ -11,29 +11,28 @@ function create_manifest($url) {
     $url_parts = $null
     try {
         $url_parts = parse_url $url
-    }
-    catch {
+    } catch {
         abort "Error: $url is not a valid URL"
     }
 
-    $name = choose_item $url_parts "App name"
+    $name = choose_item $url_parts 'App name'
     $name = if ($name.Length -gt 0) {
         $name
-    }
-    else {
-        file_name ($url_parts | select-object -last 1)
+    } else {
+        file_name ($url_parts | Select-Object -Last 1)
     }
 
-    $manifest.version = choose_item $url_parts "Version"
+    $manifest.version = choose_item $url_parts 'Version'
 
-    $manifest | convertto-json | out-file -filepath "$name.json" -encoding utf8
-    $manifest_path = join-path $pwd "$name.json"
-    write-host "Created '$manifest_path'."
+    $manifest | ConvertTo-Json | Out-File -FilePath "$name.json" -Encoding ASCII
+    $manifest_path = Join-Path $pwd "$name.json"
+    Write-Host "Created '$manifest_path'."
 }
 
 function new_manifest() {
-    @{ "homepage" = ""; "license" = ""; "version" = ""; "url" = "";
-        "hash" = ""; "extract_dir" = ""; "bin" = ""; "depends" = "" }
+    @{ 'homepage' = ''; 'license' = ''; 'version' = ''; 'url' = '';
+        'hash' = ''; 'extract_dir' = ''; 'bin' = ''; 'depends' = ''
+    }
 }
 
 function file_name($segment) {
@@ -41,19 +40,19 @@ function file_name($segment) {
 }
 
 function parse_url($url) {
-    $uri = new-object Uri $url
-    $uri.pathandquery.substring(1).split("/")
+    $uri = New-Object Uri $url
+    $uri.pathandquery.substring(1).split('/')
 }
 
 function choose_item($list, $query) {
     for ($i = 0; $i -lt $list.count; $i++) {
         $item = $list[$i]
-        write-host "$($i + 1)) $item"
+        Write-Host "$($i + 1)) $item"
     }
-    $sel = read-host $query
+    $sel = Read-Host $query
 
     if ($sel.trim() -match '^[0-9+]$') {
-        return $list[$sel-1]
+        return $list[$sel - 1]
     }
 
     $sel
@@ -61,8 +60,7 @@ function choose_item($list, $query) {
 
 if (!$url) {
     scoop help create
-}
-else {
+} else {
     create_manifest $url
 }
 


### PR DESCRIPTION
In PowerShell 5, `Out-File -Encoding UTF8` will produce an UTF-BOM file, which may cause some error.

`Out-File -Encoding ASCII` produces UTF file in fact, so 'cos Scoop support PS5, using ASCII encoding is better.

Also some file formatting.