### PR TITLE
build(ci): Use cache in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Scoop Core CI Tests
 
 on:
   pull_request:
@@ -14,11 +14,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Init and Test
+      - name: Init Test Suite
+        uses: potatoqualitee/psmodulecache@v4
+        with:
+          modules-to-cache: PSScriptAnalyzer, BuildHelpers, Pester:4.10.1
+          shell: powershell
+      - name: Test Scoop Core
         shell: powershell
-        run: |
-          .\test\bin\init.ps1
-          .\test\bin\test.ps1
+        run: ./test/bin/test.ps1
   test_pwsh:
     name: PowerShell
     runs-on: windows-latest
@@ -27,8 +30,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Init and Test
+      - name: Init Test Suite
+        uses: potatoqualitee/psmodulecache@v4
+        with:
+          modules-to-cache: PSScriptAnalyzer, BuildHelpers, Pester:4.10.1
+          shell: pwsh
+      - name: Test Scoop Core
         shell: pwsh
-        run: |
-          .\test\bin\init.ps1
-          .\test\bin\test.ps1
+        run: ./test/bin/test.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - **schema:** Add explicit escape to opening bracket matcher in jp/jsonpath regex ([#3719](https://github.com/ScoopInstaller/Scoop/issues/3719))
 - **tests:** Support both AppVeyor and GitHub Actions ([#4655](https://github.com/ScoopInstaller/Scoop/issues/4655))
 - **tests:** Run GitHub Actions CI on each commit ([#4664](https://github.com/ScoopInstaller/Scoop/issues/4664))
+- **tests:** Use cache in GitHub Actions ([#4671](https://github.com/ScoopInstaller/Scoop/issues/4671))
 - **vscode-settings:** Remove 'formatOnSave' trigger ([#4635](https://github.com/ScoopInstaller/Scoop/issues/4635))
 
 ### Styles

--- a/test/bin/init.ps1
+++ b/test/bin/init.ps1
@@ -1,6 +1,22 @@
-#Requires -Version 5.0
+#Requires -Version 5.1
 Write-Host "PowerShell: $($PSVersionTable.PSVersion)"
 Write-Host (7z.exe | Select-String -Pattern '7-Zip').ToString()
-Write-Host 'Install testsuite dependencies ...'
-Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name Pester -RequiredVersion 4.10.1 -SkipPublisherCheck
-Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name PSScriptAnalyzer, BuildHelpers
+Write-Host 'Check and install testsuite dependencies ...'
+if (Get-InstalledModule -Name Pester -MinimumVersion 4.0 -MaximumVersion 4.99 -ErrorAction SilentlyContinue) {
+    Write-Host 'Pester 4 is already installed.'
+} else {
+    Write-Host 'Installing Pester 4 ...'
+    Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name Pester -MinimumVersion 4.0 -MaximumVersion 4.99 -SkipPublisherCheck
+}
+if (Get-InstalledModule -Name PSScriptAnalyzer -MinimumVersion 1.17 -ErrorAction SilentlyContinue) {
+    Write-Host 'PSScriptAnalyzer is already installed.'
+} else {
+    Write-Host 'Installing PSScriptAnalyzer ...'
+    Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name PSScriptAnalyzer -SkipPublisherCheck
+}
+if (Get-InstalledModule -Name BuildHelpers -MinimumVersion 2.0 -ErrorAction SilentlyContinue) {
+    Write-Host 'BuildHelpers is already installed.'
+} else {
+    Write-Host 'Installing BuildHelpers ...'
+    Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name BuildHelpers -SkipPublisherCheck
+}

--- a/test/bin/test.ps1
+++ b/test/bin/test.ps1
@@ -1,6 +1,6 @@
-#Requires -Version 5.0
+#Requires -Version 5.1
 #Requires -Modules @{ ModuleName = 'BuildHelpers'; ModuleVersion = '2.0.1' }
-#Requires -Modules @{ ModuleName = 'Pester'; RequiredVersion = '4.10.1' }
+#Requires -Modules @{ ModuleName = 'Pester'; MaximumVersion = '4.99' }
 #Requires -Modules @{ ModuleName = 'PSScriptAnalyzer'; ModuleVersion = '1.17.1' }
 param(
     [String] $TestPath = $(Resolve-Path "$PSScriptRoot\..\")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Use ~https://github.com/actions/cache~ https://github.com/potatoqualitee/psmodulecache to cache PowerShell modules in GitHub Actions. (Really not happy while working with https://github.com/actions/cache)

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

PowerShell modules installation is the most time-consuming step of CI test, this fix tries to skip them.

It also skips modules installation if there're ones.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

~I don't find an effective way to test the PR, but it seems to work~

~From CI results below, it found cache, but doesn't use them. Maybe a little more tweak are needed.~

Use https://github.com/potatoqualitee/psmodulecache to cache PowerShell Modules, it works fine as this PR's two commits.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] ~I have updated the tests accordingly.~
