### PR TITLE
refactor(COMSPEC): Deprecate use of subshell cmd.exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - **depends:** Keep bucket in 'Get-Dependency()' ([#4673](https://github.com/ScoopInstaller/Scoop/issues/4673))
 - **mklink:** Use 'New-Item' instead of 'mklink' ([#4690](https://github.com/ScoopInstaller/Scoop/issues/4690))
 - **rmdir:** Use 'Remove-Item' instead of 'rmdir' ([#4691](https://github.com/ScoopInstaller/Scoop/issues/4691))
+- **COMSPEC:** Deprecate use of subshell cmd.exe ([#4692](https://github.com/ScoopInstaller/Scoop/pull/4692))
 
 ### Builds
 

--- a/lib/diagnostic.ps1
+++ b/lib/diagnostic.ps1
@@ -55,13 +55,3 @@ function check_long_paths {
     return $true
 }
 
-function check_envs_requirements {
-    if ($null -eq $env:COMSPEC) {
-        warn '$env:COMSPEC environment variable is missing.'
-        Write-Host "    By default the variable should point to the cmd.exe in Windows: '%SystemRoot%\system32\cmd.exe'."
-
-        return $false
-    }
-
-    return $true
-}

--- a/lib/git.ps1
+++ b/lib/git.ps1
@@ -4,7 +4,7 @@ function git_proxy_cmd {
     if($proxy -and $proxy -ne 'none') {
         $cmd = "SET HTTPS_PROXY=$proxy&&SET HTTP_PROXY=$proxy&&$cmd"
     }
-    & "$env:COMSPEC" /d /c $cmd
+    cmd.exe /d /c $cmd
 }
 
 function git_clone {

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -12,7 +12,6 @@ $issues += !(check_windows_defender $false)
 $issues += !(check_windows_defender $true)
 $issues += !(check_main_bucket)
 $issues += !(check_long_paths)
-$issues += !(check_envs_requirements)
 
 if (!(Test-HelperInstalled -Helper 7zip)) {
     error "'7-Zip' is not installed! It's required for unpacking most programs. Please Run 'scoop install 7zip' or 'scoop install 7zip-zstd'."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
It is possible that COMSPEC is undefined/empty, or some people even set it to powershell instead of cmd (extremely dangerous). 

We only use COMSPEC in one place now, in lib/git.ps1, so I replaced that with the actual binary name (which will always exist).

Also removed the function which tested COMSPEC's existence.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #3845
<!-- or -->

#### How Has This Been Tested?
No functional changes, so not tested.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
