### PR TITLE
fix(shim): Fix `sh` shim error in WSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **depends:** Check if extractor is available ([#4042](https://github.com/ScoopInstaller/Scoop/issues/4042))
 - **decompress:** Fix nested Zstd archive extraction ([#4608](https://github.com/ScoopInstaller/Scoop/issues/4608))
 - **shim:** Fix PS1 shim error when in different drive in PS7 ([#4614](https://github.com/ScoopInstaller/Scoop/issues/4614))
+- **shim:** Fix shell shim error when in WSL1(Ubuntu 20.04) ([#4637](https://github.com/ScoopInstaller/Scoop/issues/4637))
 
 ### Builds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - **depends:** Check if extractor is available ([#4042](https://github.com/ScoopInstaller/Scoop/issues/4042))
 - **decompress:** Fix nested Zstd archive extraction ([#4608](https://github.com/ScoopInstaller/Scoop/issues/4608))
 - **shim:** Fix PS1 shim error when in different drive in PS7 ([#4614](https://github.com/ScoopInstaller/Scoop/issues/4614))
-- **shim:** Fix shell shim error when in WSL1(Ubuntu 20.04) ([#4637](https://github.com/ScoopInstaller/Scoop/issues/4637))
+- **shim:** Fix `sh` shim error in WSL ([#4637](https://github.com/ScoopInstaller/Scoop/issues/4637))
 
 ### Builds
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -652,7 +652,7 @@ function shim($path, $global, $name, $arg) {
         @(
             "#!/bin/sh",
             "# $resolved_path",
-            "java -jar `"$resolved_path`" $arg `"$@`""
+            "java.exe -jar `"$resolved_path`" $arg `"$@`""
         ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
     } elseif ($path -match '\.py$') {
         warn_on_overwrite "$shim.cmd" $path
@@ -665,7 +665,7 @@ function shim($path, $global, $name, $arg) {
         @(
             "#!/bin/sh",
             "# $resolved_path",
-            "python `"$resolved_path`" $arg `"$@`""
+            "python.exe `"$resolved_path`" $arg `"$@`""
         ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
     } else {
         warn_on_overwrite "$shim.cmd" $path

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -635,12 +635,12 @@ function shim($path, $global, $name, $arg) {
         @(
             "#!/bin/sh",
             "# $resolved_path",
-            "if command -v pwsh.exe &> /dev/null; then",
-            "    pwsh -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
+            "if command -v pwsh.exe > /dev/null 2>&1; then",
+            "    pwsh.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
             "else",
-            "    powershell -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
+            "    powershell.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
             "fi"
-        ) -join "`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
     } elseif ($path -match '\.jar$') {
         warn_on_overwrite "$shim.cmd" $path
         @(

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -587,7 +587,7 @@ function shim($path, $global, $name, $arg) {
             "#!/bin/sh",
             "# $resolved_path",
             "MSYS2_ARG_CONV_EXCL=/C cmd.exe /C `"$resolved_path`" $arg `"$@`""
-        ) -join "`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
     } elseif ($path -match '\.ps1$') {
         # if $path points to another drive resolve-path prepends .\ which could break shims
         warn_on_overwrite "$shim.ps1" $path
@@ -653,7 +653,7 @@ function shim($path, $global, $name, $arg) {
             "#!/bin/sh",
             "# $resolved_path",
             "java -jar `"$resolved_path`" $arg `"$@`""
-        ) -join "`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
     } elseif ($path -match '\.py$') {
         warn_on_overwrite "$shim.cmd" $path
         @(
@@ -666,7 +666,7 @@ function shim($path, $global, $name, $arg) {
             "#!/bin/sh",
             "# $resolved_path",
             "python `"$resolved_path`" $arg `"$@`""
-        ) -join "`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
     } else {
         warn_on_overwrite "$shim.cmd" $path
         # find path to Git's bash so that batch scripts can run bash scripts
@@ -684,7 +684,7 @@ function shim($path, $global, $name, $arg) {
             "#!/bin/sh",
             "# $resolved_path",
             "`"$resolved_path`" $arg `"$@`""
-        ) -join "`n" | Out-File $shim -Encoding ASCII
+        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
     }
 }
 


### PR DESCRIPTION
#### Description

`&>` is bash operator, not sh.
shell file must end with `\n`.

see: 
- https://unix.stackexchange.com/questions/641042/sh-shell-redirect-output-to-both-terminal-and-file-inside-script
- https://www.freebsd.org/cgi/man.cgi?sh

#### Motivation and Context

Before:
![image](https://user-images.githubusercontent.com/4396864/148682984-5769dfa5-455b-4152-8c52-50255718a4c8.png)

After:
![image](https://user-images.githubusercontent.com/4396864/148683023-02c529fe-073d-4122-9f28-eb221ce125e3.png)

