### PR TITLE
Remove nightlies bucket, the repo no longer exists

### DIFF
--- a/buckets.json
+++ b/buckets.json
@@ -2,7 +2,6 @@
     "main": "https://github.com/ScoopInstaller/Main",
     "extras": "https://github.com/ScoopInstaller/Extras",
     "versions": "https://github.com/ScoopInstaller/Versions",
-    "nightlies": "https://github.com/ScoopInstaller/Nightlies",
     "nirsoft": "https://github.com/kodybrown/scoop-nirsoft",
     "php": "https://github.com/ScoopInstaller/PHP",
     "nerd-fonts": "https://github.com/matthewjberger/scoop-nerd-fonts",


### PR DESCRIPTION
#### Description
This removes the "nightlies" bucket from `buckets.json` as the repo associated with it (https://github.com/ScoopInstaller/Nightlies) no longer exists.

#### Motivation and Context
This was resulting in an error message from the `Invoke-WebRequest` cmdlet being displayed to when `scoop search` was used (and possibly other commands).
Relates to #4574

#### How Has This Been Tested?
I've verified that when this entry is no longer in `buckets.json` the `scoop search` command does not produce an error related to requesting that repository.

Issue #4574 should still be fixed separately however, as there are other sources of potential failure by the `Invoke-WebRequest` cmdlet that should be handled.
