### PR TITLE
refactor(diagnostic,scoop-checkup): Improvements for 'check_windows_defender' and 'scoop-checkup'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 - **mklink:** Use 'New-Item' instead of 'mklink' ([#4690](https://github.com/ScoopInstaller/Scoop/issues/4690))
 - **rmdir:** Use 'Remove-Item' instead of 'rmdir' ([#4691](https://github.com/ScoopInstaller/Scoop/issues/4691))
 - **COMSPEC:** Deprecate use of subshell cmd.exe ([#4692](https://github.com/ScoopInstaller/Scoop/pull/4692))
+- **diagnostic** Downgrade defender checks from 'WARN' to 'INFO' ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
+- **diagnostic** Skip check for 'exclusionPath' if defender realtime protect is disabled ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
+- **scoop-checkup** Skip 'check_windows_defender' when have not admin privileges ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
+- **scoop-checkup** Separate defender issues, mark as performance problem instead potential problem ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 
 ### Builds
 

--- a/lib/diagnostic.ps1
+++ b/lib/diagnostic.ps1
@@ -7,9 +7,10 @@ Use 'warn' to highlight the issue, and follow up with the recommended actions to
 
 function check_windows_defender($global) {
     $defender = Get-Service -Name WinDefend -ErrorAction SilentlyContinue
-    if ($defender -and $defender.Status) {
-        if ($defender.Status -eq [System.ServiceProcess.ServiceControllerStatus]::Running) {
-            if (Test-CommandAvailable Get-MpPreference) {
+    if (Test-CommandAvailable Get-MpPreference) {
+        if ((Get-MpPreference).DisableRealtimeMonitoring) { return $true }
+        if ($defender -and $defender.Status) {
+            if ($defender.Status -eq [System.ServiceProcess.ServiceControllerStatus]::Running) {
                 $installPath = $scoopdir;
                 if ($global) { $installPath = $globaldir; }
 

--- a/lib/diagnostic.ps1
+++ b/lib/diagnostic.ps1
@@ -6,19 +6,19 @@ Use 'warn' to highlight the issue, and follow up with the recommended actions to
 . "$PSScriptRoot\buckets.ps1"
 
 function check_windows_defender($global) {
-    $defender = get-service -name WinDefend -errorAction SilentlyContinue
-    if($defender -and $defender.status) {
-        if($defender.status -eq [system.serviceprocess.servicecontrollerstatus]::running) {
+    $defender = Get-Service -Name WinDefend -ErrorAction SilentlyContinue
+    if ($defender -and $defender.Status) {
+        if ($defender.Status -eq [System.ServiceProcess.ServiceControllerStatus]::Running) {
             if (Test-CommandAvailable Get-MpPreference) {
                 $installPath = $scoopdir;
-                if($global) { $installPath = $globaldir; }
+                if ($global) { $installPath = $globaldir; }
 
-                $exclusionPath = (Get-MpPreference).exclusionPath
-                if(!($exclusionPath -contains $installPath)) {
-                    warn "Windows Defender may slow down or disrupt installs with realtime scanning."
-                    write-host "  Consider running:"
-                    write-host "    sudo Add-MpPreference -ExclusionPath '$installPath'"
-                    write-host "  (Requires 'sudo' command. Run 'scoop install sudo' if you don't have it.)"
+                $exclusionPath = (Get-MpPreference).ExclusionPath
+                if (!($exclusionPath -contains $installPath)) {
+                    info "Windows Defender may slow down or disrupt installs with realtime scanning."
+                    Write-Host "  Consider running:"
+                    Write-Host "    sudo Add-MpPreference -ExclusionPath '$installPath'"
+                    Write-Host "  (Requires 'sudo' command. Run 'scoop install sudo' if you don't have it.)"
                     return $false
                 }
             }
@@ -28,7 +28,7 @@ function check_windows_defender($global) {
 }
 
 function check_main_bucket {
-    if ((Get-LocalBucket) -notcontains 'main'){
+    if ((Get-LocalBucket) -notcontains 'main') {
         warn 'Main bucket is not added.'
         Write-Host "  run 'scoop bucket add main'"
 

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -7,9 +7,15 @@
 . "$psscriptroot\..\lib\diagnostic.ps1"
 
 $issues = 0
+$defenderIssues = 0
 
-$issues += !(check_windows_defender $false)
-$issues += !(check_windows_defender $true)
+$adminPrivileges = ([System.Security.Principal.WindowsPrincipal] [System.Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+
+if ($adminPrivileges) {
+    $defenderIssues += !(check_windows_defender $false)
+    $defenderIssues += !(check_windows_defender $true)
+}
+
 $issues += !(check_main_bucket)
 $issues += !(check_long_paths)
 
@@ -29,19 +35,23 @@ if (!(Test-HelperInstalled -Helper Dark)) {
 }
 
 $globaldir = New-Object System.IO.DriveInfo($globaldir)
-if($globaldir.DriveFormat -ne 'NTFS') {
+if ($globaldir.DriveFormat -ne 'NTFS') {
     error "Scoop requires an NTFS volume to work! Please point `$env:SCOOP_GLOBAL or 'globalPath' variable in '~/.config/scoop/config.json' to another Drive."
     $issues++
 }
 
 $scoopdir = New-Object System.IO.DriveInfo($scoopdir)
-if($scoopdir.DriveFormat -ne 'NTFS') {
+if ($scoopdir.DriveFormat -ne 'NTFS') {
     error "Scoop requires an NTFS volume to work! Please point `$env:SCOOP or 'rootPath' variable in '~/.config/scoop/config.json' to another Drive."
     $issues++
 }
 
-if($issues) {
-    warn "Found $issues potential $(pluralize $issues problem problems)."
+if ($issues + $defenderIssues) {
+    if ($issues) { warn "Found $issues potential $(pluralize $issues problem problems)." }
+    if ($defenderIssues) {
+        info "Found $defenderIssues performance $(pluralize $defenderIssues problem problems)."
+        warn "Security is more important than performance, in most cases."
+    }
 } else {
     success "No problems identified!"
 }

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -46,12 +46,11 @@ if ($scoopdir.DriveFormat -ne 'NTFS') {
     $issues++
 }
 
-if ($issues + $defenderIssues) {
-    if ($issues) { warn "Found $issues potential $(pluralize $issues problem problems)." }
-    if ($defenderIssues) {
-        info "Found $defenderIssues performance $(pluralize $defenderIssues problem problems)."
-        warn "Security is more important than performance, in most cases."
-    }
+if ($issues) {
+    warn "Found $issues potential $(pluralize $issues problem problems)."
+} elseif ($defenderIssues) {
+    info "Found $defenderIssues performance $(pluralize $defenderIssues problem problems)."
+    warn "Security is more important than performance, in most cases."
 } else {
     success "No problems identified!"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
- Skip `check_windows_defender` when have not admin privileges
- Separate defender issues($defenderIssues), mark as performance problem instead potential problem
- Add a security tips (display when defender issues are found)
- Skip check for ExclusionPath, if defender realtime protect is disabled (there no way to distinguish between temporary and permanen disable, for now)
- Downgrade `check_windows_defender` checks output from `WARN` to `INFO` (it may also be an Upgrade, in some views)

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #4098

Relates to #4591 #4551

#### How Has This Been Tested?
```
> scoop checkup
No problems identified!

> sudo scoop checkup
INFO  Windows Defender may slow down or disrupt installs with realtime scanning.
  Consider running:
    sudo Add-MpPreference -ExclusionPath 'C:\Users\HUMOR\scoop'
  (Requires 'sudo' command. Run 'scoop install sudo' if you don't have it.)
INFO  Windows Defender may slow down or disrupt installs with realtime scanning.
  Consider running:
    sudo Add-MpPreference -ExclusionPath 'C:\ProgramData\scoop'
  (Requires 'sudo' command. Run 'scoop install sudo' if you don't have it.)
INFO  Found 2 performance problems.
WARN  Security is more important than performance, in most cases.

// disable defender realtime protect (temporary)
> sudo scoop checkup
No problems identified!

// disable defender realtime protect (group policy)
> sudo scoop checkup
No problems identified!
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
