### PR TITLE
fix(core): Ensure manipulating config with UTF8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - **autoupdate:** Allow checksum file that contains whitespaces ([#4619](https://github.com/ScoopInstaller/Scoop/issues/4619))
 - **autoupdate:** Rename $response to $res ([#4706](https://github.com/ScoopInstaller/Scoop/issues/4706))
+- **config:** Ensure manipulating config with UTF8 encoding ([#4644](https://github.com/ScoopInstaller/Scoop/issues/4644))
 - **config:** Allow scoop config use Unicode characters ([#4631](https://github.com/ScoopInstaller/Scoop/issues/4631))
 - **config:** Fix `set_config` bugs ([#3681](https://github.com/ScoopInstaller/Scoop/issues/3681))
 - **current:** Remove 'current' while it's not a junction ([#4687](https://github.com/ScoopInstaller/Scoop/issues/4687))

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -41,9 +41,9 @@ function load_cfg($file) {
     }
 
     try {
-        # ReadAllText will detect the encoding of the file automatically
-        # Ref: https://docs.microsoft.com/en-us/dotnet/api/system.io.file.readalltext
-        $content = [System.IO.File]::ReadAllText($file)
+        # ReadAllLines will detect the encoding of the file automatically
+        # Ref: https://docs.microsoft.com/en-us/dotnet/api/system.io.file.readalllines?view=netframework-4.5
+        $content = [System.IO.File]::ReadAllLines($file)
         return ($content | ConvertFrom-Json -ErrorAction Stop)
     } catch {
         Write-Host "ERROR loading $file`: $($_.exception.message)"

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -301,7 +301,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         Write-Host 'Starting download with aria2 ...'
 
         # Set console output encoding to UTF8 for non-ASCII characters printing
-        $ConsoleEncodingBackup = [Console]::OutputEncoding
+        $oriConsoleEncoding = [Console]::OutputEncoding
         [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
         Invoke-Expression $aria2 | ForEach-Object {
@@ -341,7 +341,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         }
 
         # Revert console encoding
-        [Console]::OutputEncoding = $ConsoleEncodingBackup
+        [Console]::OutputEncoding = $oriConsoleEncoding
     }
 
     foreach ($url in $urls) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -289,7 +289,9 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
     if (-not($download_finished)) {
         # write aria2 input file
         if ($urlstxt_content -ne '') {
-            Set-Content -Path $urlstxt $urlstxt_content
+            ensure $cachedir | Out-Null
+            # Write aria2 input-file with UTF8NoBOM encoding
+            $urlstxt_content | Out-UTF8File -FilePath $urlstxt
         }
 
         # build aria2 command
@@ -297,6 +299,10 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
 
         # handle aria2 console output
         Write-Host 'Starting download with aria2 ...'
+
+        # Set console output encoding to UTF8 for non-ASCII characters printing
+        $ConsoleEncodingBackup = [Console]::OutputEncoding
+        [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 
         Invoke-Expression $aria2 | ForEach-Object {
             # Skip blank lines
@@ -333,6 +339,9 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
             Remove-Item $urlstxt -Force -ErrorAction SilentlyContinue
             Remove-Item "$($data.$url.source).aria2*" -Force -ErrorAction SilentlyContinue
         }
+
+        # Revert console encoding
+        [Console]::OutputEncoding = $ConsoleEncodingBackup
     }
 
     foreach ($url in $urls) {

--- a/test/Scoop-Config.Tests.ps1
+++ b/test/Scoop-Config.Tests.ps1
@@ -2,11 +2,15 @@
 
 Describe 'config' -Tag 'Scoop' {
     BeforeAll {
-        $scoopConfig = $null
-        $configFile = "$PSScriptRoot\tmp\config.json"
+        $configFile = "$env:TEMP\ScoopTestFixtures\config.json"
         if (Test-Path $configFile) {
             Remove-Item -Path $configFile -Force
         }
+        $unicode = [Regex]::Unescape('\u4f60\u597d\u3053\u3093\u306b\u3061\u306f') # 你好こんにちは
+    }
+
+    BeforeEach {
+        $scoopConfig = $null
     }
 
     It 'load_cfg should return null if config file does not exist' {
@@ -32,12 +36,12 @@ Describe 'config' -Tag 'Scoop' {
         $scoopConfig = set_config 'five' 'not null'
 
         # datetime
-        $scoopConfig = set_config 'time' ([System.DateTime]::Parse("2019-03-18T15:22:09.3930000+00:00"))
+        $scoopConfig = set_config 'time' ([System.DateTime]::Parse('2019-03-18T15:22:09.3930000+00:00', $null, [System.Globalization.DateTimeStyles]::AdjustToUniversal))
         $scoopConfig.time | Should -BeOfType [System.DateTime]
 
         # non-ASCII
-        $scoopConfig = set_config 'unicode' '你好こんにちは'
-        $scoopConfig.unicode | Should -Be '你好こんにちは'
+        $scoopConfig = set_config 'unicode' $unicode
+        $scoopConfig.unicode | Should -Be $unicode
     }
 
     It 'load_cfg should return PSObject if config file exist' {
@@ -50,8 +54,8 @@ Describe 'config' -Tag 'Scoop' {
         $scoopConfig.under_line | Should -BeExactly 'four'
         $scoopConfig.five | Should -Be 'not null'
         $scoopConfig.time | Should -BeOfType [System.DateTime]
-        $scoopConfig.time | Should -Be ([System.DateTime]::Parse("2019-03-18T15:22:09.3930000+00:00"))
-        $scoopConfig.unicode | Should -Be '你好こんにちは'
+        $scoopConfig.time | Should -Be ([System.DateTime]::Parse('2019-03-18T15:22:09.3930000+00:00', $null, [System.Globalization.DateTimeStyles]::AdjustToUniversal))
+        $scoopConfig.unicode | Should -Be $unicode
     }
 
     It 'get_config should return exactly the same values' {
@@ -62,11 +66,11 @@ Describe 'config' -Tag 'Scoop' {
         (get_config 'under_line') | Should -BeExactly 'four'
         (get_config 'five') | Should -Be 'not null'
         (get_config 'time') | Should -BeOfType [System.DateTime]
-        (get_config 'time') | Should -Be ([System.DateTime]::Parse("2019-03-18T15:22:09.3930000+00:00"))
-        (get_config 'unicode') | Should -Be '你好こんにちは'
+        (get_config 'time') | Should -Be ([System.DateTime]::Parse('2019-03-18T15:22:09.3930000+00:00', $null, [System.Globalization.DateTimeStyles]::AdjustToUniversal))
+        (get_config 'unicode') | Should -Be $unicode
     }
 
-    It "set_config should remove a value if being set to `$null" {
+    It 'set_config should remove a value if being set to $null' {
         $scoopConfig = load_cfg $configFile
         $scoopConfig = set_config 'five' $null
         $scoopConfig.five | Should -BeNullOrEmpty

--- a/test/Scoop-Config.Tests.ps1
+++ b/test/Scoop-Config.Tests.ps1
@@ -33,11 +33,7 @@ Describe 'config' -Tag 'Scoop' {
 
         # datetime
         $scoopConfig = set_config 'time' ([System.DateTime]::Parse("2019-03-18T15:22:09.3930000+00:00"))
-        if ($PSVersionTable.PSVersion.Major -lt 6) {
-            $scoopConfig.time | Should -BeOfType [System.String]
-        } else {
-            $scoopConfig.time | Should -BeOfType [System.DateTime]
-        }
+        $scoopConfig.time | Should -BeOfType [System.DateTime]
 
         # non-ASCII
         $scoopConfig = set_config 'unicode' '你好こんにちは'
@@ -53,11 +49,8 @@ Describe 'config' -Tag 'Scoop' {
         $scoopConfig.three | Should -BeFalse
         $scoopConfig.under_line | Should -BeExactly 'four'
         $scoopConfig.five | Should -Be 'not null'
-        if ($PSVersionTable.PSVersion.Major -lt 6) {
-            $scoopConfig.time | Should -BeOfType [System.String]
-        } else {
-            $scoopConfig.time | Should -BeOfType [System.DateTime]
-        }
+        $scoopConfig.time | Should -BeOfType [System.DateTime]
+        $scoopConfig.time | Should -Be ([System.DateTime]::Parse("2019-03-18T15:22:09.3930000+00:00"))
         $scoopConfig.unicode | Should -Be '你好こんにちは'
     }
 
@@ -68,11 +61,8 @@ Describe 'config' -Tag 'Scoop' {
         (get_config 'three') | Should -BeFalse
         (get_config 'under_line') | Should -BeExactly 'four'
         (get_config 'five') | Should -Be 'not null'
-        if ($PSVersionTable.PSVersion.Major -lt 6) {
-            (get_config 'time') | Should -BeOfType [System.String]
-        } else {
-            (get_config 'time') | Should -BeOfType [System.DateTime]
-        }
+        (get_config 'time') | Should -BeOfType [System.DateTime]
+        (get_config 'time') | Should -Be ([System.DateTime]::Parse("2019-03-18T15:22:09.3930000+00:00"))
         (get_config 'unicode') | Should -Be '你好こんにちは'
     }
 

--- a/test/Scoop-Config.Tests.ps1
+++ b/test/Scoop-Config.Tests.ps1
@@ -2,80 +2,83 @@
 
 Describe 'config' -Tag 'Scoop' {
     BeforeAll {
-        $json = '{ "one": 1, "two": [ { "a": "a" }, "b", 2 ], "three": { "four": 4 }, "five": true, "six": false, "seven": "\/Date(1529917395805)\/", "eight": "2019-03-18T15:22:09.3930000+00:00" }'
-    }
-
-    It 'converts JSON to PSObject' {
-        $obj = ConvertFrom-Json $json
-
-        $obj.one | Should -BeExactly 1
-        $obj.two[0].a | Should -Be 'a'
-        $obj.two[1] | Should -Be 'b'
-        $obj.two[2] | Should -BeExactly 2
-        $obj.three.four | Should -BeExactly 4
-        $obj.five | Should -BeTrue
-        $obj.six | Should -BeFalse
-        $obj.seven | Should -BeOfType [System.DateTime]
-        if ($PSVersionTable.PSVersion.Major -lt 6) {
-            $obj.eight | Should -BeOfType [System.String]
-        } else {
-            $obj.eight | Should -BeOfType [System.DateTime]
+        $scoopConfig = $null
+        $configFile = "$PSScriptRoot\tmp\config.json"
+        if (Test-Path $configFile) {
+            Remove-Item -Path $configFile -Force
         }
     }
 
-    It 'load_config should return PSObject' {
-        Mock Get-Content { $json }
-        Mock Test-Path { $true }
-        (load_cfg 'file') | Should -Not -BeNullOrEmpty
-        (load_cfg 'file') | Should -BeOfType [System.Management.Automation.PSObject]
-        (load_cfg 'file').one | Should -BeExactly 1
+    It 'load_cfg should return null if config file does not exist' {
+        load_cfg $configFile | Should -Be $null
+    }
+
+    It 'set_config should be able to save typed values correctly' {
+        # number
+        $scoopConfig = set_config 'one' 1
+        $scoopConfig.one | Should -BeExactly 1
+
+        # boolean
+        $scoopConfig = set_config 'two' $true
+        $scoopConfig.two | Should -BeTrue
+        $scoopConfig = set_config 'three' $false
+        $scoopConfig.three | Should -BeFalse
+
+        # underline key
+        $scoopConfig = set_config 'under_line' 'four'
+        $scoopConfig.under_line | Should -BeExactly 'four'
+
+        # string
+        $scoopConfig = set_config 'five' 'not null'
+
+        # datetime
+        $scoopConfig = set_config 'time' ([System.DateTime]::Parse("2019-03-18T15:22:09.3930000+00:00"))
+        if ($PSVersionTable.PSVersion.Major -lt 6) {
+            $scoopConfig.time | Should -BeOfType [System.String]
+        } else {
+            $scoopConfig.time | Should -BeOfType [System.DateTime]
+        }
+
+        # non-ASCII
+        $scoopConfig = set_config 'unicode' '你好こんにちは'
+        $scoopConfig.unicode | Should -Be '你好こんにちは'
+    }
+
+    It 'load_cfg should return PSObject if config file exist' {
+        $scoopConfig = load_cfg $configFile
+        $scoopConfig | Should -Not -BeNullOrEmpty
+        $scoopConfig | Should -BeOfType [System.Management.Automation.PSObject]
+        $scoopConfig.one | Should -BeExactly 1
+        $scoopConfig.two | Should -BeTrue
+        $scoopConfig.three | Should -BeFalse
+        $scoopConfig.under_line | Should -BeExactly 'four'
+        $scoopConfig.five | Should -Be 'not null'
+        if ($PSVersionTable.PSVersion.Major -lt 6) {
+            $scoopConfig.time | Should -BeOfType [System.String]
+        } else {
+            $scoopConfig.time | Should -BeOfType [System.DateTime]
+        }
+        $scoopConfig.unicode | Should -Be '你好こんにちは'
     }
 
     It 'get_config should return exactly the same values' {
-        $scoopConfig = ConvertFrom-Json $json
-        get_config 'does_not_exist' 'default' | Should -Be 'default'
-
-        get_config 'one' | Should -BeExactly 1
-        (get_config 'two')[0].a | Should -Be 'a'
-        (get_config 'two')[1] | Should -Be 'b'
-        (get_config 'two')[2] | Should -BeExactly 2
-        (get_config 'three').four | Should -BeExactly 4
-        get_config 'five' | Should -BeTrue
-        get_config 'six' | Should -BeFalse
-        get_config 'seven' | Should -BeOfType [System.DateTime]
+        $scoopConfig = load_cfg $configFile
+        (get_config 'one') | Should -BeExactly 1
+        (get_config 'two') | Should -BeTrue
+        (get_config 'three') | Should -BeFalse
+        (get_config 'under_line') | Should -BeExactly 'four'
+        (get_config 'five') | Should -Be 'not null'
         if ($PSVersionTable.PSVersion.Major -lt 6) {
-            get_config 'eight' | Should -BeOfType [System.String]
+            (get_config 'time') | Should -BeOfType [System.String]
         } else {
-            get_config 'eight' | Should -BeOfType [System.DateTime]
+            (get_config 'time') | Should -BeOfType [System.DateTime]
         }
+        (get_config 'unicode') | Should -Be '你好こんにちは'
     }
 
-    It 'set_config should create a new PSObject and ensure existing directory' {
-        $scoopConfig = $null
-        $configFile = "$PSScriptRoot\.scoop"
-
-        Mock ensure { $PSScriptRoot } -Verifiable -ParameterFilter { $dir -eq (Split-Path -Path $configFile) }
-        Mock Set-Content {} -Verifiable -ParameterFilter { $Path -eq $configFile }
-        Mock ConvertTo-Json { '' } -Verifiable -ParameterFilter { $InputObject -is [System.Management.Automation.PSObject] }
-
-        set_config 'does_not_exist' 'default'
-
-        Assert-VerifiableMock
-    }
-
-    It "set_config should remove a value if set to `$null" {
-        $scoopConfig = New-Object PSObject
-        $scoopConfig | Add-Member -MemberType NoteProperty -Name 'should_be_removed' -Value 'a_value'
-        $scoopConfig | Add-Member -MemberType NoteProperty -Name 'should_stay' -Value 'another_value'
-        $configFile = "$PSScriptRoot\.scoop"
-
-        Mock Set-Content {} -Verifiable -ParameterFilter { $Path -eq $configFile }
-        Mock ConvertTo-Json { '' } -Verifiable -ParameterFilter { $InputObject -is [System.Management.Automation.PSObject] }
-
-        $scoopConfig = set_config 'should_be_removed' $null
-        $scoopConfig.should_be_removed | Should -BeNullOrEmpty
-        $scoopConfig.should_stay | Should -Be 'another_value'
-
-        Assert-VerifiableMock
+    It "set_config should remove a value if being set to `$null" {
+        $scoopConfig = load_cfg $configFile
+        $scoopConfig = set_config 'five' $null
+        $scoopConfig.five | Should -BeNullOrEmpty
     }
 }


### PR DESCRIPTION
#### Description
Use utf8 encoding in scoop's and aria2's config

#### Motivation and Context

<!-- removed
This patch forces Scoop's config.json and aria2's input-file
are saved and used with the UTF8 encoding to support non-ASCII
characters like CJK. A previous patch #4631 was applied to fix
the encoding of Scoop's config file. But it does not work well,
it replaced the 'ASCII' encoding of function `Set-Content` with
the 'Default' encoding. This does not work in PowerShell 5 since
the default encoding under PowerShell 5 [1] corresponds to the
system's active code page (usually ANSI).

This patch introduces a `Set-ContentUTF8NoBOM` function. It's a
wrapper of the `Out-File` function using the 'UTF8NoBOM' encoding
and .NET's `WriteAllText` function which saves file in a BOMless
UTF8 encoding [2]. When Scoop is executed under PowerShell 6+, the
native PowerShell `Out-File` function will be used, otherwise the
.NET's one will be used.

Also with this patch, now aria2 reads the correct `cachedir` from
Scoop's config file, and consumes the input-file which is also utf8
encoded. By changing console's encoding to utf8 temporarily, aria2's
output can display correctly even it contains non-ASCII. -->

Fixes #4629

[1]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-content?view=powershell-5.1
[2]: https://docs.microsoft.com/en-us/dotnet/api/system.io.file.writealltext

#### How Has This Been Tested?
New unit tests introduced.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
