### PR TITLE
fix(shim): Fix PS1 shim error when in different drive in PS7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - **depends:** Prevent error on no URL ([#4595](https://github.com/ScoopInstaller/Scoop/issues/4595))
 - **decompress:** Fix nested Zstd archive extraction ([#4608](https://github.com/ScoopInstaller/Scoop/issues/4608))
+- **shim:** Fix PS1 shim error when in different drive in PS7 ([#4614](https://github.com/ScoopInstaller/Scoop/issues/4614))
 
 ### Documentation
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -584,7 +584,7 @@ function shim($path, $global, $name, $arg) {
 
         warn_on_overwrite $shim $path
         @(
-            '#!/bin/sh',
+            "#!/bin/sh",
             "# $resolved_path",
             "MSYS2_ARG_CONV_EXCL=/C cmd.exe /C `"$resolved_path`" $arg `"$@`""
         ) -join "`n" | Out-File $shim -Encoding ASCII
@@ -614,32 +614,32 @@ function shim($path, $global, $name, $arg) {
         warn_on_overwrite "$shim.cmd" $path
         @(
             "@rem $resolved_path",
-            '@echo off',
-            'setlocal enabledelayedexpansion',
-            'set args=%*',
-            ':: replace problem characters in arguments',
+            "@echo off",
+            "setlocal enabledelayedexpansion",
+            "set args=%*",
+            ":: replace problem characters in arguments",
             "set args=%args:`"='%",
             "set args=%args:(=``(%",
             "set args=%args:)=``)%",
             "set invalid=`"='",
-            'if !args! == !invalid! ( set args= )',
-            'where /q pwsh.exe',
-            'if %errorlevel% equ 0 (',
+            "if !args! == !invalid! ( set args= )",
+            "where /q pwsh.exe",
+            "if %errorlevel% equ 0 (",
             "    pwsh -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"",
-            ') else (',
+            ") else (",
             "    powershell -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"",
-            ')'
+            ")"
         ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
 
         warn_on_overwrite $shim $path
         @(
-            '#!/bin/sh',
+            "#!/bin/sh",
             "# $resolved_path",
-            'if command -v pwsh.exe &> /dev/null; then',
+            "if command -v pwsh.exe &> /dev/null; then",
             "    pwsh -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
-            'else',
+            "else",
             "    powershell -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
-            'fi'
+            "fi"
         ) -join "`n" | Out-File $shim -Encoding ASCII
     } elseif ($path -match '\.jar$') {
         warn_on_overwrite "$shim.cmd" $path
@@ -650,7 +650,7 @@ function shim($path, $global, $name, $arg) {
 
         warn_on_overwrite $shim $path
         @(
-            '#!/bin/sh',
+            "#!/bin/sh",
             "# $resolved_path",
             "java -jar `"$resolved_path`" $arg `"$@`""
         ) -join "`n" | Out-File $shim -Encoding ASCII
@@ -663,7 +663,7 @@ function shim($path, $global, $name, $arg) {
 
         warn_on_overwrite $shim $path
         @(
-            '#!/bin/sh',
+            "#!/bin/sh",
             "# $resolved_path",
             "python `"$resolved_path`" $arg `"$@`""
         ) -join "`n" | Out-File $shim -Encoding ASCII
@@ -681,7 +681,7 @@ function shim($path, $global, $name, $arg) {
 
         warn_on_overwrite $shim $path
         @(
-            '#!/bin/sh',
+            "#!/bin/sh",
             "# $resolved_path",
             "`"$resolved_path`" $arg `"$@`""
         ) -join "`n" | Out-File $shim -Encoding ASCII

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -587,7 +587,7 @@ function shim($path, $global, $name, $arg) {
             '#!/bin/sh',
             "# $resolved_path",
             "MSYS2_ARG_CONV_EXCL=/C cmd.exe /C `"$resolved_path`" $arg `"$@`""
-        ) -join "`r`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII
     } elseif ($path -match '\.ps1$') {
         # if $path points to another drive resolve-path prepends .\ which could break shims
         warn_on_overwrite "$shim.ps1" $path
@@ -636,11 +636,11 @@ function shim($path, $global, $name, $arg) {
             '#!/bin/sh',
             "# $resolved_path",
             'if command -v pwsh.exe &> /dev/null; then',
-            "    pwsh.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
+            "    pwsh -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
             'else',
-            "    powershell.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
+            "    powershell -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
             'fi'
-        ) -join "`r`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII
     } elseif ($path -match '\.jar$') {
         warn_on_overwrite "$shim.cmd" $path
         @(
@@ -653,7 +653,7 @@ function shim($path, $global, $name, $arg) {
             '#!/bin/sh',
             "# $resolved_path",
             "java -jar `"$resolved_path`" $arg `"$@`""
-        ) -join "`r`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII
     } elseif ($path -match '\.py$') {
         warn_on_overwrite "$shim.cmd" $path
         @(
@@ -666,7 +666,7 @@ function shim($path, $global, $name, $arg) {
             '#!/bin/sh',
             "# $resolved_path",
             "python `"$resolved_path`" $arg `"$@`""
-        ) -join "`r`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII
     } else {
         warn_on_overwrite "$shim.cmd" $path
         # find path to Git's bash so that batch scripts can run bash scripts
@@ -684,7 +684,7 @@ function shim($path, $global, $name, $arg) {
             '#!/bin/sh',
             "# $resolved_path",
             "`"$resolved_path`" $arg `"$@`""
-        ) -join "`r`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII
     }
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -577,76 +577,96 @@ function shim($path, $global, $name, $arg) {
     } elseif ($path -match '\.(bat|cmd)$') {
         # shim .bat, .cmd so they can be used by programs with no awareness of PSH
         warn_on_overwrite "$shim.cmd" $path
-        "@rem $resolved_path
-@`"$resolved_path`" $arg %*" | Out-File "$shim.cmd" -Encoding ASCII
+        @(
+            "@rem $resolved_path",
+            "@`"$resolved_path`" $arg %*"
+        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
 
         warn_on_overwrite $shim $path
-        "#!/bin/sh
-# $resolved_path
-MSYS2_ARG_CONV_EXCL=/C cmd.exe /C `"$resolved_path`" $arg `"$@`"" | Out-File $shim -Encoding ASCII
+        @(
+            '#!/bin/sh',
+            "# $resolved_path",
+            "MSYS2_ARG_CONV_EXCL=/C cmd.exe /C `"$resolved_path`" $arg `"$@`""
+        ) -join "`r`n" | Out-File $shim -Encoding ASCII
     } elseif ($path -match '\.ps1$') {
         # if $path points to another drive resolve-path prepends .\ which could break shims
         warn_on_overwrite "$shim.ps1" $path
-        $ps1text = if ($relative_path -match '^(.\\[\w]:).*$') {
-            "# $resolved_path
-`$path = `"$path`"
-if(`$myinvocation.expectingInput) { `$input | & `$path $arg @args } else { & `$path $arg @args }
-exit `$lastexitcode"
+        $ps1text = if ($relative_path -match '^(\.\\)?\w:.*$') {
+            @(
+                "# $resolved_path",
+                "`$path = `"$path`"",
+                "if (`$MyInvocation.ExpectingInput) { `$input | & `$path $arg @args } else { & `$path $arg @args }",
+                "exit `$LASTEXITCODE"
+            )
         } else {
             # Setting PSScriptRoot in Shim if it is not defined, so the shim doesn't break in PowerShell 2.0
-            "# $resolved_path
-if (!(Test-Path Variable:PSScriptRoot)) { `$PSScriptRoot = Split-Path `$MyInvocation.MyCommand.Path -Parent }
-`$path = join-path `"`$psscriptroot`" `"$relative_path`"
-if(`$myinvocation.expectingInput) { `$input | & `$path $arg @args } else { & `$path $arg @args }
-exit `$lastexitcode"
+            @(
+                "# $resolved_path",
+                "if (!(Test-Path Variable:PSScriptRoot)) { `$PSScriptRoot = Split-Path `$MyInvocation.MyCommand.Path -Parent }",
+                "`$path = Join-Path `"`$PSScriptRoot`" `"$relative_path`"",
+                "if (`$MyInvocation.ExpectingInput) { `$input | & `$path $arg @args } else { & `$path $arg @args }",
+                "exit `$LASTEXITCODE"
+            )
         }
-        $ps1text | Out-File "$shim.ps1" -Encoding ASCII
+        $ps1text -join "`r`n" | Out-File "$shim.ps1" -Encoding ASCII
 
         # make ps1 accessible from cmd.exe
         warn_on_overwrite "$shim.cmd" $path
-        "@rem $resolved_path
-@echo off
-setlocal enabledelayedexpansion
-set args=%*
-:: replace problem characters in arguments
-set args=%args:`"='%
-set args=%args:(=``(%
-set args=%args:)=``)%
-set invalid=`"='
-if !args! == !invalid! ( set args= )
-where /q pwsh.exe
-if %errorlevel% equ 0 (
-    pwsh -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"
-) else (
-    powershell -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"
-)" | Out-File "$shim.cmd" -Encoding ASCII
+        @(
+            "@rem $resolved_path",
+            '@echo off',
+            'setlocal enabledelayedexpansion',
+            'set args=%*',
+            ':: replace problem characters in arguments',
+            "set args=%args:`"='%",
+            "set args=%args:(=``(%",
+            "set args=%args:)=``)%",
+            "set invalid=`"='",
+            'if !args! == !invalid! ( set args= )',
+            'where /q pwsh.exe',
+            'if %errorlevel% equ 0 (',
+            "    pwsh -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"",
+            ') else (',
+            "    powershell -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"",
+            ')'
+        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
 
         warn_on_overwrite $shim $path
-        "#!/bin/sh
-# $resolved_path
-if command -v pwsh.exe &> /dev/null; then
-    pwsh.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"
-else
-    powershell.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"
-fi" | Out-File $shim -Encoding ASCII
+        @(
+            '#!/bin/sh',
+            "# $resolved_path",
+            'if command -v pwsh.exe &> /dev/null; then',
+            "    pwsh.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
+            'else',
+            "    powershell.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
+            'fi'
+        ) -join "`r`n" | Out-File $shim -Encoding ASCII
     } elseif ($path -match '\.jar$') {
         warn_on_overwrite "$shim.cmd" $path
-        "@rem $resolved_path
-@java -jar `"$resolved_path`" $arg %*" | Out-File "$shim.cmd" -Encoding ASCII
+        @(
+            "@rem $resolved_path",
+            "@java -jar `"$resolved_path`" $arg %*"
+        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
 
         warn_on_overwrite $shim $path
-        "#!/bin/sh
-# $resolved_path
-java -jar `"$resolved_path`" $arg `"$@`"" | Out-File $shim -Encoding ASCII
+        @(
+            '#!/bin/sh',
+            "# $resolved_path",
+            "java -jar `"$resolved_path`" $arg `"$@`""
+        ) -join "`r`n" | Out-File $shim -Encoding ASCII
     } elseif ($path -match '\.py$') {
         warn_on_overwrite "$shim.cmd" $path
-        "@rem $resolved_path
-@python `"$resolved_path`" $arg %*" | Out-File "$shim.cmd" -Encoding ASCII
+        @(
+            "@rem $resolved_path",
+            "@python `"$resolved_path`" $arg %*"
+        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
 
         warn_on_overwrite $shim $path
-        "#!/bin/sh
-# $resolved_path
-python `"$resolved_path`" $arg `"$@`"" | Out-File $shim -Encoding ASCII
+        @(
+            '#!/bin/sh',
+            "# $resolved_path",
+            "python `"$resolved_path`" $arg `"$@`""
+        ) -join "`r`n" | Out-File $shim -Encoding ASCII
     } else {
         warn_on_overwrite "$shim.cmd" $path
         # find path to Git's bash so that batch scripts can run bash scripts
@@ -654,13 +674,17 @@ python `"$resolved_path`" $arg `"$@`"" | Out-File $shim -Encoding ASCII
         if ($gitdir.FullName -imatch 'mingw') {
             $gitdir = $gitdir.Parent
         }
-        "@rem $resolved_path
-@`"$(Join-Path (Join-Path $gitdir.FullName 'bin') 'bash.exe')`" `"$resolved_path`" $arg %*" | Out-File "$shim.cmd" -Encoding ASCII
+        @(
+            "@rem $resolved_path",
+            "@`"$(Join-Path (Join-Path $gitdir.FullName 'bin') 'bash.exe')`" `"$resolved_path`" $arg %*"
+        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
 
         warn_on_overwrite $shim $path
-        "#!/bin/sh
-# $resolved_path
-`"$resolved_path`" $arg `"$@`"" | Out-File $shim -Encoding ASCII
+        @(
+            '#!/bin/sh',
+            "# $resolved_path",
+            "`"$resolved_path`" $arg `"$@`""
+        ) -join "`r`n" | Out-File $shim -Encoding ASCII
     }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Fix PS1 shim's content switch, change from `^(.\\[\w]:).*$` to `^(\.\\)?\w:.*$`. Also enclose shim content with @() for a clear look.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

PS1 shim went wrong in PowerShell 7 if target is in a different drive other than shim dir. This is introduced by `Resolve-Path -Relative` cmdlet's output.

In PS5:
![image](https://user-images.githubusercontent.com/5832170/147776286-09b3676d-3df6-4f0c-b2ae-09bf9faf1d2e.png)

In PS7:
![image](https://user-images.githubusercontent.com/5832170/147776324-34a4b77b-0620-48d4-8ebc-eb302da5896e.png)

Other changes are pure refactoring (enclosed raw code in `@()`)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Run `Invoke-Pester ".\test\Scoop-Core.Tests.ps1"`

Before:
![image](https://user-images.githubusercontent.com/5832170/147776634-9b020ae9-ef2a-4e75-8133-663768f56b6d.png)

After:
![image](https://user-images.githubusercontent.com/5832170/147776719-14450fdd-c996-4f5c-88e2-f941fdadd391.png)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
