### PR TITLE
Do not try to set read only property values in the normalize_values function

### DIFF
--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -179,7 +179,7 @@ function normalize_values([psobject] $json) {
             }
         }
 		
-		# Convert single value array into string
+        # Convert single value array into string
         if (($_.Value -is [Array]) -and $_.IsSettable) {
             # Array contains only 1 element String or Array
             if ($_.Value.Count -eq 1) {

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -178,9 +178,9 @@ function normalize_values([psobject] $json) {
                 $_.Value = $parts
             }
         }
-
-        # Convert single value array into string
-        if ($_.Value -is [Array]) {
+		
+		# Convert single value array into string
+        if (($_.Value -is [Array]) -and $_.IsSettable) {
             # Array contains only 1 element String or Array
             if ($_.Value.Count -eq 1) {
                 # Array


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
I added to an if statement to exclude properties that are not settable.

#### Motivation and Context
The normalize_values uses reflection to flatten array values on properties into single strings. This fails if the object has read only properties. Under clean circumstances, I guess this maybe doesn't happen, but in my case I add some properties via extensions and the "$_.Value = whatever" lines throw exceptions that display in the console as errors.

#### How Has This Been Tested?
I have been using this changed code for myself and things work without errors now. I also ran the 

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly. <- I could not figure out how to run the tests without errors (even without my change). I installed pester and ran invoke-pester from the scoop source directory
