### PR TITLE
refactor(deps): Rewrite 'depends.ps1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - **decompress:** Fix nested Zstd archive extraction ([#4608](https://github.com/ScoopInstaller/Scoop/issues/4608))
 - **shim:** Fix PS1 shim error when in different drive in PS7 ([#4614](https://github.com/ScoopInstaller/Scoop/issues/4614))
 
+### Code Refactoring
+
+- **depends:** Rewrite 'depends.ps1' ([#4638](https://github.com/ScoopInstaller/Scoop/issues/4638))
+
 ### Builds
 
 - **checkver:** Fix output with '-Version' ([#3774](https://github.com/ScoopInstaller/Scoop/issues/3774))

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -314,7 +314,7 @@ function app_status($app, $global) {
     }
 
     $status.missing_deps = @()
-    $deps = @(runtime_deps $manifest) | Where-Object {
+    $deps = @($manifest.depends) | Where-Object {
         $app, $bucket, $null = parse_app $_
         return !(installed $app)
     }

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -1,41 +1,25 @@
 function Test-7zipRequirement {
-    [CmdletBinding(DefaultParameterSetName = 'URL')]
+    [CmdletBinding()]
     [OutputType([Boolean])]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'URL')]
+        [Parameter(Mandatory = $true)]
         [String[]]
-        $URL,
-        [Parameter(Mandatory = $true, ParameterSetName = 'File')]
-        [String]
-        $File
+        $Uri
     )
-    if ($URL) {
-        if ((get_config 7ZIPEXTRACT_USE_EXTERNAL)) {
-            return $false
-        } else {
-            return ($URL | Where-Object { Test-7zipRequirement -File $_ }).Count -gt 0
-        }
-    } else {
-        return $File -match '\.((gz)|(tar)|(t[abgpx]z2?)|(lzma)|(bz2?)|(7z)|(rar)|(iso)|(xz)|(lzh)|(nupkg))(\.[^.]+)?$'
-    }
+    return ($Uri | Where-Object {
+            $_ -match '\.((gz)|(tar)|(t[abgpx]z2?)|(lzma)|(bz2?)|(7z)|(rar)|(iso)|(xz)|(lzh)|(nupkg))(\.[^.]+)?$'
+        }).Count -gt 0
 }
 
 function Test-ZstdRequirement {
-    [CmdletBinding(DefaultParameterSetName = 'URL')]
+    [CmdletBinding()]
     [OutputType([Boolean])]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'URL')]
+        [Parameter(Mandatory = $true)]
         [String[]]
-        $URL,
-        [Parameter(Mandatory = $true, ParameterSetName = 'File')]
-        [String]
-        $File
+        $Uri
     )
-    if ($URL) {
-        return ($URL | Where-Object { Test-ZstdRequirement -File $_ }).Count -gt 0
-    } else {
-        return $File -match '\.zst$'
-    }
+    return ($Uri | Where-Object { $_ -match '\.zst$' }).Count -gt 0
 }
 
 function Test-LessmsiRequirement {
@@ -44,13 +28,9 @@ function Test-LessmsiRequirement {
     param (
         [Parameter(Mandatory = $true)]
         [String[]]
-        $URL
+        $Uri
     )
-    if ((get_config MSIEXTRACT_USE_LESSMSI)) {
-        return ($URL | Where-Object { $_ -match '\.msi$' }).Count -gt 0
-    } else {
-        return $false
-    }
+    return ($Uri | Where-Object { $_ -match '\.msi$' }).Count -gt 0
 }
 
 function Expand-7zipArchive {

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -1,38 +1,3 @@
-function Test-7zipRequirement {
-    [CmdletBinding()]
-    [OutputType([Boolean])]
-    param (
-        [Parameter(Mandatory = $true)]
-        [String[]]
-        $Uri
-    )
-    return ($Uri | Where-Object {
-            $_ -match '\.((gz)|(tar)|(t[abgpx]z2?)|(lzma)|(bz2?)|(7z)|(rar)|(iso)|(xz)|(lzh)|(nupkg))(\.[^.]+)?$'
-        }).Count -gt 0
-}
-
-function Test-ZstdRequirement {
-    [CmdletBinding()]
-    [OutputType([Boolean])]
-    param (
-        [Parameter(Mandatory = $true)]
-        [String[]]
-        $Uri
-    )
-    return ($Uri | Where-Object { $_ -match '\.zst$' }).Count -gt 0
-}
-
-function Test-LessmsiRequirement {
-    [CmdletBinding()]
-    [OutputType([Boolean])]
-    param (
-        [Parameter(Mandatory = $true)]
-        [String[]]
-        $Uri
-    )
-    return ($Uri | Where-Object { $_ -match '\.msi$' }).Count -gt 0
-}
-
 function Expand-7zipArchive {
     [CmdletBinding()]
     param (

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -1,11 +1,11 @@
 function Test-7zipRequirement {
-    [CmdletBinding(DefaultParameterSetName = "URL")]
+    [CmdletBinding(DefaultParameterSetName = 'URL')]
     [OutputType([Boolean])]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = "URL")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'URL')]
         [String[]]
         $URL,
-        [Parameter(Mandatory = $true, ParameterSetName = "File")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'File')]
         [String]
         $File
     )
@@ -21,13 +21,13 @@ function Test-7zipRequirement {
 }
 
 function Test-ZstdRequirement {
-    [CmdletBinding(DefaultParameterSetName = "URL")]
+    [CmdletBinding(DefaultParameterSetName = 'URL')]
     [OutputType([Boolean])]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = "URL")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'URL')]
         [String[]]
         $URL,
-        [Parameter(Mandatory = $true, ParameterSetName = "File")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'File')]
         [String]
         $File
     )
@@ -67,7 +67,7 @@ function Expand-7zipArchive {
         [Parameter(ValueFromRemainingArguments = $true)]
         [String]
         $Switches,
-        [ValidateSet("All", "Skip", "Rename")]
+        [ValidateSet('All', 'Skip', 'Rename')]
         [String]
         $Overwrite,
         [Switch]
@@ -92,9 +92,9 @@ function Expand-7zipArchive {
         $ArgList += (-split $Switches)
     }
     switch ($Overwrite) {
-        "All" { $ArgList += "-aoa" }
-        "Skip" { $ArgList += "-aos" }
-        "Rename" { $ArgList += "-aou" }
+        'All' { $ArgList += '-aoa' }
+        'Skip' { $ArgList += '-aos' }
+        'Rename' { $ArgList += '-aou' }
     }
     $Status = Invoke-ExternalCommand $7zPath $ArgList -LogPath $LogPath
     if (!$Status) {
@@ -187,7 +187,7 @@ function Expand-MsiArchive {
         [Switch]
         $Removal
     )
-    $DestinationPath = $DestinationPath.TrimEnd("\")
+    $DestinationPath = $DestinationPath.TrimEnd('\')
     if ($ExtractDir) {
         $OriDestinationPath = $DestinationPath
         $DestinationPath = "$DestinationPath\_tmp"
@@ -248,9 +248,9 @@ function Expand-InnoArchive {
     $LogPath = "$(Split-Path $Path)\innounp.log"
     $ArgList = @('-x', "-d`"$DestinationPath`"", "`"$Path`"", '-y')
     switch -Regex ($ExtractDir) {
-        "^[^{].*" { $ArgList += "-c{app}\$ExtractDir" }
-        "^{.*" { $ArgList += "-c$ExtractDir" }
-        Default { $ArgList += "-c{app}" }
+        '^[^{].*' { $ArgList += "-c{app}\$ExtractDir" }
+        '^{.*' { $ArgList += "-c$ExtractDir" }
+        Default { $ArgList += '-c{app}' }
     }
     if ($Switches) {
         $ArgList += (-split $Switches)

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -20,9 +20,9 @@ function Expand-7zipArchive {
     )
     if ((get_config 7ZIPEXTRACT_USE_EXTERNAL)) {
         try {
-            $7zPath = (Get-Command '7z' -CommandType Application | Select-Object -First 1).Source
+            $7zPath = (Get-Command '7z' -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
         } catch [System.Management.Automation.CommandNotFoundException] {
-            abort "Cannot find external 7-Zip (7z.exe) while '7ZIPEXTRACT_USE_EXTERNAL' is 'true'!`nRun 'scoop config 7ZIPEXTRACT_USE_EXTERNAL false' or install 7-Zip manually and try again."
+            abort "`nCannot find external 7-Zip (7z.exe) while '7ZIPEXTRACT_USE_EXTERNAL' is 'true'!`nRun 'scoop config 7ZIPEXTRACT_USE_EXTERNAL false' or install 7-Zip manually and try again."
         }
     } else {
         $7zPath = Get-HelperPath -Helper 7zip

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -286,34 +286,7 @@ function Expand-ZipArchive {
         $OriDestinationPath = $DestinationPath
         $DestinationPath = "$DestinationPath\_tmp"
     }
-    # All methods to unzip the file require .NET4.5+
-    if ($PSVersionTable.PSVersion.Major -lt 5) {
-        Add-Type -AssemblyName System.IO.Compression.FileSystem
-        try {
-            [System.IO.Compression.ZipFile]::ExtractToDirectory($Path, $DestinationPath)
-        } catch [System.IO.PathTooLongException] {
-            # try to fall back to 7zip if path is too long
-            if (Test-HelperInstalled -Helper 7zip) {
-                Expand-7zipArchive $Path $DestinationPath -Removal
-                return
-            } else {
-                abort "Unzip failed: Windows can't handle the long paths in this zip file.`nRun 'scoop install 7zip' and try again."
-            }
-        } catch [System.IO.IOException] {
-            if (Test-HelperInstalled -Helper 7zip) {
-                Expand-7zipArchive $Path $DestinationPath -Removal
-                return
-            } else {
-                abort "Unzip failed: Windows can't handle the file names in this zip file.`nRun 'scoop install 7zip' and try again."
-            }
-        } catch {
-            abort "Unzip failed: $_"
-        }
-    } else {
-        # Use Expand-Archive to unzip in PowerShell 5+
-        # Compatible with Pscx (https://github.com/Pscx/Pscx)
-        Microsoft.PowerShell.Archive\Expand-Archive -Path $Path -DestinationPath $DestinationPath -Force
-    }
+    Expand-Archive -Path $Path -DestinationPath $DestinationPath -Force
     if ($ExtractDir) {
         movedir "$DestinationPath\$ExtractDir" $OriDestinationPath | Out-Null
         Remove-Item $DestinationPath -Recurse -Force
@@ -355,24 +328,4 @@ function Expand-DarkArchive {
         # Remove original archive file
         Remove-Item $Path -Force
     }
-}
-
-function extract_7zip($path, $to, $removal) {
-    Show-DeprecatedWarning $MyInvocation 'Expand-7zipArchive'
-    Expand-7zipArchive -Path $path -DestinationPath $to -Removal:$removal @args
-}
-
-function extract_msi($path, $to, $removal) {
-    Show-DeprecatedWarning $MyInvocation 'Expand-MsiArchive'
-    Expand-MsiArchive -Path $path -DestinationPath $to -Removal:$removal
-}
-
-function unpack_inno($path, $to, $removal) {
-    Show-DeprecatedWarning $MyInvocation 'Expand-InnoArchive'
-    Expand-InnoArchive -Path $path -DestinationPath $to -Removal:$removal @args
-}
-
-function extract_zip($path, $to, $removal) {
-    Show-DeprecatedWarning $MyInvocation 'Expand-ZipArchive'
-    Expand-ZipArchive -Path $path -DestinationPath $to -Removal:$removal
 }

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -1,21 +1,3 @@
-# resolve dependencies for the supplied apps, and sort into the correct order
-function install_order($apps, $arch) {
-    $res = @()
-    foreach ($app in $apps) {
-        foreach ($dep in deps $app $arch) {
-            if ($res -notcontains $dep) { $res += $dep }
-        }
-        if ($res -notcontains $app) { $res += $app }
-    }
-    return $res
-}
-
-function deps($app, $arch) {
-    $resolved = Get-Dependency $app $arch
-    if ($resolved.Length -eq 1) { return @() } # no dependencies
-    return $resolved[0..($resolved.Length - 2)]
-}
-
 function Get-Dependency {
     <#
     .SYNOPSIS

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -83,16 +83,16 @@ function install_deps($manifest, $arch) {
     $test_url = script:url $manifest $arch
     if (-not $test_url) { $test_url = ' ' }
 
-    if (!(Test-HelperInstalled -Helper 7zip) -and (Test-7zipRequirement -URL $test_url)) {
+    if (!(Test-HelperInstalled -Helper 7zip) -and (Test-7zipRequirement -Uri $test_url)) {
         $deps += '7zip'
     }
-    if (!(Test-HelperInstalled -Helper Lessmsi) -and (Test-LessmsiRequirement -URL $test_url)) {
+    if (!(Test-HelperInstalled -Helper Lessmsi) -and (Test-LessmsiRequirement -Uri $test_url)) {
         $deps += 'lessmsi'
     }
     if (!(Test-HelperInstalled -Helper Innounp) -and $manifest.innosetup) {
         $deps += 'innounp'
     }
-    if (!(Test-HelperInstalled -Helper Zstd) -and (Test-ZstdRequirement -URL $test_url)) {
+    if (!(Test-HelperInstalled -Helper Zstd) -and (Test-ZstdRequirement -Uri $test_url)) {
         $deps += 'zstd'
     }
 

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -3,7 +3,7 @@ function install_order($apps, $arch) {
     $res = @()
     foreach ($app in $apps) {
         foreach ($dep in deps $app $arch) {
-            if ($res -notcontains $dep) { $res += $dep}
+            if ($res -notcontains $dep) { $res += $dep }
         }
         if ($res -notcontains $app) { $res += $app }
     }
@@ -12,7 +12,7 @@ function install_order($apps, $arch) {
 
 # http://www.electricmonk.nl/docs/dependency_resolving_algorithm/dependency_resolving_algorithm.html
 function deps($app, $arch) {
-    $resolved = new-object collections.arraylist
+    $resolved = New-Object collections.arraylist
     dep_resolve $app $arch $resolved @()
 
     if ($resolved.count -eq 1) { return @() } # no dependencies
@@ -24,8 +24,8 @@ function dep_resolve($app, $arch, $resolved, $unresolved) {
     $unresolved += $app
     $null, $manifest, $null, $null = Find-Manifest $app $bucket
 
-    if(!$manifest) {
-        if(((Get-LocalBucket) -notcontains $bucket) -and $bucket) {
+    if (!$manifest) {
+        if (((Get-LocalBucket) -notcontains $bucket) -and $bucket) {
             warn "Bucket '$bucket' not installed. Add it with 'scoop bucket add $bucket' or 'scoop bucket add $bucket <repo>'."
         }
         abort "Couldn't find manifest for '$app'$(if(!$bucket) { '.' } else { " from '$bucket' bucket." })"
@@ -51,10 +51,10 @@ function runtime_deps($manifest) {
 
 function script_deps($script) {
     $deps = @()
-    if($script -is [Array]) {
+    if ($script -is [Array]) {
         $script = $script -join "`n"
     }
-    if([String]::IsNullOrEmpty($script)) {
+    if ([String]::IsNullOrEmpty($script)) {
         return $deps
     }
 
@@ -81,7 +81,7 @@ function install_deps($manifest, $arch) {
     $deps = @()
 
     $test_url = script:url $manifest $arch
-    if (-not $test_url) { $test_url = " " }
+    if (-not $test_url) { $test_url = ' ' }
 
     if (!(Test-HelperInstalled -Helper 7zip) -and (Test-7zipRequirement -URL $test_url)) {
         $deps += '7zip'

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -31,7 +31,7 @@ function dep_resolve($app, $arch, $resolved, $unresolved) {
         abort "Couldn't find manifest for '$app'$(if(!$bucket) { '.' } else { " from '$bucket' bucket." })"
     }
 
-    $deps = @(Get-InstallationHelper $manifest $arch) + @(runtime_deps $manifest) | Select-Object -Unique
+    $deps = @(Get-InstallationHelper $manifest $arch) + @($manifest.depends) | Select-Object -Unique
 
     foreach ($dep in $deps) {
         if ($resolved -notcontains $dep) {
@@ -45,9 +45,6 @@ function dep_resolve($app, $arch, $resolved, $unresolved) {
     $unresolved = $unresolved -ne $app # remove from unresolved
 }
 
-function runtime_deps($manifest) {
-    if ($manifest.depends) { return $manifest.depends }
-}
 function Get-InstallationHelper {
     <#
     .SYNOPSIS

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -58,19 +58,19 @@ function script_deps($script) {
         return $deps
     }
 
-    if (!(Test-HelperInstalled -Helper 7zip) -and ($script -like '*Expand-7zipArchive *' -or $script -like '*extract_7zip *')) {
+    if (!(Test-HelperInstalled -Helper 7zip) -and ($script -like '*Expand-7zipArchive *')) {
         $deps += '7zip'
     }
-    if (!(Test-HelperInstalled -Helper Lessmsi) -and ($script -like '*Expand-MsiArchive *' -or $script -like '*extract_msi *')) {
+    if (!(Test-HelperInstalled -Helper Lessmsi) -and ($script -like '*Expand-MsiArchive *')) {
         $deps += 'lessmsi'
     }
-    if (!(Test-HelperInstalled -Helper Innounp) -and ($script -like '*Expand-InnoArchive *' -or $script -like '*unpack_inno *')) {
+    if (!(Test-HelperInstalled -Helper Innounp) -and ($script -like '*Expand-InnoArchive *')) {
         $deps += 'innounp'
     }
-    if (!(Test-HelperInstalled -Helper Dark) -and $script -like '*Expand-DarkArchive *') {
+    if (!(Test-HelperInstalled -Helper Dark) -and ($script -like '*Expand-DarkArchive *')) {
         $deps += 'dark'
     }
-    if (!(Test-HelperInstalled -Helper Zstd) -and $script -like '*Expand-ZstdArchive *') {
+    if (!(Test-HelperInstalled -Helper Zstd) -and ($script -like '*Expand-ZstdArchive *')) {
         $deps += 'zstd'
     }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -608,9 +608,9 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
             } else {
                 $extract_fn = 'Expand-MsiArchive'
             }
-        } elseif(Test-ZstdRequirement -File $fname) { # Zstd first
+        } elseif(Test-ZstdRequirement -Uri $fname) { # Zstd first
             $extract_fn = 'Expand-ZstdArchive'
-        } elseif(Test-7zipRequirement -File $fname) { # 7zip
+        } elseif(Test-7zipRequirement -Uri $fname) { # 7zip
             $extract_fn = 'Expand-7zipArchive'
         }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1088,8 +1088,9 @@ function failed($app, $global) {
 
 function ensure_none_failed($apps, $global) {
     foreach($app in $apps) {
-        if(failed $app $global) {
-            abort "'$app' install failed previously. Please uninstall it and try again."
+        if (failed $app $global) {
+            warn "Purging previous failed installation of $app."
+            & "$PSScriptRoot\..\libexec\scoop-uninstall.ps1" $app$(if ($global) { ' --global' })
         }
     }
 }

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -23,7 +23,7 @@ try {
     abort "ERROR: $_"
 }
 
-$deps = @(deps $app $architecture)
+$deps = @(Get-Dependency $app $architecture) -ne $app
 if($deps) {
     $deps[($deps.length - 1)..0]
 }

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -114,7 +114,7 @@ $apps = @(($specific_versions_paths + $difference) | Where-Object { $_ } | Sort-
 $explicit_apps = $apps
 
 if (!$independent) {
-    $apps = install_order $apps $architecture # adds dependencies
+    $apps = $apps | Get-Dependency -Architecture $architecture | Select-Object -Unique # adds dependencies
 }
 ensure_none_failed $apps $global
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -171,7 +171,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     if (!$independent) {
         # check dependencies
         $man = if ($url) { $url } else { $app }
-        $deps = @(deps $man $architecture) | Where-Object { !(installed $_) }
+        $deps = @(Get-Dependency $man $architecture) | Where-Object { !(installed $_) }
         $deps | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
     }
 

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -66,8 +66,8 @@ if($apps_param -eq '*') {
     $apps += installed_apps $true
 }
 
-if (!$opt.n -and !$opt."no-depends") {
-    $apps = install_order $apps $architecture
+if (!$opt.n -and !$opt.'no-depends') {
+    $apps = $apps | Get-Dependency -Architecture $architecture | Select-Object -Unique
 }
 
 $_ERR_UNSAFE = 2

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     BeforeAll {
         $working_dir = setup_working 'decompress'
 
-        It "Decompression test cases should exist" {
+        It 'Decompression test cases should exist' {
             $testcases = "$working_dir\TestCases.zip"
             $testcases | Should -Exist
             compute_hash $testcases 'sha256' | Should -Be '3a442e85b466833eeafbd08c57d8f51bf7ff041867ee0bdb7db1f12480b3624a'
@@ -26,7 +26,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
         }
     }
 
-    Context "7zip extraction" {
+    Context '7zip extraction' {
 
         BeforeAll {
             if ($env:CI) {
@@ -40,42 +40,42 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
             $test4 = "$working_dir\7ZipTest4.tar.gz"
         }
 
-        It "extract normal compressed file" -Skip:$isUnix {
-            $to = test_extract "Expand-7zipArchive" $test1
+        It 'extract normal compressed file' -Skip:$isUnix {
+            $to = test_extract 'Expand-7zipArchive' $test1
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
-        It "extract nested compressed file" -Skip:$isUnix {
+        It 'extract nested compressed file' -Skip:$isUnix {
             # file ext: tgz
-            $to = test_extract "Expand-7zipArchive" $test2
+            $to = test_extract 'Expand-7zipArchive' $test2
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
 
             # file ext: tar.bz2
-            $to = test_extract "Expand-7zipArchive" $test3
+            $to = test_extract 'Expand-7zipArchive' $test3
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
-        It "extract nested compressed file with different inner name" -Skip:$isUnix {
-            $to = test_extract "Expand-7zipArchive" $test4
+        It 'extract nested compressed file with different inner name' -Skip:$isUnix {
+            $to = test_extract 'Expand-7zipArchive' $test4
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
-        It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
+        It 'works with "-Removal" switch ($removal param)' -Skip:$isUnix {
             $test1 | Should -Exist
-            test_extract "Expand-7zipArchive" $test1 $true
+            test_extract 'Expand-7zipArchive' $test1 $true
             $test1 | Should -Not -Exist
         }
     }
 
-    Context "zstd extraction" {
+    Context 'zstd extraction' {
 
         BeforeAll {
             if ($env:CI) {
@@ -88,28 +88,28 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
             $test2 = "$working_dir\ZstdTest.tar.zst"
         }
 
-        It "extract normal compressed file" -Skip:$isUnix {
-            $to = test_extract "Expand-ZstdArchive" $test1
+        It 'extract normal compressed file' -Skip:$isUnix {
+            $to = test_extract 'Expand-ZstdArchive' $test1
             $to | Should -Exist
             "$to\ZstdTest" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
-        It "extract nested compressed file" -Skip:$isUnix {
-            $to = test_extract "Expand-ZstdArchive" $test2
+        It 'extract nested compressed file' -Skip:$isUnix {
+            $to = test_extract 'Expand-ZstdArchive' $test2
             $to | Should -Exist
             "$to\ZstdTest" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
-        It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
+        It 'works with "-Removal" switch ($removal param)' -Skip:$isUnix {
             $test1 | Should -Exist
-            test_extract "Expand-ZstdArchive" $test1 $true
+            test_extract 'Expand-ZstdArchive' $test1 $true
             $test1 | Should -Not -Exist
         }
     }
 
-    Context "msi extraction" {
+    Context 'msi extraction' {
 
         BeforeAll {
             if ($env:CI) {
@@ -121,29 +121,29 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
             $test2 = "$working_dir\MSITestNull.msi"
         }
 
-        It "extract normal MSI file" -Skip:$isUnix {
+        It 'extract normal MSI file' -Skip:$isUnix {
             Mock get_config { $false }
-            $to = test_extract "Expand-MsiArchive" $test1
+            $to = test_extract 'Expand-MsiArchive' $test1
             $to | Should -Exist
             "$to\MSITest\empty" | Should -Exist
             (Get-ChildItem "$to\MSITest").Count | Should -Be 1
         }
 
-        It "extract empty MSI file using lessmsi" -Skip:$isUnix {
+        It 'extract empty MSI file using lessmsi' -Skip:$isUnix {
             Mock get_config { $true }
-            $to = test_extract "Expand-MsiArchive" $test2
+            $to = test_extract 'Expand-MsiArchive' $test2
             $to | Should -Exist
         }
 
-        It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
+        It 'works with "-Removal" switch ($removal param)' -Skip:$isUnix {
             Mock get_config { $false }
             $test1 | Should -Exist
-            test_extract "Expand-MsiArchive" $test1 $true
+            test_extract 'Expand-MsiArchive' $test1 $true
             $test1 | Should -Not -Exist
         }
     }
 
-    Context "inno extraction" {
+    Context 'inno extraction' {
 
         BeforeAll {
             if ($env:CI) {
@@ -154,36 +154,36 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
             $test = "$working_dir\InnoTest.exe"
         }
 
-        It "extract Inno Setup file" -Skip:$isUnix {
-            $to = test_extract "Expand-InnoArchive" $test
+        It 'extract Inno Setup file' -Skip:$isUnix {
+            $to = test_extract 'Expand-InnoArchive' $test
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
-        It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
+        It 'works with "-Removal" switch ($removal param)' -Skip:$isUnix {
             $test | Should -Exist
-            test_extract "Expand-InnoArchive" $test $true
+            test_extract 'Expand-InnoArchive' $test $true
             $test | Should -Not -Exist
         }
     }
 
-    Context "zip extraction" {
+    Context 'zip extraction' {
 
         BeforeAll {
             $test = "$working_dir\ZipTest.zip"
         }
 
-        It "extract compressed file" -Skip:$isUnix {
-            $to = test_extract "Expand-ZipArchive" $test
+        It 'extract compressed file' -Skip:$isUnix {
+            $to = test_extract 'Expand-ZipArchive' $test
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
-        It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
+        It 'works with "-Removal" switch ($removal param)' -Skip:$isUnix {
             $test | Should -Exist
-            test_extract "Expand-ZipArchive" $test $true
+            test_extract 'Expand-ZipArchive' $test $true
             $test | Should -Not -Exist
         }
     }

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -6,25 +6,6 @@
 
 $isUnix = is_unix
 
-Describe 'Requirement function' -Tag 'Scoop' {
-    It 'Test 7zip requirement' {
-        Test-7zipRequirement -Uri 'test.xz' | Should -BeTrue
-        Test-7zipRequirement -Uri 'test.bin' | Should -BeFalse
-        Test-7zipRequirement -Uri @('test.xz', 'test.bin') | Should -BeTrue
-    }
-    It 'Test Zstd requirement' {
-        Test-ZstdRequirement -Uri 'test.zst' | Should -BeTrue
-        Test-ZstdRequirement -Uri 'test.bin' | Should -BeFalse
-        Test-ZstdRequirement -Uri @('test.zst', 'test.bin') | Should -BeTrue
-    }
-    It 'Test lessmsi requirement' {
-        Mock get_config { $true }
-        Test-LessmsiRequirement -Uri 'test.msi' | Should -BeTrue
-        Test-LessmsiRequirement -Uri 'test.bin' | Should -BeFalse
-        Test-LessmsiRequirement -Uri @('test.msi', 'test.bin') | Should -BeTrue
-    }
-}
-
 Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
     BeforeAll {

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -6,15 +6,35 @@
 
 $isUnix = is_unix
 
-function test_extract($extract_fn, $from, $removal) {
-    $to = (strip_ext $from) -replace '\.tar$', ''
-    & $extract_fn ($from -replace '/', '\') ($to -replace '/', '\') -Removal:$removal
-    return $to
+Describe 'Requirement function' -Tag 'Scoop' {
+    It 'Test 7zip requirement' {
+        Test-7zipRequirement -Uri 'test.xz' | Should -BeTrue
+        Test-7zipRequirement -Uri 'test.bin' | Should -BeFalse
+        Test-7zipRequirement -Uri @('test.xz', 'test.bin') | Should -BeTrue
+    }
+    It 'Test Zstd requirement' {
+        Test-ZstdRequirement -Uri 'test.zst' | Should -BeTrue
+        Test-ZstdRequirement -Uri 'test.bin' | Should -BeFalse
+        Test-ZstdRequirement -Uri @('test.zst', 'test.bin') | Should -BeTrue
+    }
+    It 'Test lessmsi requirement' {
+        Mock get_config { $true }
+        Test-LessmsiRequirement -Uri 'test.msi' | Should -BeTrue
+        Test-LessmsiRequirement -Uri 'test.bin' | Should -BeFalse
+        Test-LessmsiRequirement -Uri @('test.msi', 'test.bin') | Should -BeTrue
+    }
 }
 
 Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
+
     BeforeAll {
         $working_dir = setup_working 'decompress'
+
+        function test_extract($extract_fn, $from, $removal) {
+            $to = (strip_ext $from) -replace '\.tar$', ''
+            & $extract_fn ($from -replace '/', '\') ($to -replace '/', '\') -Removal:$removal
+            return $to
+        }
 
         It 'Decompression test cases should exist' {
             $testcases = "$working_dir\TestCases.zip"

--- a/test/Scoop-Depends.Tests.ps1
+++ b/test/Scoop-Depends.Tests.ps1
@@ -1,0 +1,58 @@
+. "$psscriptroot\Scoop-TestLib.ps1"
+. "$psscriptroot\..\lib\depends.ps1"
+. "$psscriptroot\..\lib\install.ps1"
+. "$psscriptroot\..\lib\manifest.ps1"
+
+Describe 'Requirement function' -Tag 'Scoop' {
+    It 'Test 7zip requirement' {
+        Test-7zipRequirement -Uri 'test.xz' | Should -BeTrue
+        Test-7zipRequirement -Uri 'test.bin' | Should -BeFalse
+        Test-7zipRequirement -Uri @('test.xz', 'test.bin') | Should -BeTrue
+    }
+    It 'Test Zstd requirement' {
+        Test-ZstdRequirement -Uri 'test.zst' | Should -BeTrue
+        Test-ZstdRequirement -Uri 'test.bin' | Should -BeFalse
+        Test-ZstdRequirement -Uri @('test.zst', 'test.bin') | Should -BeTrue
+    }
+    It 'Test lessmsi requirement' {
+        Mock get_config { $true }
+        Test-LessmsiRequirement -Uri 'test.msi' | Should -BeTrue
+        Test-LessmsiRequirement -Uri 'test.bin' | Should -BeFalse
+        Test-LessmsiRequirement -Uri @('test.msi', 'test.bin') | Should -BeTrue
+    }
+}
+
+Describe 'InstallationHelper function' -Tag 'Scoop' {
+    BeforeAll {
+        $working_dir = setup_working 'format/formated'
+        $manifest1 = parse_json (Join-Path $working_dir '3-array-with-single-and-multi.json')
+        $manifest2 = parse_json (Join-Path $working_dir '4-script-block.json')
+        Mock Test-HelperInstalled { $false }
+    }
+    It 'Get helpers from URL' {
+        Mock get_config { $true }
+        Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -Be @('lessmsi')
+    }
+    It 'Get helpers from script' {
+        Mock get_config { $false }
+        Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -Be @('7zip')
+    }
+    It 'Helpers reflect config changes' {
+        Mock get_config { $false } -ParameterFilter { $name -eq 'MSIEXTRACT_USE_LESSMSI' }
+        Mock get_config { $true } -ParameterFilter { $name -eq '7ZIPEXTRACT_USE_EXTERNAL' }
+        Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -BeNullOrEmpty
+        Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -BeNullOrEmpty
+    }
+    It 'Not return installed helpers' {
+        Mock get_config { $true } -ParameterFilter { $name -eq 'MSIEXTRACT_USE_LESSMSI' }
+        Mock get_config { $false } -ParameterFilter { $name -eq '7ZIPEXTRACT_USE_EXTERNAL' }
+        Mock Test-HelperInstalled { $true }-ParameterFilter { $Helper -eq '7zip' }
+        Mock Test-HelperInstalled { $false }-ParameterFilter { $Helper -eq 'Lessmsi' }
+        Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -Be @('lessmsi')
+        Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -BeNullOrEmpty
+        Mock Test-HelperInstalled { $false }-ParameterFilter { $Helper -eq '7zip' }
+        Mock Test-HelperInstalled { $true }-ParameterFilter { $Helper -eq 'Lessmsi' }
+        Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -BeNullOrEmpty
+        Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -Be @('7zip')
+    }
+}

--- a/test/fixtures/format/formated/4-script-block.json
+++ b/test/fixtures/format/formated/4-script-block.json
@@ -9,12 +9,12 @@
     "architecture": {
         "64bit": {
             "installer": {
-                "script": "extract_7zip \"$dir\\app-64.7z\" \"$dir\""
+                "script": "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\""
             }
         },
         "32bit": {
             "installer": {
-                "script": "extract_7zip \"$dir\\app-32.7z\" \"$dir\""
+                "script": "Expand-7zipArchive \"$dir\\app-32.7z\" \"$dir\""
             }
         }
     },

--- a/test/fixtures/format/unformated/4-script-block.json
+++ b/test/fixtures/format/unformated/4-script-block.json
@@ -10,14 +10,14 @@
         "64bit": {
             "installer": {
                 "script": [
-                    "extract_7zip \"$dir\\app-64.7z\" \"$dir\""
+                    "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\""
                 ]
             }
         },
         "32bit": {
             "installer": {
                 "script": [
-                    "extract_7zip \"$dir\\app-32.7z\" \"$dir\""
+                    "Expand-7zipArchive \"$dir\\app-32.7z\" \"$dir\""
                 ]
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Refactor Scoop's dependencies resolving functions, and fix some dependencies error

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Closes #3700
<!-- or -->
- Relates to #3502

Commits are organized as following:

- Remove unused code, i.e., `extract_7zip()`, `extract_msi()`, `extract_zip()`, `unpack_inno()` and zip extraction code that before PowerShell 5
- Simplify `Test-xxxRequirement()` that only one type of param is allowed and add tests
- Refactor `script_deps()` and `install_deps()` to `Get-InstallationHelper()` and add tests (fix #3700 in this step)
- Remove naïve function `runtime_deps()` (wrapper of `$manifest.depends`)
- Refactor `dep_resolve()` to `Get-Dependency()`
- Remove `install_order()` and `deps()` with direct call of `Get-Dependency()`
- Refactor code that introduced in #3685 (move some lines of code to make them more readable)
- Fix a small bug related to #3281

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

```powershell
# Use LessMSI
scoop config MSIEXTRACT_USE_LESSMSI true
# Uninstall some apps
scoop uninstall 7zip 7zip-zstd lessmsi dark powertoys yori
# Install 7zip-zstd, this will install lessmsi, 7zip and 7zip-zstd
scoop install 7zip-zstd
# Uninstall
scoop uninstall 7zip lessmsi 7zip-zstd
# Use external 7zip
scoop config 7ZIPEXTRACT_USE_EXTERNAL true
# Install yori and this will give error that no 7z.exe while 7ZIPEXTRACT_USE_EXTERNAL is true
scoop install yori
# Change back
scoop config rm 7ZIPEXTRACT_USE_EXTERNAL
# Install multiple apps and it's okay
scoop install yori powertoys 7zip-zstd
```

#### Remarks

If something (i.e., some config option switch) is missing, please let me know.

Maybe `aria2`'s dependence should be added here too? (By config `aria2-enabled`)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
