### PR TITLE
tests: Make test for files to end with a newline compatible with UTF-16

### DIFF
--- a/test/Import-File-Tests.ps1
+++ b/test/Import-File-Tests.ps1
@@ -55,8 +55,8 @@ describe 'Style constraints for non-binary project files' {
                 if ($file -match "TestResults.xml") {
                     continue
                 }
-                $string = [System.IO.File]::ReadAllText($file.FullName)
-                if ($string.Length -gt 0 -and $string[-1] -ne "`n")
+                $string = [System.IO.File]::ReadAllBytes($file.FullName)
+                if ($string.Length -gt 0 -and $string[-2] -ne 10) # Char(10) ... New Line
                 {
                     $file.FullName
                 }


### PR DESCRIPTION
The import file test will fail if the file tested is `UTF-16` (@Windows called `Unicode`).

This test is modified to meet it purpose, testing if the file imported ends with new line, but also to work with `UTF-16`.