### PR TITLE
fix(core): Escape '.' in 'parse_app()'.

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -814,7 +814,7 @@ function applist($apps, $global) {
 }
 
 function parse_app([string] $app) {
-    if($app -match '(?:(?<bucket>[a-zA-Z0-9-]+)\/)?(?<app>.*.json$|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?') {
+    if($app -match '(?:(?<bucket>[a-zA-Z0-9-]+)\/)?(?<app>.*\.json$|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?') {
         return $matches['app'], $matches['bucket'], $matches['version']
     }
     return $app, $null, $null


### PR DESCRIPTION
Since the `.` has a special meaning in regex, in needs to be escaped.  Since there is all characters matching (`.*`) just ahead of it, it is safe to assume that author wanted to have the `.json` and not `<any character>json`.