### PR TITLE
fix(decompress): Fix 'Expand-7zipArchive()' for nested archive

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -434,8 +434,8 @@ function Invoke-ExternalCommand {
         return $false
     }
     if ($LogPath -and ($FilePath -notmatch '(^|\W)msiexec($|\W)')) {
-        Out-File -FilePath $LogPath -Encoding ASCII -Append -InputObject $Process.StandardOutput.ReadToEnd()
-        Out-File -FilePath $LogPath -Encoding ASCII -Append -InputObject $Process.StandardError.ReadToEnd()
+        Out-File -FilePath $LogPath -Encoding Default -Append -InputObject $Process.StandardOutput.ReadToEnd()
+        Out-File -FilePath $LogPath -Encoding Default -Append -InputObject $Process.StandardError.ReadToEnd()
     }
     $Process.WaitForExit()
     if ($Process.ExitCode -ne 0) {

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -110,7 +110,7 @@ function Expand-7zipArchive {
         # Check for tar
         $Status = Invoke-ExternalCommand $7zPath @('l', "`"$Path`"") -LogPath $LogPath
         if ($Status) {
-            $TarFile = (Get-Content -Path $LogPath)[-4] -replace '.{53}(.*)', '$1' # get inner tar file name
+            $TarFile = (Get-Content -Path $LogPath)[-5] -replace '.{53}(.*)', '$1' # get inner tar file name
             Expand-7zipArchive -Path "$DestinationPath\$TarFile" -DestinationPath $DestinationPath -ExtractDir $ExtractDir -Removal
         } else {
             abort "Failed to list files in $Path.`nNot a 7-Zip supported archive file."


### PR DESCRIPTION
After we added error log in 7zip.log (#4570), nested archive extraction by 7-zip had been broken... This PR fix it.

Besides, output and error logs have some encoding error as in https://github.com/ScoopInstaller/Scoop/issues/4569, and change encoding to `Default` solve my problem (CP936, in PS 7 and PS 5), please test it in different codepage and PowerShell version.