### PR TITLE
fix: replace `&>` to `2>&1`

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -624,7 +624,7 @@ if %errorlevel% equ 0 (
         warn_on_overwrite $shim $path
         "#!/bin/sh
 # $resolved_path
-if command -v pwsh.exe &> /dev/null; then
+if command -v pwsh.exe > /dev/null 2>&1; then
     pwsh.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"
 else
     powershell.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"


### PR DESCRIPTION
#### Description

`&>` is bash operator, not sh.
see: 
- https://unix.stackexchange.com/questions/641042/sh-shell-redirect-output-to-both-terminal-and-file-inside-script
- https://www.freebsd.org/cgi/man.cgi?sh

#### Motivation and Context

The script fails on wsl1 (Ubuntu20.04). 
