### PR TITLE
fix(installed): Fix 'core/installed' that mark failed app as 'installed'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **depends:** Check if extractor is available ([#4042](https://github.com/ScoopInstaller/Scoop/issues/4042))
 - **decompress:** Fix nested Zstd archive extraction ([#4608](https://github.com/ScoopInstaller/Scoop/issues/4608))
   - **decompress:** Fix `Split-Path -LeafBase` in PS5 ([#4639](https://github.com/ScoopInstaller/Scoop/issues/4639))
+- **installed:** Fix 'core/installed' that mark failed app as 'installed' ([#4650](https://github.com/ScoopInstaller/Scoop/issues/4650))
 - **shim:** Fix PS1 shim error when in different drive in PS7 ([#4614](https://github.com/ScoopInstaller/Scoop/issues/4614))
 - **shim:** Fix `sh` shim error in WSL ([#4637](https://github.com/ScoopInstaller/Scoop/issues/4637))
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -185,13 +185,17 @@ function cache_path($app, $version, $url) { "$cachedir\$app#$version#$($url -rep
 
 # apps
 function sanitary_path($path) { return [regex]::replace($path, "[/\\?:*<>|]", "") }
-function installed($app, $global=$null) {
-    if($null -eq $global) { return (installed $app $true) -or (installed $app $false) }
+function installed($app, $global) {
     # Dependencies of the format "bucket/dependency" install in a directory of form
     # "dependency". So we need to extract the bucket from the name and only give the app
     # name to is_directory
-    $app = $app.split("/")[-1]
-    return is_directory (appdir $app $global)
+    $app = ($app -split '/|\\')[-1]
+    if (get_config NO_JUNCTIONS) {
+        $installedVersion = Select-CurrentVersion -AppName $app -Global:$global
+    } else {
+        $installedVersion = 'current'
+    }
+    return Join-Path (versiondir $app $installedVersion $global) 'install.json' | Test-Path
 }
 function installed_apps($global) {
     $dir = appsdir $global


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

- Check if `NO_JUNCTIONS` is set
  - set: use current version
  - unset: use `current`
- Check if there is `install.json` file in versioned directory

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #4648

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Before:

![image](https://user-images.githubusercontent.com/5832170/149077377-1307011f-6947-4b32-a915-e8e091618a86.png)

After:

![image](https://user-images.githubusercontent.com/5832170/149093208-4e42bbda-02b9-400f-9ccc-3cb4cdce3d47.png)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
~- [ ] I have updated the tests accordingly.~
