### PR TITLE
feat(download): Allow downloading without installing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### Features
+
+- **scoop-download:** Add `scoop download` command ([#4621](https://github.com/ScoopInstaller/Scoop/issues/4621))
+
 ### Bug Fixes
 
 - **autoupdate:** Allow checksum file that contains whitespaces ([#4619](https://github.com/ScoopInstaller/Scoop/issues/4619))

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -22,7 +22,7 @@
 reset_aliases
 
 $opt, $apps, $err = getopt $args 'fsa:' 'force', 'skip', 'arch='
-if ($err) { error "scoop install: $err"; exit 1 }
+if ($err) { error "scoop download: $err"; exit 1 }
 
 $check_hash = !($opt.s -or $opt.skip)
 $use_cache = !($opt.f -or $opt.force)

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -1,5 +1,5 @@
 # Usage: scoop download <app> [options]
-# Summary: Download apps in the cache folder
+# Summary: Download apps in the cache folder and verify hashes
 # Help: e.g. The usual way to download an app, without installing it (uses your local 'buckets'):
 #      scoop download git
 #
@@ -11,7 +11,7 @@
 #
 # Options:
 #   -f, --force               Force download (overwrite cache)
-#   -s, --skip                Skip hash validation (use with caution!)
+#   -h, --no-hash-heck        Skip hash verification (use with caution!)
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
 . "$psscriptroot\..\lib\manifest.ps1"
@@ -21,10 +21,10 @@
 
 reset_aliases
 
-$opt, $apps, $err = getopt $args 'fsa:' 'force', 'skip', 'arch='
+$opt, $apps, $err = getopt $args 'fha:' 'force', 'no-hash-check', 'arch='
 if ($err) { error "scoop download: $err"; exit 1 }
 
-$check_hash = !($opt.s -or $opt.skip)
+$check_hash = !($opt.h -or $opt.'no-hash-check')
 $use_cache = !($opt.f -or $opt.force)
 $architecture = default_architecture
 try {
@@ -49,7 +49,7 @@ foreach ($curr_app in $apps) {
     $app, $bucket, $version = parse_app $curr_app
     $app, $manifest, $bucket, $url = Find-Manifest $app $bucket
 
-    info "Starting download for $app"
+    info "Starting download for $app..."
 
     # Generate manifest if there is different version in manifest
     if (($null -ne $version) -and ($manifest.version -ne $version)) {
@@ -66,7 +66,7 @@ foreach ($curr_app in $apps) {
         continue
     }
     $version = $manifest.version
-    if(!$version) { 
+    if(!$version) {
         error "Manifest doesn't specify a version."
         continue
     }

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -1,0 +1,127 @@
+# Usage: scoop download <app> [options]
+# Summary: Download apps in the cache folder
+# Help: e.g. The usual way to download an app, without installing it (uses your local 'buckets'):
+#      scoop download git
+#
+# To download an app from a manifest at a URL:
+#      scoop download https://raw.githubusercontent.com/ScoopInstaller/Main/master/bucket/runat.json
+#
+# To download an app from a manifest on your computer
+#      scoop download path\to\app.json
+#
+# Options:
+#   -f, --force               Force download (overwrite cache)
+#   -s, --skip                Skip hash validation (use with caution!)
+#   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
+
+. "$psscriptroot\..\lib\manifest.ps1"
+. "$psscriptroot\..\lib\install.ps1"
+. "$psscriptroot\..\lib\help.ps1"
+. "$psscriptroot\..\lib\getopt.ps1"
+
+reset_aliases
+
+$opt, $apps, $err = getopt $args 'fsa:' 'force', 'skip', 'arch='
+if ($err) { error "scoop install: $err"; exit 1 }
+
+$check_hash = !($opt.s -or $opt.skip)
+$use_cache = !($opt.f -or $opt.force)
+$architecture = default_architecture
+try {
+    $architecture = ensure_architecture ($opt.a + $opt.arch)
+} catch {
+    abort "ERROR: $_"
+}
+
+if (!$apps) { error '<app> missing'; my_usage; exit 1 }
+
+if (is_scoop_outdated) {
+    scoop update
+}
+
+# we only want to show this warning once
+if(!$use_cache) { warn "Cache is being ignored." }
+
+foreach ($curr_app in $apps) {
+    # Prevent leaking variables from previous iteration
+    $bucket = $version = $app = $manifest = $url = $null
+
+    $app, $bucket, $version = parse_app $curr_app
+    $app, $manifest, $bucket, $url = Find-Manifest $app $bucket
+
+    info "Starting download for $app"
+
+    # Generate manifest if there is different version in manifest
+    if (($null -ne $version) -and ($manifest.version -ne $version)) {
+        $generated = generate_user_manifest $app $bucket $version
+        if ($null -eq $generated) {
+            error 'Manifest cannot be generated with provided version'
+            continue
+        }
+        $manifest = parse_json($generated)
+    }
+
+    if(!$manifest) {
+        error "Couldn't find manifest for '$app'$(if($url) { " at the URL $url" })."
+        continue
+    }
+    $version = $manifest.version
+    if(!$version) { 
+        error "Manifest doesn't specify a version."
+        continue
+    }
+    if($version -match '[^\w\.\-\+_]') {
+        error "Manifest version has unsupported character '$($matches[0])'."
+        continue
+    }
+
+    $curr_check_hash = $check_hash
+    if ($version -eq 'nightly') {
+        $version = nightly_version $(get-date)
+        $curr_check_hash = $false
+    }
+
+    if(!(supports_architecture $manifest $architecture)) {
+        error "'$app' doesn't support $architecture architecture!"
+        continue
+    }
+
+    if(Test-Aria2Enabled) {
+        dl_with_cache_aria2 $app $version $manifest $architecture $cachedir $manifest.cookie $use_cache $curr_check_hash
+    } else {
+        foreach($url in script:url $manifest $architecture) {
+            try {
+                dl_with_cache $app $version $url $null $manifest.cookie $use_cache
+            } catch {
+                write-host -f darkred $_
+                error "URL $url is not valid"
+                continue
+            }
+
+            if($curr_check_hash) {
+                $manifest_hash = hash_for_url $manifest $url $architecture
+                $cached = cache_path $app $version $url
+                $ok, $err = check_hash $cached $manifest_hash (show_app $app $bucket)
+
+                if(!$ok) {
+                    error $err
+                    if(test-path $cached) {
+                        # rm cached file
+                        Remove-Item -force $cached
+                    }
+                    if ($url -like '*sourceforge.net*') {
+                        warn 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
+                    }
+                    error (new_issue_msg $app $bucket "hash check failed")
+                    continue
+                }
+            } else {
+                info "Skipping hash verification."
+            }
+        }
+    }
+
+    success "'$app' ($version) was downloaded successfully!"
+}
+
+exit 0

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -11,7 +11,8 @@
 #
 # Options:
 #   -f, --force               Force download (overwrite cache)
-#   -h, --no-hash-heck        Skip hash verification (use with caution!)
+#   -h, --no-hash-check       Skip hash verification (use with caution!)
+#   -u, --no-update-scoop     Don't update Scoop before downloading if it's outdated
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
 . "$psscriptroot\..\lib\manifest.ps1"
@@ -21,7 +22,7 @@
 
 reset_aliases
 
-$opt, $apps, $err = getopt $args 'fha:' 'force', 'no-hash-check', 'arch='
+$opt, $apps, $err = getopt $args 'fhua:' 'force', 'no-hash-check', 'no-update-scoop', 'arch='
 if ($err) { error "scoop download: $err"; exit 1 }
 
 $check_hash = !($opt.h -or $opt.'no-hash-check')
@@ -36,7 +37,11 @@ try {
 if (!$apps) { error '<app> missing'; my_usage; exit 1 }
 
 if (is_scoop_outdated) {
-    scoop update
+    if ($opt.u -or $opt.'no-update-scoop') {
+        warn "Scoop is out of date."
+    } else {
+        scoop update
+    }
 }
 
 # we only want to show this warning once


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
Useful for:
- **Users:** to pre-populate the cache:
  - in case they need to install something later (i.e. no internet scenario)
  - in case they want to inspect the installer/archive for an application (without installing)
- **Maintainers:** to manually verify:
  - hash check failures
  - 404 errors (e.g. with aria2, sourceforge etc.)


The second scenario is perhaps the most useful personally because many people open issues about download failures, but I don't really want to install the particular app. So I can just do `scoop download <app>` to rectify the issue.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #1804
<!-- or -->
Relates to #2293

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Simple test: 
![image](https://user-images.githubusercontent.com/46838874/148277430-2211580d-2983-4e53-96c5-ac9f4dabf095.png)

2. Above test with pre-filled cache: 
![image](https://user-images.githubusercontent.com/46838874/148277550-8cb1a31e-7051-4a7c-9947-18c8d06eab7e.png)

3. Test 1 with 32bit download: 
![image](https://user-images.githubusercontent.com/46838874/148277641-dc5501cb-f89e-402b-b768-eab2887cf15f.png)

4. Test 3 with skipping hash check: 
![image](https://user-images.githubusercontent.com/46838874/148277749-8f67bef4-dc3c-4da2-bfac-8029878bf11b.png)

5. Test 4 with force download (overwrite cache): 
![image](https://user-images.githubusercontent.com/46838874/148277834-f21e7b04-80b2-4320-ad7c-55d87690cf4f.png)

6. Test with one app with unsupported architecture: 
![image](https://user-images.githubusercontent.com/46838874/148277972-812e4c6b-8864-4f9e-b072-a4815b42a21f.png)

7. Test 6 with aria2: 
![image](https://user-images.githubusercontent.com/46838874/148278055-7020c0eb-86f4-4a37-9ab7-954dcd5fe25c.png)

8. Test with pre-cached install: 
![image](https://user-images.githubusercontent.com/46838874/148278274-c0616118-c30c-4b99-b4b8-f7e9597b287f.png)


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
