### PR TITLE
fix(autoupdate): rename $response to $res

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -152,7 +152,7 @@ function find_hash_in_headers([String] $url) {
         $req.Timeout = 2000
         $req.Method = 'HEAD'
         $res = $req.GetResponse()
-        if(([int]$response.StatusCode -ge 300) -and ([int]$response.StatusCode -lt 400)) {
+        if(([int]$res.StatusCode -ge 300) -and ([int]$res.StatusCode -lt 400)) {
             if($res.Headers['Digest'] -match 'SHA-256=([^,]+)' -or $res.Headers['Digest'] -match 'SHA=([^,]+)' -or $res.Headers['Digest'] -match 'MD5=([^,]+)') {
                 $hash = ([System.Convert]::FromBase64String($matches[1]) | ForEach-Object { $_.ToString('x2') }) -join ''
                 debug $hash


### PR DESCRIPTION
#### Description
Rename variable from "$response" to "$res"

#### Motivation and Context


#### How Has This Been Tested?


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
