### PR TITLE
test(zstd): Fix 'zstd' extraction error in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 - **test-bin:** Only write output file in CI and fix trailing whitespaces ([#4613](https://github.com/ScoopInstaller/Scoop/issues/4613))
 - **manifest:** Fix manifests validation ([#4620](https://github.com/ScoopInstaller/Scoop/issues/4620))
+- **zstd:** Fix 'zstd' extraction error in test ([#4651](https://github.com/ScoopInstaller/Scoop/issues/4651))
 
 ### Documentation
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,17 +2,13 @@ version: "{build}-{branch}"
 branches:
   except:
     - gh-pages
-build: off
-deploy: off
+build: false
+deploy: false
 clone_depth: 49
 image: Visual Studio 2019
 environment:
   scoop: C:\projects\scoop
   scoop_home: C:\projects\scoop
-  scoop_helpers: C:\projects\helpers
-  lessmsi: '%scoop_helpers%\lessmsi\lessmsi.exe'
-  innounp: '%scoop_helpers%\innounp\innounp.exe'
-  zstd: '%scoop_helpers%\zstd\zstd.exe'
   matrix:
     - PowerShell: 5
     - PowerShell: 6

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context '7zip extraction' {
 
         BeforeAll {
-            if ($env:CI) {
+            if ($env:CI_WINDOWS) {
                 Mock Get-AppFilePath { (Get-Command 7z.exe).Path }
             } elseif (!(installed 7zip)) {
                 scoop install 7zip
@@ -79,8 +79,9 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context 'zstd extraction' {
 
         BeforeAll {
-            if ($env:CI) {
-                Mock Get-AppFilePath { $env:zstd }
+            if ($env:CI_WINDOWS) {
+                Mock Get-AppFilePath { $env:ZSTD } -ParameterFilter { $Helper -eq 'zstd' }
+                Mock Get-AppFilePath { '7z.exe' } -ParameterFilter { $Helper -eq '7zip' }
             } elseif (!(installed zstd)) {
                 scoop install zstd
             }
@@ -113,8 +114,8 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context 'msi extraction' {
 
         BeforeAll {
-            if ($env:CI) {
-                Mock Get-AppFilePath { $env:lessmsi }
+            if ($env:CI_WINDOWS) {
+                Mock Get-AppFilePath { $env:LESSMSI }
             } elseif (!(installed lessmsi)) {
                 scoop install lessmsi
             }
@@ -147,8 +148,8 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context 'inno extraction' {
 
         BeforeAll {
-            if ($env:CI) {
-                Mock Get-AppFilePath { $env:innounp }
+            if ($env:CI_WINDOWS) {
+                Mock Get-AppFilePath { $env:INNOUNP }
             } elseif (!(installed innounp)) {
                 scoop install innounp
             }

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -80,7 +80,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         BeforeAll {
             if ($env:CI) {
-                Mock Get-AppFilePath { $env:ZSTD } -ParameterFilter { $Helper -eq 'zstd' }
+                Mock Get-AppFilePath { $env:ZSTD_PATH } -ParameterFilter { $Helper -eq 'zstd' }
                 Mock Get-AppFilePath { '7z.exe' } -ParameterFilter { $Helper -eq '7zip' }
             } elseif (!(installed zstd)) {
                 scoop install zstd
@@ -115,7 +115,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         BeforeAll {
             if ($env:CI) {
-                Mock Get-AppFilePath { $env:LESSMSI }
+                Mock Get-AppFilePath { $env:LESSMSI_PATH }
             } elseif (!(installed lessmsi)) {
                 scoop install lessmsi
             }
@@ -149,7 +149,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         BeforeAll {
             if ($env:CI) {
-                Mock Get-AppFilePath { $env:INNOUNP }
+                Mock Get-AppFilePath { $env:INNOUNP_PATH }
             } elseif (!(installed innounp)) {
                 scoop install innounp
             }

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -80,7 +80,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         BeforeAll {
             if ($env:CI) {
-                Mock Get-AppFilePath { $env:ZSTD_PATH } -ParameterFilter { $Helper -eq 'zstd' }
+                Mock Get-AppFilePath { $env:SCOOP_ZSTD_PATH } -ParameterFilter { $Helper -eq 'zstd' }
                 Mock Get-AppFilePath { '7z.exe' } -ParameterFilter { $Helper -eq '7zip' }
             } elseif (!(installed zstd)) {
                 scoop install zstd
@@ -115,7 +115,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         BeforeAll {
             if ($env:CI) {
-                Mock Get-AppFilePath { $env:LESSMSI_PATH }
+                Mock Get-AppFilePath { $env:SCOOP_LESSMSI_PATH }
             } elseif (!(installed lessmsi)) {
                 scoop install lessmsi
             }
@@ -149,7 +149,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         BeforeAll {
             if ($env:CI) {
-                Mock Get-AppFilePath { $env:INNOUNP_PATH }
+                Mock Get-AppFilePath { $env:SCOOP_INNOUNP_PATH }
             } elseif (!(installed innounp)) {
                 scoop install innounp
             }

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context '7zip extraction' {
 
         BeforeAll {
-            if ($env:CI_WINDOWS) {
+            if ($env:CI) {
                 Mock Get-AppFilePath { (Get-Command 7z.exe).Path }
             } elseif (!(installed 7zip)) {
                 scoop install 7zip
@@ -79,7 +79,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context 'zstd extraction' {
 
         BeforeAll {
-            if ($env:CI_WINDOWS) {
+            if ($env:CI) {
                 Mock Get-AppFilePath { $env:ZSTD } -ParameterFilter { $Helper -eq 'zstd' }
                 Mock Get-AppFilePath { '7z.exe' } -ParameterFilter { $Helper -eq '7zip' }
             } elseif (!(installed zstd)) {
@@ -114,7 +114,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context 'msi extraction' {
 
         BeforeAll {
-            if ($env:CI_WINDOWS) {
+            if ($env:CI) {
                 Mock Get-AppFilePath { $env:LESSMSI }
             } elseif (!(installed lessmsi)) {
                 scoop install lessmsi
@@ -148,7 +148,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context 'inno extraction' {
 
         BeforeAll {
-            if ($env:CI_WINDOWS) {
+            if ($env:CI) {
                 Mock Get-AppFilePath { $env:INNOUNP }
             } elseif (!(installed innounp)) {
                 scoop install innounp

--- a/test/bin/init.ps1
+++ b/test/bin/init.ps1
@@ -1,32 +1,8 @@
 Write-Host "PowerShell: $($PSVersionTable.PSVersion)"
-(7z.exe | Select-String -Pattern '7-Zip').ToString()
+Write-Host (7z.exe | Select-String -Pattern '7-Zip').ToString()
 Write-Host 'Install dependencies ...'
 Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name Pester -RequiredVersion 4.10.1 -SkipPublisherCheck
 Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name PSScriptAnalyzer, BuildHelpers
-
-if ($env:CI_WINDOWS -eq $true) {
-    # Do not force maintainers to have this inside environment appveyor config
-    if (-not $env:SCOOP_HELPERS) {
-        $env:SCOOP_HELPERS = 'C:\projects\helpers'
-        [System.Environment]::SetEnvironmentVariable('SCOOP_HELPERS', $env:SCOOP_HELPERS, 'Machine')
-    }
-
-    if (!(Test-Path $env:SCOOP_HELPERS)) {
-        New-Item -ItemType Directory -Path $env:SCOOP_HELPERS
-    }
-    if (!(Test-Path "$env:SCOOP_HELPERS\lessmsi\lessmsi.exe")) {
-        Start-FileDownload 'https://github.com/activescott/lessmsi/releases/download/v1.10.0/lessmsi-v1.10.0.zip' -FileName "$env:SCOOP_HELPERS\lessmsi.zip"
-        & 7z.exe x "$env:SCOOP_HELPERS\lessmsi.zip" -o"$env:SCOOP_HELPERS\lessmsi" -y
-    }
-    if (!(Test-Path "$env:SCOOP_HELPERS\innounp\innounp.exe")) {
-        Start-FileDownload 'https://raw.githubusercontent.com/ScoopInstaller/Binary/master/innounp/innounp050.rar' -FileName "$env:SCOOP_HELPERS\innounp.rar"
-        & 7z.exe x "$env:SCOOP_HELPERS\innounp.rar" -o"$env:SCOOP_HELPERS\innounp" -y
-    }
-    if (!(Test-Path "$env:SCOOP_HELPERS\zstd\zstd.exe")) {
-        Start-FileDownload 'https://github.com/facebook/zstd/releases/download/v1.5.0/zstd-v1.5.0-win32.zip' -FileName "$env:SCOOP_HELPERS\zstd.zip"
-        & 7z.exe x "$env:SCOOP_HELPERS\zstd.zip" 'zstd-v1.5.0-win32' -o"$env:SCOOP_HELPERS\zstd" -y
-    }
-}
 
 if ($env:CI -eq $true) {
     Write-Host "Load 'BuildHelpers' environment variables ..."

--- a/test/bin/test.ps1
+++ b/test/bin/test.ps1
@@ -11,9 +11,9 @@ $splat = @{
     PassThru = $true
 }
 
+$excludes = @()
 if ($env:CI -eq $true) {
     $resultsXml = "$PSScriptRoot/TestResults.xml"
-    $excludes = @()
 
     $splat += @{
         OutputFile   = $resultsXml
@@ -35,8 +35,7 @@ if ($env:CI -eq $true) {
         $excludes += 'Scoop'
     }
 
-    $changed_scripts = (Get-GitChangedFile -Include '*decompress.ps1' -Commit $commit)
-    if (!$changed_scripts) {
+    if (!($changed_scripts -like '*decompress.ps1')) {
         Write-Warning "Skipping tests and code linting for decompress.ps1 files because it didn't change"
         $excludes += 'Decompress'
     }
@@ -55,6 +54,30 @@ if ($env:CI -eq $true) {
     if (!$changed_manifests) {
         Write-Warning "Skipping tests and validation for manifest files because they didn't change"
         $excludes += 'Manifests'
+    }
+
+    if ($env:CI_WINDOWS -eq $true -and 'Decompress' -notin $excludes) {
+        Write-Host 'Install decompress dependencies ...'
+
+        $env:SCOOP_HELPERS = 'C:\projects\helpers'
+        if (!(Test-Path $env:SCOOP_HELPERS)) {
+            New-Item -ItemType Directory -Path $env:SCOOP_HELPERS
+        }
+        if (!(Test-Path "$env:SCOOP_HELPERS\lessmsi\lessmsi.exe")) {
+            Start-FileDownload 'https://github.com/activescott/lessmsi/releases/download/v1.10.0/lessmsi-v1.10.0.zip' -FileName "$env:SCOOP_HELPERS\lessmsi.zip"
+            & 7z.exe x "$env:SCOOP_HELPERS\lessmsi.zip" -o"$env:SCOOP_HELPERS\lessmsi" -y
+            $env:LESSMSI = "$env:SCOOP_HELPERS\lessmsi\lessmsi.exe"
+        }
+        if (!(Test-Path "$env:SCOOP_HELPERS\innounp\innounp.exe")) {
+            Start-FileDownload 'https://raw.githubusercontent.com/ScoopInstaller/Binary/master/innounp/innounp050.rar' -FileName "$env:SCOOP_HELPERS\innounp.rar"
+            & 7z.exe x "$env:SCOOP_HELPERS\innounp.rar" -o"$env:SCOOP_HELPERS\innounp" -y
+            $env:INNOUNP = "$env:SCOOP_HELPERS\innounp\innounp.exe"
+        }
+        if (!(Test-Path "$env:SCOOP_HELPERS\zstd\zstd.exe")) {
+            Start-FileDownload 'https://github.com/facebook/zstd/releases/download/v1.5.1/zstd-v1.5.1-win32.zip' -FileName "$env:SCOOP_HELPERS\zstd.zip"
+            & 7z.exe x "$env:SCOOP_HELPERS\zstd.zip" -o"$env:SCOOP_HELPERS\zstd" -y
+            $env:ZSTD = "$env:SCOOP_HELPERS\zstd\zstd.exe"
+        }
     }
 }
 

--- a/test/bin/test.ps1
+++ b/test/bin/test.ps1
@@ -66,17 +66,17 @@ if ($env:CI -eq $true) {
         if (!(Test-Path "$env:SCOOP_HELPERS_PATH\lessmsi\lessmsi.exe")) {
             Start-FileDownload 'https://github.com/activescott/lessmsi/releases/download/v1.10.0/lessmsi-v1.10.0.zip' -FileName "$env:SCOOP_HELPERS_PATH\lessmsi.zip"
             & 7z.exe x "$env:SCOOP_HELPERS_PATH\lessmsi.zip" -o"$env:SCOOP_HELPERS_PATH\lessmsi" -y
-            $env:LESSMSI_PATH = "$env:SCOOP_HELPERS_PATH\lessmsi\lessmsi.exe"
+            $env:SCOOP_LESSMSI_PATH = "$env:SCOOP_HELPERS_PATH\lessmsi\lessmsi.exe"
         }
         if (!(Test-Path "$env:SCOOP_HELPERS_PATH\innounp\innounp.exe")) {
             Start-FileDownload 'https://raw.githubusercontent.com/ScoopInstaller/Binary/master/innounp/innounp050.rar' -FileName "$env:SCOOP_HELPERS_PATH\innounp.rar"
             & 7z.exe x "$env:SCOOP_HELPERS_PATH\innounp.rar" -o"$env:SCOOP_HELPERS_PATH\innounp" -y
-            $env:INNOUNP_PATH = "$env:SCOOP_HELPERS_PATH\innounp\innounp.exe"
+            $env:SCOOP_INNOUNP_PATH = "$env:SCOOP_HELPERS_PATH\innounp\innounp.exe"
         }
         if (!(Test-Path "$env:SCOOP_HELPERS_PATH\zstd\zstd.exe")) {
             Start-FileDownload 'https://github.com/facebook/zstd/releases/download/v1.5.1/zstd-v1.5.1-win32.zip' -FileName "$env:SCOOP_HELPERS_PATH\zstd.zip"
             & 7z.exe x "$env:SCOOP_HELPERS_PATH\zstd.zip" -o"$env:SCOOP_HELPERS_PATH\zstd" -y
-            $env:ZSTD_PATH = "$env:SCOOP_HELPERS_PATH\zstd\zstd.exe"
+            $env:SCOOP_ZSTD_PATH = "$env:SCOOP_HELPERS_PATH\zstd\zstd.exe"
         }
     }
 }

--- a/test/bin/test.ps1
+++ b/test/bin/test.ps1
@@ -56,7 +56,7 @@ if ($env:CI -eq $true) {
         $excludes += 'Manifests'
     }
 
-    if ($env:CI_WINDOWS -eq $true -and 'Decompress' -notin $excludes) {
+    if ('Decompress' -notin $excludes) {
         Write-Host 'Install decompress dependencies ...'
 
         $env:SCOOP_HELPERS = 'C:\projects\helpers'

--- a/test/bin/test.ps1
+++ b/test/bin/test.ps1
@@ -59,24 +59,24 @@ if ($env:CI -eq $true) {
     if ('Decompress' -notin $excludes) {
         Write-Host 'Install decompress dependencies ...'
 
-        $env:SCOOP_HELPERS = 'C:\projects\helpers'
-        if (!(Test-Path $env:SCOOP_HELPERS)) {
-            New-Item -ItemType Directory -Path $env:SCOOP_HELPERS
+        $env:SCOOP_HELPERS_PATH = 'C:\projects\helpers'
+        if (!(Test-Path $env:SCOOP_HELPERS_PATH)) {
+            New-Item -ItemType Directory -Path $env:SCOOP_HELPERS_PATH
         }
-        if (!(Test-Path "$env:SCOOP_HELPERS\lessmsi\lessmsi.exe")) {
-            Start-FileDownload 'https://github.com/activescott/lessmsi/releases/download/v1.10.0/lessmsi-v1.10.0.zip' -FileName "$env:SCOOP_HELPERS\lessmsi.zip"
-            & 7z.exe x "$env:SCOOP_HELPERS\lessmsi.zip" -o"$env:SCOOP_HELPERS\lessmsi" -y
-            $env:LESSMSI = "$env:SCOOP_HELPERS\lessmsi\lessmsi.exe"
+        if (!(Test-Path "$env:SCOOP_HELPERS_PATH\lessmsi\lessmsi.exe")) {
+            Start-FileDownload 'https://github.com/activescott/lessmsi/releases/download/v1.10.0/lessmsi-v1.10.0.zip' -FileName "$env:SCOOP_HELPERS_PATH\lessmsi.zip"
+            & 7z.exe x "$env:SCOOP_HELPERS_PATH\lessmsi.zip" -o"$env:SCOOP_HELPERS_PATH\lessmsi" -y
+            $env:LESSMSI_PATH = "$env:SCOOP_HELPERS_PATH\lessmsi\lessmsi.exe"
         }
-        if (!(Test-Path "$env:SCOOP_HELPERS\innounp\innounp.exe")) {
-            Start-FileDownload 'https://raw.githubusercontent.com/ScoopInstaller/Binary/master/innounp/innounp050.rar' -FileName "$env:SCOOP_HELPERS\innounp.rar"
-            & 7z.exe x "$env:SCOOP_HELPERS\innounp.rar" -o"$env:SCOOP_HELPERS\innounp" -y
-            $env:INNOUNP = "$env:SCOOP_HELPERS\innounp\innounp.exe"
+        if (!(Test-Path "$env:SCOOP_HELPERS_PATH\innounp\innounp.exe")) {
+            Start-FileDownload 'https://raw.githubusercontent.com/ScoopInstaller/Binary/master/innounp/innounp050.rar' -FileName "$env:SCOOP_HELPERS_PATH\innounp.rar"
+            & 7z.exe x "$env:SCOOP_HELPERS_PATH\innounp.rar" -o"$env:SCOOP_HELPERS_PATH\innounp" -y
+            $env:INNOUNP_PATH = "$env:SCOOP_HELPERS_PATH\innounp\innounp.exe"
         }
-        if (!(Test-Path "$env:SCOOP_HELPERS\zstd\zstd.exe")) {
-            Start-FileDownload 'https://github.com/facebook/zstd/releases/download/v1.5.1/zstd-v1.5.1-win32.zip' -FileName "$env:SCOOP_HELPERS\zstd.zip"
-            & 7z.exe x "$env:SCOOP_HELPERS\zstd.zip" -o"$env:SCOOP_HELPERS\zstd" -y
-            $env:ZSTD = "$env:SCOOP_HELPERS\zstd\zstd.exe"
+        if (!(Test-Path "$env:SCOOP_HELPERS_PATH\zstd\zstd.exe")) {
+            Start-FileDownload 'https://github.com/facebook/zstd/releases/download/v1.5.1/zstd-v1.5.1-win32.zip' -FileName "$env:SCOOP_HELPERS_PATH\zstd.zip"
+            & 7z.exe x "$env:SCOOP_HELPERS_PATH\zstd.zip" -o"$env:SCOOP_HELPERS_PATH\zstd" -y
+            $env:ZSTD_PATH = "$env:SCOOP_HELPERS_PATH\zstd\zstd.exe"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Fix Appveyor error caused by wrong `zstd.exe` extraction.

#### Description
<!-- Describe your changes in detail -->

- Update `zstd` to v1.5.1 and change its 7z extraction param (This is why CI cannot find `zstd`)
- Fix `Mock` function in zstd test cases (This is why nested zstd test fails)
- Some unrelated tweaks
  - Install helper and set EnvVars on demand (Move from `init.ps1` to `test.ps1`)
  - Move helper EnvVars from `appveyor.yml` to `test.ps1`
  - ~Change condition of `Mock Get-AppFilePath` to `CI_WINDOWS` so developers could simulate test in CI by setting `$env:CI_WINDOWS = $true` and modifying the helper downloading part of `test.ps1` file~

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Relates tohttps://github.com/ScoopInstaller/Scoop/pull/4608#issuecomment-1011022366

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

https://ci.appveyor.com/project/niheaven/scoop/builds/42177522/job/l8b7kyla9deyiohx

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
