### PR TITLE
fix(depends): Keep bucket in 'Get-Dependency()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Code Refactoring
 
 - **depends:** Rewrite 'depends.ps1' ([#4638](https://github.com/ScoopInstaller/Scoop/issues/4638))
+  - **depends:** Keep bucket in 'Get-Dependency()' ([#4673](https://github.com/ScoopInstaller/Scoop/issues/4673))
 
 ### Builds
 

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -55,7 +55,11 @@ function Get-Dependency {
         }
 
         $Unresolved = $Unresolved -ne $AppName
-        $Resolved += $AppName
+        if ($bucket) {
+            $Resolved += "$bucket/$AppName"
+        } else {
+            $Resolved += $AppName
+        }
         if ($Unresolved.Length -eq 0) {
             return $Resolved
         } else {
@@ -95,16 +99,10 @@ function Get-InstallationHelper {
     }
     process {
         $url = arch_specific 'url' $Manifest $Architecture
-        if (!$url) {
-            $url = ''
-        }
         $pre_install = arch_specific 'pre_install' $Manifest $Architecture
         $installer = arch_specific 'installer' $Manifest $Architecture
         $post_install = arch_specific 'post_install' $Manifest $Architecture
         $script = $pre_install + $installer.script + $post_install
-        if (!$script) {
-            $script = ''
-        }
         if (((Test-7zipRequirement -Uri $url) -or ($script -like '*Expand-7zipArchive *')) -and !(get_config 7ZIPEXTRACT_USE_EXTERNAL)) {
             $helper += '7zip'
         }
@@ -138,6 +136,7 @@ function Test-7zipRequirement {
     [OutputType([Boolean])]
     param (
         [Parameter(Mandatory = $true)]
+        [AllowNull()]
         [String[]]
         $Uri
     )
@@ -151,6 +150,7 @@ function Test-ZstdRequirement {
     [OutputType([Boolean])]
     param (
         [Parameter(Mandatory = $true)]
+        [AllowNull()]
         [String[]]
         $Uri
     )
@@ -162,6 +162,7 @@ function Test-LessmsiRequirement {
     [OutputType([Boolean])]
     param (
         [Parameter(Mandatory = $true)]
+        [AllowNull()]
         [String[]]
         $Uri
     )

--- a/test/Scoop-Depends.Tests.ps1
+++ b/test/Scoop-Depends.Tests.ps1
@@ -3,56 +3,94 @@
 . "$psscriptroot\..\lib\install.ps1"
 . "$psscriptroot\..\lib\manifest.ps1"
 
-Describe 'Requirement function' -Tag 'Scoop' {
-    It 'Test 7zip requirement' {
-        Test-7zipRequirement -Uri 'test.xz' | Should -BeTrue
-        Test-7zipRequirement -Uri 'test.bin' | Should -BeFalse
-        Test-7zipRequirement -Uri @('test.xz', 'test.bin') | Should -BeTrue
+Describe 'Package Dependencies' -Tag 'Scoop' {
+    Context 'Requirement function' {
+        It 'Test 7zip requirement' {
+            Test-7zipRequirement -Uri 'test.xz' | Should -BeTrue
+            Test-7zipRequirement -Uri 'test.bin' | Should -BeFalse
+            Test-7zipRequirement -Uri @('test.xz', 'test.bin') | Should -BeTrue
+        }
+        It 'Test Zstd requirement' {
+            Test-ZstdRequirement -Uri 'test.zst' | Should -BeTrue
+            Test-ZstdRequirement -Uri 'test.bin' | Should -BeFalse
+            Test-ZstdRequirement -Uri @('test.zst', 'test.bin') | Should -BeTrue
+        }
+        It 'Test lessmsi requirement' {
+            Mock get_config { $true }
+            Test-LessmsiRequirement -Uri 'test.msi' | Should -BeTrue
+            Test-LessmsiRequirement -Uri 'test.bin' | Should -BeFalse
+            Test-LessmsiRequirement -Uri @('test.msi', 'test.bin') | Should -BeTrue
+        }
+        It 'Allow $Uri be $null' {
+            Test-7zipRequirement -Uri $null | Should -BeFalse
+            Test-ZstdRequirement -Uri $null | Should -BeFalse
+            Test-LessmsiRequirement -Uri $null | Should -BeFalse
+        }
     }
-    It 'Test Zstd requirement' {
-        Test-ZstdRequirement -Uri 'test.zst' | Should -BeTrue
-        Test-ZstdRequirement -Uri 'test.bin' | Should -BeFalse
-        Test-ZstdRequirement -Uri @('test.zst', 'test.bin') | Should -BeTrue
-    }
-    It 'Test lessmsi requirement' {
-        Mock get_config { $true }
-        Test-LessmsiRequirement -Uri 'test.msi' | Should -BeTrue
-        Test-LessmsiRequirement -Uri 'test.bin' | Should -BeFalse
-        Test-LessmsiRequirement -Uri @('test.msi', 'test.bin') | Should -BeTrue
-    }
-}
 
-Describe 'InstallationHelper function' -Tag 'Scoop' {
-    BeforeAll {
-        $working_dir = setup_working 'format/formated'
-        $manifest1 = parse_json (Join-Path $working_dir '3-array-with-single-and-multi.json')
-        $manifest2 = parse_json (Join-Path $working_dir '4-script-block.json')
-        Mock Test-HelperInstalled { $false }
+    Context 'InstallationHelper function' {
+        BeforeAll {
+            $working_dir = setup_working 'format/formated'
+            $manifest1 = parse_json (Join-Path $working_dir '3-array-with-single-and-multi.json')
+            $manifest2 = parse_json (Join-Path $working_dir '4-script-block.json')
+            Mock Test-HelperInstalled { $false }
+        }
+        It 'Get helpers from URL' {
+            Mock get_config { $true }
+            Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -Be @('lessmsi')
+        }
+        It 'Get helpers from script' {
+            Mock get_config { $false }
+            Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -Be @('7zip')
+        }
+        It 'Helpers reflect config changes' {
+            Mock get_config { $false } -ParameterFilter { $name -eq 'MSIEXTRACT_USE_LESSMSI' }
+            Mock get_config { $true } -ParameterFilter { $name -eq '7ZIPEXTRACT_USE_EXTERNAL' }
+            Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -BeNullOrEmpty
+            Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -BeNullOrEmpty
+        }
+        It 'Not return installed helpers' {
+            Mock get_config { $true } -ParameterFilter { $name -eq 'MSIEXTRACT_USE_LESSMSI' }
+            Mock get_config { $false } -ParameterFilter { $name -eq '7ZIPEXTRACT_USE_EXTERNAL' }
+            Mock Test-HelperInstalled { $true }-ParameterFilter { $Helper -eq '7zip' }
+            Mock Test-HelperInstalled { $false }-ParameterFilter { $Helper -eq 'Lessmsi' }
+            Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -Be @('lessmsi')
+            Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -BeNullOrEmpty
+            Mock Test-HelperInstalled { $false }-ParameterFilter { $Helper -eq '7zip' }
+            Mock Test-HelperInstalled { $true }-ParameterFilter { $Helper -eq 'Lessmsi' }
+            Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -BeNullOrEmpty
+            Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -Be @('7zip')
+        }
     }
-    It 'Get helpers from URL' {
-        Mock get_config { $true }
-        Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -Be @('lessmsi')
-    }
-    It 'Get helpers from script' {
-        Mock get_config { $false }
-        Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -Be @('7zip')
-    }
-    It 'Helpers reflect config changes' {
-        Mock get_config { $false } -ParameterFilter { $name -eq 'MSIEXTRACT_USE_LESSMSI' }
-        Mock get_config { $true } -ParameterFilter { $name -eq '7ZIPEXTRACT_USE_EXTERNAL' }
-        Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -BeNullOrEmpty
-        Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -BeNullOrEmpty
-    }
-    It 'Not return installed helpers' {
-        Mock get_config { $true } -ParameterFilter { $name -eq 'MSIEXTRACT_USE_LESSMSI' }
-        Mock get_config { $false } -ParameterFilter { $name -eq '7ZIPEXTRACT_USE_EXTERNAL' }
-        Mock Test-HelperInstalled { $true }-ParameterFilter { $Helper -eq '7zip' }
-        Mock Test-HelperInstalled { $false }-ParameterFilter { $Helper -eq 'Lessmsi' }
-        Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -Be @('lessmsi')
-        Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -BeNullOrEmpty
-        Mock Test-HelperInstalled { $false }-ParameterFilter { $Helper -eq '7zip' }
-        Mock Test-HelperInstalled { $true }-ParameterFilter { $Helper -eq 'Lessmsi' }
-        Get-InstallationHelper -Manifest $manifest1 -Architecture '32bit' | Should -BeNullOrEmpty
-        Get-InstallationHelper -Manifest $manifest2 -Architecture '32bit' | Should -Be @('7zip')
+
+    Context 'Dependencies resolution' {
+        BeforeAll {
+            Mock Test-HelperInstalled { $false }
+            Mock get_config { $true } -ParameterFilter { $name -eq 'MSIEXTRACT_USE_LESSMSI' }
+            Mock Find-Manifest { $null, @{}, $null, $null } -ParameterFilter { $AppName -eq 'lessmsi' }
+            Mock Find-Manifest { $null, @{ url = 'test.msi' }, $null, $null } -ParameterFilter { $AppName -eq '7zip' }
+            Mock Find-Manifest { $null, @{}, $null, $null } -ParameterFilter { $AppName -eq 'innounp' }
+        }
+
+        It 'Resolve install dependencies' {
+            Mock Find-Manifest { $null, @{ url = 'test.7z' }, $null, $null }
+            Get-Dependency -AppName 'test' -Architecture '32bit' | Should -Be @('lessmsi', '7zip', 'test')
+            Mock Find-Manifest { $null, @{ innosetup = $true }, $null, $null }
+            Get-Dependency -AppName 'test' -Architecture '32bit' | Should -Be @('innounp', 'test')
+        }
+        It 'Resolve script dependencies' {
+            Mock Find-Manifest { $null, @{ pre_install = 'Expand-7zipArchive ' }, $null, $null }
+            Get-Dependency -AppName 'test' -Architecture '32bit' | Should -Be @('lessmsi', '7zip', 'test')
+        }
+        It 'Resolve runtime dependencies' {
+            Mock Find-Manifest { $null, @{}, $null, $null } -ParameterFilter { $AppName -eq 'depends' }
+            Mock Find-Manifest { $null, @{ depends = 'depends' }, $null, $null }
+            Get-Dependency -AppName 'test' -Architecture '32bit' | Should -Be @('depends', 'test')
+        }
+        It 'Keep bucket name of app' {
+            Mock Find-Manifest { $null, @{}, $null, $null } -ParameterFilter { $AppName -eq 'bucket/depends' }
+            Mock Find-Manifest { $null, @{ depends = 'bucket/depends' }, $null, $null }
+            Get-Dependency -AppName 'anotherbucket/test' -Architecture '32bit' | Should -Be @('bucket/depends', 'anotherbucket/test')
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

#4638 changes some logic of installing and updating, and `Get-Dependency()` trimmed bucket from app's name (e.g., `versions/7zip-zstd` -> `7zip-zstd`), this introduces some bug when user installs some apps that duplicated with known buckets.

This PR keeps bucket name with app name while resolving dependencies, so the installation won't be confused.

Besides, #4638 may breaks #4595, and no URL bug is fixed again by allow $null in `Test-xxxRequirement()` functions.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #4662

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

![image](https://user-images.githubusercontent.com/5832170/149975093-519323a9-f3eb-4e62-860a-bae06c8a6972.png)
![image](https://user-images.githubusercontent.com/5832170/149975145-5d9fbf6a-0e8c-44df-b94e-044693821dc4.png)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
