### PR TITLE
test(test-bin): Only write output file in CI and fix trailing whitespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@
 - **depends:** Prevent error on no URL ([#4595](https://github.com/ScoopInstaller/Scoop/issues/4595))
 - **decompress:** Fix nested Zstd archive extraction ([#4608](https://github.com/ScoopInstaller/Scoop/issues/4608))
 
-### Documentation
-
-- **changelog:** Add 'CHANGLOG.md' ([#4600](https://github.com/ScoopInstaller/Scoop/issues/4600))
-
 ### Styles
 
 - **test:** Format scripts by VSCode's PowerShell extension ([#4609](https://github.com/ScoopInstaller/Scoop/issues/4609))
+
+### Tests
+
+- **test-bin:** Only write output file in CI and fix trailing whitespaces ([#4613](https://github.com/ScoopInstaller/Scoop/issues/4613))
+
+### Documentation
+
+- **changelog:** Add 'CHANGLOG.md' ([#4600](https://github.com/ScoopInstaller/Scoop/issues/4600))
 
 <a name="2021-12-26"></a>
 ## [2021-12-26]

--- a/libexec/scoop-prefix.ps1
+++ b/libexec/scoop-prefix.ps1
@@ -2,7 +2,7 @@
 # Summary: Returns the path to the specified app
 param($app)
 
-if(!$app) { 
+if (!$app) {
     . "$psscriptroot\..\lib\help.ps1"
     my_usage
     exit 1
@@ -11,11 +11,11 @@ if(!$app) {
 . "$psscriptroot\..\lib\core.ps1"
 
 $app_path = versiondir $app 'current' $false
-if(!(Test-Path $app_path)) {
+if (!(Test-Path $app_path)) {
     $app_path = versiondir $app 'current' $true
 }
 
-if(Test-Path $app_path) {
+if (Test-Path $app_path) {
     Write-Output $app_path
 } else {
     abort "Could not find app path for '$app'."

--- a/schema.json
+++ b/schema.json
@@ -220,9 +220,6 @@
                 },
                 "persist": {
                     "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
-                },                
-                "license": {
-                    "$ref": "#/definitions/license"
                 },
                 "license": {
                     "$ref": "#/definitions/license"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Only produce test result file while run by CI and fix two styling failure.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When run `test\bin\test.ps1` locally, it will produce `TestResults.xml` file and give a failure on next run.

Also fix duplicate `license` item in `schema.json` and trailing space in `libexec\scoop-prefix.ps1`

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Running `test\bin\test.ps1`

Before:
![image](https://user-images.githubusercontent.com/5832170/147774960-8f1e4141-db83-469a-ba49-ab565651b0a2.png)
![image](https://user-images.githubusercontent.com/5832170/147774979-3b3fedeb-e176-4d5a-aa7d-cd1ef64cf2dc.png)

After:
![image](https://user-images.githubusercontent.com/5832170/147775107-74c39004-11a0-49c0-90e8-e448a90e5bed.png)
![image](https://user-images.githubusercontent.com/5832170/147775123-b2c9f9d1-c31e-4c1c-a75b-74ae695117d5.png)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
