### PR TITLE
fix(install): Don't show manifest while updating

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -34,7 +34,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
         return
     }
 
-    if (get_config 'manifest-review' $false) {
+    if ((get_config 'manifest-review' $false) -and ($MyInvocation.ScriptName -notlike '*scoop-update*')) {
         Write-Output 'Manifest:'
         Write-Output $manifest | ConvertToPrettyJson
         $answer = Read-Host -Prompt "Continue installation? [Y/n]"


### PR DESCRIPTION
Don't show manifest while 'scoop update` (https://github.com/ScoopInstaller/Scoop/pull/4155#issuecomment-993554265)