### PR TITLE
refactor(git): Use 'git -C' to specify the work directory instead of 'Push-Location'/'Pop-Location'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - **mklink:** Use 'New-Item' instead of 'mklink' ([#4690](https://github.com/ScoopInstaller/Scoop/issues/4690))
 - **rmdir:** Use 'Remove-Item' instead of 'rmdir' ([#4691](https://github.com/ScoopInstaller/Scoop/issues/4691))
 - **COMSPEC:** Deprecate use of subshell cmd.exe ([#4692](https://github.com/ScoopInstaller/Scoop/pull/4692))
-- **git:** Use 'git -C' to specify the work directory instead of 'Push-Location'/'Pop-Location'. ([#4697](https://github.com/ScoopInstaller/Scoop/pull/4697))
+- **git:** Use 'git -C' to specify the work directory instead of 'Push-Location'/'Pop-Location' ([#4697](https://github.com/ScoopInstaller/Scoop/pull/4697))
 
 ### Builds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - **mklink:** Use 'New-Item' instead of 'mklink' ([#4690](https://github.com/ScoopInstaller/Scoop/issues/4690))
 - **rmdir:** Use 'Remove-Item' instead of 'rmdir' ([#4691](https://github.com/ScoopInstaller/Scoop/issues/4691))
 - **COMSPEC:** Deprecate use of subshell cmd.exe ([#4692](https://github.com/ScoopInstaller/Scoop/pull/4692))
+- **git:** Use 'git -C' to specify the work directory instead of 'Push-Location'/'Pop-Location'. ([#4697](https://github.com/ScoopInstaller/Scoop/pull/4697))
 
 ### Builds
 

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -12,20 +12,17 @@ reset_aliases
 
 $commands = commands
 if ('--version' -contains $cmd -or (!$cmd -and '-v' -contains $args)) {
-    Push-Location $(versiondir 'scoop' 'current')
-    write-host "Current Scoop version:"
-    Invoke-Expression "git --no-pager log --oneline HEAD -n 1"
-    write-host ""
-    Pop-Location
+    Write-Host "Current Scoop version:"
+    Invoke-Expression "git -C '$(versiondir 'scoop' 'current')' --no-pager log --oneline HEAD -n 1"
+    Write-Host ""
 
     Get-LocalBucket | ForEach-Object {
-        Push-Location (Find-BucketDirectory $_ -Root)
-        if(test-path '.git') {
-            write-host "'$_' bucket:"
-            Invoke-Expression "git --no-pager log --oneline HEAD -n 1"
-            write-host ""
+        $bucket =  (Find-BucketDirectory $_ -Root)
+        if(Test-Path "$bucket\.git") {
+            Write-Host "'$_' bucket:"
+            Invoke-Expression "git -C '$bucket' --no-pager log --oneline HEAD -n 1"
+            Write-Host ""
         }
-        Pop-Location
     }
 }
 elseif (@($null, '--help', '/?') -contains $cmd -or $args[0] -contains '-h') { exec 'help' $args }

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -17,10 +17,10 @@ if ('--version' -contains $cmd -or (!$cmd -and '-v' -contains $args)) {
     Write-Host ""
 
     Get-LocalBucket | ForEach-Object {
-        $bucket =  (Find-BucketDirectory $_ -Root)
-        if(Test-Path "$bucket\.git") {
+        $bucketLoc =  Find-BucketDirectory $_ -Root
+        if(Test-Path (Join-Path $bucketLoc '.git')) {
             Write-Host "'$_' bucket:"
-            Invoke-Expression "git -C '$bucket' --no-pager log --oneline HEAD -n 1"
+            Invoke-Expression "git -C '$bucketLoc' --no-pager log --oneline HEAD -n 1"
             Write-Host ""
         }
     }

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -127,14 +127,12 @@ function new_issue_msg($app, $bucket, $title, $body) {
     $bucket_path = "$bucketsdir\$bucket"
 
     if (Test-path $bucket_path) {
-        Push-Location $bucket_path
-        $remote = Invoke-Expression "git config --get remote.origin.url"
+        $remote = Invoke-Expression "git -C '$bucket_path' config --get remote.origin.url"
         # Support ssh and http syntax
         # git@PROVIDER:USER/REPO.git
         # https://PROVIDER/USER/REPO.git
         $remote -match '(@|:\/\/)(?<provider>.+)[:/](?<user>.*)\/(?<repo>.*)(\.git)?$' | Out-Null
         $url = "https://$($Matches.Provider)/$($Matches.User)/$($Matches.Repo)"
-        Pop-Location
     }
 
     if(!$url) { return 'Please contact the bucket maintainer!' }

--- a/lib/git.ps1
+++ b/lib/git.ps1
@@ -1,7 +1,7 @@
 function git_proxy_cmd {
     $proxy = get_config 'proxy'
     $cmd = "git $($args | ForEach-Object { "$_ " })"
-    if($proxy -and $proxy -ne 'none') {
+    if ($proxy -and $proxy -ne 'none') {
         $cmd = "SET HTTPS_PROXY=$proxy&&SET HTTP_PROXY=$proxy&&$cmd"
     }
     cmd.exe /d /c $cmd
@@ -13,22 +13,6 @@ function git_clone {
 
 function git_ls_remote {
     git_proxy_cmd ls-remote $args
-}
-
-function git_checkout {
-    git_proxy_cmd checkout $args
-}
-
-function git_pull {
-    git_proxy_cmd pull --rebase=false $args
-}
-
-function git_fetch {
-    git_proxy_cmd fetch $args
-}
-
-function git_checkout {
-    git_proxy_cmd checkout $args
 }
 
 function git_cmd {

--- a/lib/git.ps1
+++ b/lib/git.ps1
@@ -30,3 +30,7 @@ function git_fetch {
 function git_checkout {
     git_proxy_cmd checkout $args
 }
+
+function git_cmd {
+    git_proxy_cmd $args
+}

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -22,7 +22,6 @@ param($cmd, $name, $repo)
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\buckets.ps1"
 . "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\git.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -14,12 +14,10 @@ reset_aliases
 $currentdir = fullpath $(versiondir 'scoop' 'current')
 $needs_update = $false
 
-if(test-path "$currentdir\.git") {
-    Push-Location $currentdir
-    git_fetch -q origin
-    $commits = $(git log "HEAD..origin/$(scoop config SCOOP_BRANCH)" --oneline)
+if(Test-Path "$currentdir\.git") {
+    git_cmd -C "`"$currentdir`"" fetch -q origin
+    $commits = $(git -C "`"$currentdir`"" log "HEAD..origin/$(scoop config SCOOP_BRANCH)" --oneline)
     if($commits) { $needs_update = $true }
-    Pop-Location
 }
 else {
     $needs_update = $true
@@ -39,7 +37,7 @@ $onhold = @()
 $true, $false | ForEach-Object { # local and global apps
     $global = $_
     $dir = appsdir $global
-    if(!(test-path $dir)) { return }
+    if(!(Test-Path $dir)) { return }
 
     Get-ChildItem $dir | Where-Object name -ne 'scoop' | ForEach-Object {
         $app = $_.name
@@ -63,7 +61,7 @@ $true, $false | ForEach-Object { # local and global apps
 }
 
 if($outdated) {
-    write-host -f DarkCyan 'Updates are available for:'
+    Write-Host -f DarkCyan 'Updates are available for:'
     $outdated.keys | ForEach-Object {
         $versions = $outdated.$_
         "    $_`: $($versions[0]) -> $($versions[1])"
@@ -71,7 +69,7 @@ if($outdated) {
 }
 
 if($onhold) {
-    write-host -f DarkCyan 'These apps are outdated and on hold:'
+    Write-Host -f DarkCyan 'These apps are outdated and on hold:'
     $onhold.keys | ForEach-Object {
         $versions = $onhold.$_
         "    $_`: $($versions[0]) -> $($versions[1])"
@@ -79,21 +77,21 @@ if($onhold) {
 }
 
 if($removed) {
-    write-host -f DarkCyan 'These app manifests have been removed:'
+    Write-Host -f DarkCyan 'These app manifests have been removed:'
     $removed.keys | ForEach-Object {
         "    $_"
     }
 }
 
 if($failed) {
-    write-host -f DarkCyan 'These apps failed to install:'
+    Write-Host -f DarkCyan 'These apps failed to install:'
     $failed.keys | ForEach-Object {
         "    $_"
     }
 }
 
 if($missing_deps) {
-    write-host -f DarkCyan 'Missing runtime dependencies:'
+    Write-Host -f DarkCyan 'Missing runtime dependencies:'
     $missing_deps | ForEach-Object {
         $app, $deps = $_
         "    '$app' requires '$([string]::join("', '", $deps))'"

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -63,20 +63,20 @@ function update_scoop() {
     # check for git
     if(!(Test-CommandAvailable git)) { abort "Scoop uses Git to update itself. Run 'scoop install git' and try again." }
 
-    write-host "Updating Scoop..."
+    Write-Host "Updating Scoop..."
     $last_update = $(last_scoop_update)
     if ($null -eq $last_update) {$last_update = [System.DateTime]::Now}
     $last_update = $last_update.ToString('s')
     $show_update_log = get_config 'show_update_log' $true
     $currentdir = fullpath $(versiondir 'scoop' 'current')
-    if (!(test-path "$currentdir\.git")) {
+    if (!(Test-Path "$currentdir\.git")) {
         $newdir = fullpath $(versiondir 'scoop' 'new')
 
         # get git scoop
         git_clone -q $configRepo --branch $configBranch --single-branch "`"$newdir`""
 
         # check if scoop was successful downloaded
-        if (!(test-path "$newdir")) {
+        if (!(Test-Path "$newdir")) {
             abort 'Scoop update failed.'
         }
 
@@ -84,40 +84,37 @@ function update_scoop() {
         Remove-Item -r -force $currentdir -ea stop
         Move-Item $newdir $currentdir
     } else {
-        Push-Location $currentdir
-
-        $previousCommit = Invoke-Expression 'git rev-parse HEAD'
-        $currentRepo = Invoke-Expression "git config remote.origin.url"
-        $currentBranch = Invoke-Expression "git branch"
+        $previousCommit = Invoke-Expression "git -C '$currentdir' rev-parse HEAD"
+        $currentRepo = Invoke-Expression "git -C '$currentdir' config remote.origin.url"
+        $currentBranch = Invoke-Expression "git -C '$currentdir' branch"
 
         $isRepoChanged = !($currentRepo -match $configRepo)
         $isBranchChanged = !($currentBranch -match "\*\s+$configBranch")
 
         # Change remote url if the repo is changed
         if ($isRepoChanged) {
-            Invoke-Expression "git config remote.origin.url '$configRepo'"
+            Invoke-Expression "git -C '$currentdir' config remote.origin.url '$configRepo'"
         }
 
         # Fetch and reset local repo if the repo or the branch is changed
         if ($isRepoChanged -or $isBranchChanged) {
             # Reset git fetch refs, so that it can fetch all branches (GH-3368)
-            Invoke-Expression "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
+            Invoke-Expression "git -C '$currentdir' config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
             # fetch remote branch
-            git_fetch --force origin "refs/heads/`"$configBranch`":refs/remotes/origin/$configBranch" -q
+            git_cmd -C "`"$currentdir`"" fetch --force origin "refs/heads/`"$configBranch`":refs/remotes/origin/$configBranch" -q
             # checkout and track the branch
-            git_checkout -B $configBranch -t origin/$configBranch -q
+            git_cmd -C "`"$currentdir`"" checkout -B $configBranch -t origin/$configBranch -q
             # reset branch HEAD
-            Invoke-Expression "git reset --hard origin/$configBranch -q"
+            Invoke-Expression "git -C '$currentdir' reset --hard origin/$configBranch -q"
         } else {
-            git_pull -q
+            git_cmd -C "`"$currentdir`"" pull -q
         }
 
         $res = $lastexitcode
         if ($show_update_log) {
-            Invoke-Expression "git --no-pager log --no-decorate --grep='^chore' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
+            Invoke-Expression "git -C '$currentdir' --no-pager log --no-decorate --grep='^chore' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
         }
 
-        Pop-Location
         if ($res -ne 0) {
             abort 'Update failed.'
         }
@@ -150,13 +147,11 @@ function update_scoop() {
             continue
         }
 
-        Push-Location $bucketLoc
-        $previousCommit = (Invoke-Expression 'git rev-parse HEAD')
-        git_pull -q
+        $previousCommit = (Invoke-Expression "git -C '$bucketLoc' rev-parse HEAD")
+        git_cmd -C "`"$bucketLoc`"" pull -q
         if ($show_update_log) {
-            Invoke-Expression "git --no-pager log --no-decorate --grep='^chore' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
+            Invoke-Expression "git -C '$bucketLoc' --no-pager log --no-decorate --grep='^chore' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
         }
-        Pop-Location
     }
 
     set_config lastupdate ([System.DateTime]::Now.ToString('o')) | Out-Null
@@ -196,7 +191,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
         return
     }
 
-    write-host "Updating '$app' ($old_version -> $version)"
+    Write-Host "Updating '$app' ($old_version -> $version)"
 
     # region Workaround
     # Workaround for https://github.com/ScoopInstaller/Scoop/issues/2220 until install is refactored
@@ -217,7 +212,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
 
                 if (!$ok) {
                     error $err
-                    if (test-path $source) {
+                    if (Test-Path $source) {
                         # rm cached file
                         Remove-Item -force $source
                     }
@@ -244,7 +239,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     }
     #endregion Workaround for #2952
 
-    write-host "Uninstalling '$app' ($old_version)"
+    Write-Host "Uninstalling '$app' ($old_version)"
     run_uninstaller $old_manifest $architecture $dir
     rm_shims $old_manifest $global $architecture
     env_rm_path $old_manifest $dir $global $architecture
@@ -319,7 +314,7 @@ if (-not ($apps -or $all)) {
             if ($status.installed -and ($force -or $status.outdated)) {
                 if(!$status.hold) {
                     $outdated += applist $app $global
-                    write-host -f yellow ("$app`: $($status.version) -> $($status.latest_version){0}" -f ('',' (global)')[$global])
+                    Write-Host -f yellow ("$app`: $($status.version) -> $($status.latest_version){0}" -f ('',' (global)')[$global])
                 } else {
                     warn "'$app' is held to version $($status.version)"
                 }
@@ -338,11 +333,11 @@ if (-not ($apps -or $all)) {
             warn "To disable this warning, run 'scoop config aria2-warning-enabled false'."
         }
         if ($outdated.Length -gt 1) {
-            write-host -f DarkCyan "Updating $($outdated.Length) outdated apps:"
+            Write-Host -f DarkCyan "Updating $($outdated.Length) outdated apps:"
         } elseif ($outdated.Length -eq 0) {
-            write-host -f Green "Latest versions for all apps are installed! For more information try 'scoop status'"
+            Write-Host -f Green "Latest versions for all apps are installed! For more information try 'scoop status'"
         } else {
-            write-host -f DarkCyan "Updating one outdated app:"
+            Write-Host -f DarkCyan "Updating one outdated app:"
         }
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
no longer using `Push-Location` to change work directory before executing git operations

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #4358 
Fixes #4675

send ^C(SIGINT) will change current directory to bucket path, when scoop is updating buckets.

solve:
using command options `-C` to specify the work directory for git, then no longer need to change the \<work directory> with `Push-Location` and `Pop-Location`.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

before:
```
PS C:\Users\WDAGUtilityAccount> scoop update
Updating Scoop...
Updating 'main' bucket...
^C
PS C:\Users\WDAGUtilityAccount\scoop\buckets\main>
```
after:
```
PS C:\Users\WDAGUtilityAccount> scoop update
Updating Scoop...
Updating 'main' bucket...
^C
PS C:\Users\WDAGUtilityAccount>
```

tested on PS 5.1 and PS Core 7.2 in sandbox, the changes will not affect other areas.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
