### PR TITLE
perf(uninstall/reset): avoid checking all files for unlink persisted data

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -650,7 +650,7 @@ python `"$resolved_path`" $arg `"$@`"" | Out-File $shim -Encoding ASCII
     } else {
         warn_on_overwrite "$shim.cmd" $path
         # find path to Git's bash so that batch scripts can run bash scripts
-        $gitdir = (Get-Item (Get-Command git -ErrorAction:Stop).Source -ErrorAction:Stop).Directory.Parent
+        $gitdir = (Get-Item (Get-Command git -CommandType:Application -ErrorAction:Stop).Source -ErrorAction:Stop).Directory.Parent
         if ($gitdir.FullName -imatch 'mingw') {
             $gitdir = $gitdir.Parent
         }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1166,7 +1166,7 @@ function persist_data($manifest, $original_dir, $persist_dir) {
                 # ensure target parent folder exist
                 ensure (Split-Path -Path $target) | Out-Null
                 Move-Item $source $target
-            # we don't have neither source nor target data! we need to crate an empty target,
+            # we don't have neither source nor target data! we need to create an empty target,
             # but we can't make a judgement that the data should be a file or directory...
             # so we create a directory by default. to avoid this, use pre_install
             # to create the source file before persisting (DON'T use post_install)
@@ -1188,21 +1188,31 @@ function persist_data($manifest, $original_dir, $persist_dir) {
     }
 }
 
-function unlink_persist_data($dir) {
+function unlink_persist_data($manifest, $dir) {
+    $persist = $manifest.persist
     # unlink all junction / hard link in the directory
-    Get-ChildItem -Recurse $dir | ForEach-Object {
-        $file = $_
-        if ($null -ne $file.LinkType) {
-            $filepath = $file.FullName
-            # directory (junction)
-            if ($file -is [System.IO.DirectoryInfo]) {
-                # remove read-only attribute on the link
-                attrib -R /L $filepath
-                # remove the junction
-                & "$env:COMSPEC" /c "rmdir /s /q `"$filepath`""
-            } else {
-                # remove the hard link
-                & "$env:COMSPEC" /c "del `"$filepath`""
+    if($persist) {
+        if ($persist -is [String]) {
+            $persist = @($persist);
+        }
+
+        $persist | ForEach-Object {
+            $source, $target = persist_def $_
+            write-host "Unlink persisted: $source"
+            $source = $source.TrimEnd("/").TrimEnd("\\")
+            $source = Get-Item "$dir\$source"
+            if ($null -ne $source.LinkType) {
+                $source_path = $source.FullName
+                # directory (junction)
+                if ($source -is [System.IO.DirectoryInfo]) {
+                    # remove read-only attribute on the link
+                    attrib -R /L $source_path
+                    # remove the junction
+                    & "$env:COMSPEC" /c "rmdir /s /q `"$source_path`""
+                } else {
+                    # remove the hard link
+                    & "$env:COMSPEC" /c "del `"$source_path`""
+                }
             }
         }
     }

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -47,7 +47,7 @@ function cleanup($app, $global, $verbose, $cache) {
         write-host " $version" -nonewline
         $dir = versiondir $app $version $global
         # unlink all potential old link before doing recursive Remove-Item
-        unlink_persist_data $dir
+        unlink_persist_data $manifest $dir
         Remove-Item $dir -ErrorAction Stop -Recurse -Force
     }
     write-host ''

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -84,7 +84,7 @@ $apps | ForEach-Object {
     env_add_path $manifest $dir $global $architecture
     env_set $manifest $dir $global $architecture
     # unlink all potential old link before re-persisting
-    unlink_persist_data $original_dir
+    unlink_persist_data $manifest $original_dir
     persist_data $manifest $original_dir $persist_dir
     persist_permission $manifest $global
 }

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -91,7 +91,7 @@ if (!$apps) { exit 0 }
 
     try {
         # unlink all potential old link before doing recursive Remove-Item
-        unlink_persist_data $dir
+        unlink_persist_data $manifest $dir
         Remove-Item $dir -Recurse -Force -ErrorAction Stop
     } catch {
         if (Test-Path $dir) {
@@ -107,7 +107,7 @@ if (!$apps) { exit 0 }
         $dir = versiondir $app $oldver $global
         try {
             # unlink all potential old link before doing recursive Remove-Item
-            unlink_persist_data $dir
+            unlink_persist_data $manifest $dir
             Remove-Item $dir -Recurse -Force -ErrorAction Stop
         } catch {
             error "Couldn't remove '$(friendly_path $dir)'; it may be in use."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

My commit involved two changes:

1. when uninstall or reset <app>, avoid checking all files for unlink persisted data in function `unlink_persist_data`. It will take a long time to check all the files when the <app> contains a great deal of files by itself or would produce many new file in the daily usage. For example: `miniconda3` and `anaconda3` kick in above two situation and would produce many new hard-link file when installing new environments.

2. when shim, add `-CommandType:Application` option to `git`. This is not that vital but it could cause problem if `git` is defined as a `powershell` function by user like me

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I reset all my scoop apps (every kinds of app from every kinds of bucket, 482 apps in total), and the whole process worked well.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
