### PR TITLE
fix(install-status): Correctly handle failed installation of apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **decompress:** Fix nested Zstd archive extraction ([#4608](https://github.com/ScoopInstaller/Scoop/issues/4608))
   - **decompress:** Fix `Split-Path -LeafBase` in PS5 ([#4639](https://github.com/ScoopInstaller/Scoop/issues/4639))
 - **installed:** Fix 'core/installed' that mark failed app as 'installed' ([#4650](https://github.com/ScoopInstaller/Scoop/issues/4650))
+  - **status:** Correctly handle failed installation of apps ([#4676](https://github.com/ScoopInstaller/Scoop/issues/4676))
 - **shim:** Fix PS1 shim error when in different drive in PS7 ([#4614](https://github.com/ScoopInstaller/Scoop/issues/4614))
 - **shim:** Fix `sh` shim error in WSL ([#4637](https://github.com/ScoopInstaller/Scoop/issues/4637))
 - **scoop-cleanup:** Remove apps other than current version ([#4665](https://github.com/ScoopInstaller/Scoop/issues/4665))

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -293,13 +293,13 @@ function Test-Aria2Enabled {
 
 function app_status($app, $global) {
     $status = @{}
-    $status.installed = (installed $app $global)
+    $status.installed = installed $app $global
     $status.version = Select-CurrentVersion -AppName $app -Global:$global
     $status.latest_version = $status.version
 
     $install_info = install_info $app $status.version $global
 
-    $status.failed = (!$install_info -or !$status.version)
+    $status.failed = failed $app $global
     $status.hold = ($install_info.hold -eq $true)
 
     $manifest = manifest $app $install_info.bucket $install_info.url
@@ -774,7 +774,7 @@ function Confirm-InstallationStatus {
             }
         }
         if (failed $App $Global) {
-            error "'$App' isn't installed correctly, please reinstall it or fix the manifest."
+            error "'$App' isn't installed correctly."
         }
     }
     return , $Installed

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -199,6 +199,11 @@ function installed_apps($global) {
     }
 }
 
+# check whether the app failed to install
+function failed($app, $global) {
+    return (is_directory (appdir $app $global)) -and !(Select-CurrentVersion -AppName $app -Global:$global)
+}
+
 function file_path($app, $file) {
     Show-DeprecatedWarning $MyInvocation 'Get-AppFilePath'
     Get-AppFilePath -App $app -File $file

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -758,7 +758,7 @@ function Confirm-InstallationStatus {
             if (Test-Path (appdir $App $true)) {
                 $Installed += , @($App, $true)
             } elseif (Test-Path (appdir $App $false)) {
-                error "'$App' isn't installed globally, but it may be installed for your account."
+                error "'$App' isn't installed globally, but it may be installed locally."
                 warn "Try again without the --global (or -g) flag instead."
             } else {
                 error "'$App' isn't installed."
@@ -767,7 +767,7 @@ function Confirm-InstallationStatus {
             if (Test-Path (appdir $App $false)) {
                 $Installed += , @($App, $false)
             } elseif (Test-Path (appdir $App $true)) {
-                error "'$App' isn't installed for your account, but it may be installed globally."
+                error "'$App' isn't installed locally, but it may be installed globally."
                 warn "Try again with the --global (or -g) flag instead."
             } else {
                 error "'$App' isn't installed."

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -320,7 +320,7 @@ function app_status($app, $global) {
     $status.missing_deps = @()
     $deps = @($manifest.depends) | Where-Object {
         if ($null -eq $_) {
-            return $false
+            return $null
         } else {
             $app, $bucket, $null = parse_app $_
             return !(installed $app)
@@ -774,7 +774,7 @@ function Confirm-InstallationStatus {
             }
         }
         if (failed $App $Global) {
-            warn "'$App' isn't installed correctly."
+            error "'$App' isn't installed correctly, please reinstall it or fix the manifest."
         }
     }
     return , $Installed

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1079,12 +1079,12 @@ function prune_installed($apps, $global) {
 
 # check whether the app failed to install
 function failed($app, $global) {
-    $app = ($app -split '/|\\')[-1]
     return (is_directory (appdir $app $global)) -and !(Select-CurrentVersion -AppName $app -Global:$global)
 }
 
 function ensure_none_failed($apps, $global) {
-    foreach($app in $apps) {
+    foreach ($app in $apps) {
+        $app = ($app -split '/|\\')[-1] -replace '\.json$', ''
         if (failed $app $global) {
             warn "Purging previous failed installation of $app."
             & "$PSScriptRoot\..\libexec\scoop-uninstall.ps1" $app$(if ($global) { ' --global' })

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1077,11 +1077,6 @@ function prune_installed($apps, $global) {
     return @($uninstalled), @($installed)
 }
 
-# check whether the app failed to install
-function failed($app, $global) {
-    return (is_directory (appdir $app $global)) -and !(Select-CurrentVersion -AppName $app -Global:$global)
-}
-
 function ensure_none_failed($apps, $global) {
     foreach ($app in $apps) {
         $app = ($app -split '/|\\')[-1] -replace '\.json$', ''

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1079,6 +1079,7 @@ function prune_installed($apps, $global) {
 
 # check whether the app failed to install
 function failed($app, $global) {
+    $app = ($app -split '/|\\')[-1]
     return (is_directory (appdir $app $global)) -and !(Select-CurrentVersion -AppName $app -Global:$global)
 }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1079,11 +1079,7 @@ function prune_installed($apps, $global) {
 
 # check whether the app failed to install
 function failed($app, $global) {
-    if (is_directory (appdir $app $global)) {
-        return !(install_info $app (Select-CurrentVersion -AppName $app -Global:$global) $global)
-    } else {
-        return $false
-    }
+    return (is_directory (appdir $app $global)) -and !(Select-CurrentVersion -AppName $app -Global:$global)
 }
 
 function ensure_none_failed($apps, $global) {

--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -51,17 +51,17 @@ function Select-CurrentVersion {
     )
     process {
         $appPath = appdir $AppName $Global
-        if (Test-Path "$appPath\current" -PathType Container) {
+        if (get_config NO_JUNCTIONS) {
+            $installedVersion = Get-InstalledVersion -AppName $AppName -Global:$Global
+            if ($installedVersion) {
+                $currentVersion = @($installedVersion)[-1]
+            } else {
+                $currentVersion = $null
+            }
+        } else {
             $currentVersion = (installed_manifest $AppName 'current' $Global).version
             if ($currentVersion -eq 'nightly') {
                 $currentVersion = (Get-Item "$appPath\current").Target | Split-Path -Leaf
-            }
-        } else {
-            $installedVersion = Get-InstalledVersion -AppName $AppName -Global:$Global
-            if ($installedVersion) {
-                $currentVersion = $installedVersion[-1]
-            } else {
-                $currentVersion = $null
             }
         }
         return $currentVersion

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -37,11 +37,7 @@ function cleanup($app, $global, $verbose, $cache) {
     }
     $appDir = appdir $app $global
     $versions = Get-ChildItem $appDir -Name
-    if (!$versions) {
-        Remove-Item $appDir -ErrorAction SilentlyContinue -Force
-        return
-    }
-    $versions = $versions | Where-Object { $_ -ne $current_version -and $_ -ne 'current' }
+    $versions = $versions | Where-Object { $current_version -ne $_ -and $_ -ne 'current' }
     if (!$versions) {
         if ($verbose) { success "$app is already clean" }
         return
@@ -56,8 +52,14 @@ function cleanup($app, $global, $verbose, $cache) {
         unlink_persist_data $dir
         Remove-Item $dir -ErrorAction Stop -Recurse -Force
     }
-    if (!(Get-ChildItem $appDir)) {
-        Remove-Item $appDir -ErrorAction SilentlyContinue -Force
+    $leftVersions = Get-ChildItem $appDir
+    if ($leftVersions.Length -eq 1 -and $leftVersions.Name -eq 'current' -and $leftVersions.LinkType) {
+        attrib $leftVersions -R /L
+        Remove-Item $leftVersions -ErrorAction Stop -Force
+        $leftVersions = $null
+    }
+    if (!$leftVersions) {
+        Remove-Item $appDir -ErrorAction Stop -Force
     }
     Write-Host ''
 }

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -54,8 +54,8 @@ function cleanup($app, $global, $verbose, $cache) {
     }
     $leftVersions = Get-ChildItem $appDir
     if ($leftVersions.Length -eq 1 -and $leftVersions.Name -eq 'current' -and $leftVersions.LinkType) {
-        attrib $leftVersions -R /L
-        Remove-Item $leftVersions -ErrorAction Stop -Force
+        attrib $leftVersions.FullName -R /L
+        Remove-Item $leftVersions.FullName -ErrorAction Stop -Force
         $leftVersions = $null
     }
     if (!$leftVersions) {

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -3,6 +3,7 @@
 
 . "$psscriptroot\..\lib\help.ps1"
 . "$psscriptroot\..\lib\manifest.ps1"
+. "$psscriptroot\..\lib\versions.ps1"
 
 reset_aliases
 $apps = $args

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -3,6 +3,7 @@
 
 . "$psscriptroot\..\lib\help.ps1"
 . "$psscriptroot\..\lib\manifest.ps1"
+. "$psscriptroot\..\lib\versions.ps1"
 
 reset_aliases
 $apps = $args

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -51,72 +51,76 @@ if (!$apps) { exit 0 }
     ($app, $global) = $_
 
     $version = Select-CurrentVersion -AppName $app -Global:$global
-    Write-Host "Uninstalling '$app' ($version)."
+    $appDir = appdir $app $global
+    if ($version) {
+        Write-Host "Uninstalling '$app' ($version)."
 
-    $dir = versiondir $app $version $global
-    $persist_dir = persistdir $app $global
+        $dir = versiondir $app $version $global
+        $persist_dir = persistdir $app $global
 
-    #region Workaround for #2952
-    $processdir = appdir $app $global | Resolve-Path | Select-Object -ExpandProperty Path
-    if (Get-Process | Where-Object { $_.Path -like "$processdir\*" }) {
-        error "Application is still running. Close all instances and try again."
-        continue
-    }
-    #endregion Workaround for #2952
-
-    try {
-        Test-Path $dir -ErrorAction Stop | Out-Null
-    } catch [UnauthorizedAccessException] {
-        error "Access denied: $dir. You might need to restart."
-        continue
-    }
-
-    $manifest = installed_manifest $app $version $global
-    $install = install_info $app $version $global
-    $architecture = $install.architecture
-
-    run_uninstaller $manifest $architecture $dir
-    rm_shims $manifest $global $architecture
-    rm_startmenu_shortcuts $manifest $global $architecture
-
-    # If a junction was used during install, that will have been used
-    # as the reference directory. Otherwise it will just be the version
-    # directory.
-    $refdir = unlink_current $dir
-
-    uninstall_psmodule $manifest $refdir $global
-
-    env_rm_path $manifest $refdir $global $architecture
-    env_rm $manifest $global $architecture
-
-    try {
-        # unlink all potential old link before doing recursive Remove-Item
-        unlink_persist_data $dir
-        Remove-Item $dir -Recurse -Force -ErrorAction Stop
-    } catch {
-        if (Test-Path $dir) {
-            error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
+        #region Workaround for #2952
+        $processdir = $appDir | Resolve-Path | Select-Object -ExpandProperty Path
+        if (Get-Process | Where-Object { $_.Path -like "$processdir\*" }) {
+            Get-error 'Application is still running. Close all instances and try again.'
             continue
         }
-    }
+        #endregion Workaround for #2952
 
-    # remove older versions
-    $old = Get-InstalledVersion -AppName $app -Global:$global
-    foreach ($oldver in $old) {
-        Write-Host "Removing older version ($oldver)."
-        $dir = versiondir $app $oldver $global
+        try {
+            Test-Path $dir -ErrorAction Stop | Out-Null
+        } catch [UnauthorizedAccessException] {
+            Get-error "Access denied: $dir. You might need to restart."
+            continue
+        }
+
+        $manifest = installed_manifest $app $version $global
+        $install = install_info $app $version $global
+        $architecture = $install.architecture
+
+        run_uninstaller $manifest $architecture $dir
+        rm_shims $manifest $global $architecture
+        rm_startmenu_shortcuts $manifest $global $architecture
+
+        # If a junction was used during install, that will have been used
+        # as the reference directory. Otherwise it will just be the version
+        # directory.
+        $refdir = unlink_current $dir
+
+        uninstall_psmodule $manifest $refdir $global
+
+        env_rm_path $manifest $refdir $global $architecture
+        env_rm $manifest $global $architecture
+
         try {
             # unlink all potential old link before doing recursive Remove-Item
             unlink_persist_data $dir
             Remove-Item $dir -Recurse -Force -ErrorAction Stop
         } catch {
-            error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
+            if (Test-Path $dir) {
+                Get-error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
+                continue
+            }
+        }
+    }
+    # remove older versions
+    $oldVersions = @(Get-ChildItem $appDir -Name -Exclude 'current')
+    foreach ($version in $oldVersions) {
+        Write-Host "Removing older version ($version)."
+        $dir = versiondir $app $version $global
+        try {
+            # unlink all potential old link before doing recursive Remove-Item
+            unlink_persist_data $dir
+            Remove-Item $dir -Recurse -Force -ErrorAction Stop
+        } catch {
+            Get-error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
             continue app_loop
         }
     }
-
-    if ((Get-InstalledVersion -AppName $app -Global:$global).length -eq 0) {
-        $appdir = appdir $app $global
+    if (Test-Path ($currentDir = Join-Path $appDir 'current')) {
+        attrib $currentDir -R /L
+        Remove-Item $currentDir -ErrorAction Stop -Force
+    }
+    if (!(Get-ChildItem $appDir)) {
         try {
             # if last install failed, the directory seems to be locked and this
             # will throw an error about the directory not existing

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -61,7 +61,7 @@ if (!$apps) { exit 0 }
         #region Workaround for #2952
         $processdir = $appDir | Resolve-Path | Select-Object -ExpandProperty Path
         if (Get-Process | Where-Object { $_.Path -like "$processdir\*" }) {
-            Get-error 'Application is still running. Close all instances and try again.'
+            error 'Application is still running. Close all instances and try again.'
             continue
         }
         #endregion Workaround for #2952
@@ -69,7 +69,7 @@ if (!$apps) { exit 0 }
         try {
             Test-Path $dir -ErrorAction Stop | Out-Null
         } catch [UnauthorizedAccessException] {
-            Get-error "Access denied: $dir. You might need to restart."
+            error "Access denied: $dir. You might need to restart."
             continue
         }
 
@@ -97,7 +97,7 @@ if (!$apps) { exit 0 }
             Remove-Item $dir -Recurse -Force -ErrorAction Stop
         } catch {
             if (Test-Path $dir) {
-                Get-error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
+                error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
                 continue
             }
         }
@@ -112,7 +112,7 @@ if (!$apps) { exit 0 }
             unlink_persist_data $dir
             Remove-Item $dir -Recurse -Force -ErrorAction Stop
         } catch {
-            Get-error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
+            error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
             continue app_loop
         }
     }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -280,7 +280,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
         install_app $app $architecture $global $suggested $use_cache $check_hash
     } else {
         # Also add missing dependencies
-        $apps = @(Get-Dependency $app $architecture) | Where-Object { !(installed $_) }
+        $apps = Get-Dependency $app $architecture | Where-Object { !(installed $_) }
         $apps | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
     }
 }
@@ -316,7 +316,7 @@ if (-not ($apps -or $all)) {
         $apps | ForEach-Object {
             ($app, $global) = $_
             $status = app_status $app $global
-            if ($force -or $status.outdated) {
+            if ($status.installed -and ($force -or $status.outdated)) {
                 if(!$status.hold) {
                     $outdated += applist $app $global
                     write-host -f yellow ("$app`: $($status.version) -> $($status.latest_version){0}" -f ('',' (global)')[$global])
@@ -324,7 +324,11 @@ if (-not ($apps -or $all)) {
                     warn "'$app' is held to version $($status.version)"
                 }
             } elseif ($apps_param -ne '*') {
-                write-host -f green "$app`: $($status.version) (latest version)"
+                if ($status.installed) {
+                    Write-Host "$app`: $($status.version) (latest version)" -ForegroundColor Green
+                } else {
+                    info 'Please reinstall it or fix the manifest.'
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

- Let `core/Confirm-InstallationStatus()` marks failed installation and give a warning
- Let `scoop-cleanup` correctly cleanup failed installation
- Simplify `core/installed()` and `install/failed()` (oh xxxx these two paired functions even are not in same file! Move them to `core`)
- Remove `scoop-install/is_installed()` and move its functionality into main file
- Some minor style fixes

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #4674
<!-- or -->
Relates to #4650

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Just as #4674

```powershell
# 1. failed installation can be purged via `scoop-cleanup`:
scoop install tests\meson.json
scoop list meson
#  meson  *failed*
scoop cleanup *
# Removing meson: 0.61.1
# Everything is shiny now!
scoop list meson
# Nothing here

# 2. previous failed installation was purged when (re)install:
scoop install tests\meson.json
scoop list meson
#  meson  *failed*
scoop install meson.json
# WARN  Purging previous failed installation of meson.
# WARN  'meson' isn't installed correctly.
# Uninstalling 'meson' ().
# 'meson' was uninstalled.
# 'meson' (0.61.1) was installed successfully!
scoop list meson
#  meson 0.61.1 [main]
ls (scoop prefix meson) | findstr 'FAILED_INSTALLATION'
# Nothing here
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] ~I have updated the tests accordingly.~ (I don't know how to test such functions)
