### PR TITLE
feat(scoop-bucket): List more detailed information for buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - **diagnostic** Skip check for 'exclusionPath' if defender realtime protect is disabled ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Skip 'check_windows_defender' when have not admin privileges ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Separate defender issues, mark as performance problem instead potential problem ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
+- **scoop-bucket** Show source/lastupdate for buckets list ([#4704](https://github.com/ScoopInstaller/Scoop/pull/4704))
 
 ### Builds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - **scoop-download:** Add `scoop download` command ([#4621](https://github.com/ScoopInstaller/Scoop/issues/4621))
 - **scoop-(install|virustotal):** Allow skipping update check ([#4634](https://github.com/ScoopInstaller/Scoop/issues/4634))
+- **scoop-bucket:** List more detailed information for buckets ([#4704](https://github.com/ScoopInstaller/Scoop/pull/4704))
 
 ### Bug Fixes
 
@@ -37,7 +38,6 @@
 - **diagnostic** Skip check for 'exclusionPath' if defender realtime protect is disabled ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Skip 'check_windows_defender' when have not admin privileges ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Separate defender issues, mark as performance problem instead potential problem ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
-- **scoop-bucket** Show detailed information for bucket list ([#4704](https://github.com/ScoopInstaller/Scoop/pull/4704))
 
 ### Builds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - **diagnostic** Skip check for 'exclusionPath' if defender realtime protect is disabled ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Skip 'check_windows_defender' when have not admin privileges ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Separate defender issues, mark as performance problem instead potential problem ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
-- **scoop-bucket** Show source/lastupdate for buckets list ([#4704](https://github.com/ScoopInstaller/Scoop/pull/4704))
+- **scoop-bucket** Show detailed information for bucket list ([#4704](https://github.com/ScoopInstaller/Scoop/pull/4704))
 
 ### Builds
 

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -52,7 +52,7 @@ function list_buckets {
             Manifests = $manifests
         }
     }
-    return ($buckets | Select-Object Name, Source, Updated, Manifests | Out-String).Trim()
+    return $buckets | Select-Object Name, Source, Updated, Manifests
 }
 
 switch ($cmd) {

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -39,7 +39,7 @@ function list_buckets {
         )
         $updated = 'N/A'
         if (Test-Path (Join-Path $source '.git')) {
-            $updated = git_cmd -C "`"$source`"" log --date=format:`""%Y-%m-%d %H:%M:%S`"" --format='%ad' -n 1
+            $updated = git_cmd -C "`"$source`"" log --date=format:"`"%Y-%m-%d %H:%M:%S`"" --format='%ad' -n 1
             $source = git_cmd -C "`"$source`"" config remote.origin.url
         } else {
             $updated = (Get-Item "$source\bucket").LastAccessTime | Get-Date -Format 'yyyy-MM-dd HH:mm:ss'

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -35,8 +35,8 @@ function list_buckets {
         $source = Find-BucketDirectory $bucket -Root
         $updated = 'N/A'
         if (Test-Path (Join-Path $source '.git')) {
-            $updated = git_cmd -C "`"$source`"" log --date=iso-local --pretty=format:'%ch' -n 1
-            $source = git_cmd -C "`"$source`"" remote get-url origin
+            $updated = git_cmd -C "`"$source`"" log --format='%ch' -n 1
+            $source = git_cmd -C "`"$source`"" config remote.origin.url
         }
         if ($source.StartsWith((Get-PSProvider 'FileSystem').Home)) {
             $source = $source.Replace((Get-PSProvider 'FileSystem').Home, '~')

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -41,9 +41,8 @@ function list_buckets {
         if (Test-Path (Join-Path $source '.git')) {
             $updated = git_cmd -C "`"$source`"" log --format='%ch' -n 1
             $source = git_cmd -C "`"$source`"" config remote.origin.url
-        }
-        if ($source.StartsWith((Get-PSProvider 'FileSystem').Home)) {
-            $source = $source.Replace((Get-PSProvider 'FileSystem').Home, '~')
+        } else {
+            $source = friendly_path $source
         }
 
         $buckets += New-Object PSObject -Property @{

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -39,9 +39,10 @@ function list_buckets {
         )
         $updated = 'N/A'
         if (Test-Path (Join-Path $source '.git')) {
-            $updated = git_cmd -C "`"$source`"" log --format='%ch' -n 1
+            $updated = git_cmd -C "`"$source`"" log --date=format:`""%Y-%m-%d %H:%M:%S`"" --format='%ad' -n 1
             $source = git_cmd -C "`"$source`"" config remote.origin.url
         } else {
+            $updated = (Get-Item "$source\bucket").LastAccessTime | Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
             $source = friendly_path $source
         }
 

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -45,7 +45,6 @@ function list_buckets {
             $updated = (Get-Item "$source\bucket").LastWriteTime | Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
             $source = friendly_path $source
         }
-
         $buckets += New-Object PSObject -Property @{
             Name      = $bucket
             Source    = $source
@@ -53,8 +52,7 @@ function list_buckets {
             Manifests = $manifests
         }
     }
-
-    return $buckets | Select-Object Name, Source, Updated, Manifests
+    return ($buckets | Select-Object Name, Source, Updated, Manifests | Out-String).Trim()
 }
 
 switch ($cmd) {

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -55,8 +55,6 @@ function list_buckets {
     }
 
     return $buckets | Select-Object Name, Manifests, Source, Updated
-
-    Write-Host
 }
 
 switch ($cmd) {

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -19,9 +19,9 @@
 #     scoop bucket known
 param($cmd, $name, $repo)
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-. "$psscriptroot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
 
 reset_aliases
 
@@ -38,7 +38,7 @@ function list_buckets {
             $updated = git_cmd -C "`"$source`"" log --date=iso-local --pretty=format:'%ch' -n 1
             $source = git_cmd -C "`"$source`"" remote get-url origin
         }
-        if ($source.Contains((Get-PSProvider 'FileSystem').Home)) {
+        if ($source.StartsWith((Get-PSProvider 'FileSystem').Home)) {
             $source = $source.Replace((Get-PSProvider 'FileSystem').Home, '~')
         }
 

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -49,7 +49,7 @@ function list_buckets {
         }
     }
 
-    return $buckets | Select-Object Name, Source, Updated | Format-Table -AutoSize -Wrap
+    return $buckets | Select-Object Name, Source, Updated
 }
 
 switch ($cmd) {

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -42,7 +42,11 @@ function list_buckets {
             $source = $source.Replace((Get-PSProvider 'FileSystem').Home, '~')
         }
 
-        $buckets += New-Object psobject -Property @{Name = $bucket; Source = $source; Updated = $updated }
+        $buckets += New-Object PSObject -Property @{
+            Name    = $bucket
+            Source  = $source
+            Updated = $updated
+        }
     }
 
     return $buckets | Select-Object Name, Source, Updated | Format-Table -AutoSize -Wrap

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -42,7 +42,7 @@ function list_buckets {
             $updated = git_cmd -C "`"$source`"" log --date=format:"`"%Y-%m-%d %H:%M:%S`"" --format='%ad' -n 1
             $source = git_cmd -C "`"$source`"" config remote.origin.url
         } else {
-            $updated = (Get-Item "$source\bucket").LastAccessTime | Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+            $updated = (Get-Item "$source\bucket").LastWriteTime | Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
             $source = friendly_path $source
         }
 

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -48,13 +48,13 @@ function list_buckets {
 
         $buckets += New-Object PSObject -Property @{
             Name      = $bucket
-            Manifests = $manifests
             Source    = $source
             Updated   = $updated
+            Manifests = $manifests
         }
     }
 
-    return $buckets | Select-Object Name, Manifests, Source, Updated
+    return $buckets | Select-Object Name, Source, Updated, Manifests
 }
 
 switch ($cmd) {

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -33,6 +33,10 @@ function list_buckets {
 
     foreach ($bucket in Get-LocalBucket) {
         $source = Find-BucketDirectory $bucket -Root
+        $manifests = (
+            Get-ChildItem "$source\bucket" -Force -Recurse -ErrorAction SilentlyContinue |
+            Measure-Object | Select-Object -ExpandProperty Count
+        )
         $updated = 'N/A'
         if (Test-Path (Join-Path $source '.git')) {
             $updated = git_cmd -C "`"$source`"" log --format='%ch' -n 1
@@ -43,13 +47,16 @@ function list_buckets {
         }
 
         $buckets += New-Object PSObject -Property @{
-            Name    = $bucket
-            Source  = $source
-            Updated = $updated
+            Name      = $bucket
+            Manifests = $manifests
+            Source    = $source
+            Updated   = $updated
         }
     }
 
-    return $buckets | Select-Object Name, Source, Updated
+    return $buckets | Select-Object Name, Manifests, Source, Updated
+
+    Write-Host
 }
 
 switch ($cmd) {

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -51,7 +51,7 @@ function list_buckets {
 switch ($cmd) {
     'add' { add_bucket $name $repo }
     'rm' { rm_bucket $name }
-    "list" { list_buckets }
+    'list' { list_buckets }
     'known' { known_buckets }
     default { "scoop bucket: cmd '$cmd' not supported"; my_usage; exit 1 }
 }


### PR DESCRIPTION
#### Description
show detailed list for buckets.

#### Motivation and Context
this is a missing part of `scoop-bucket`, IMO

#### How Has This Been Tested?
**before**
```
> scoop bucket list
1ocal
extras
java
main
nuke
tests
versions
```

**after**
```
> scoop bucket list

Name     Source                                     Updated             Manifests
----     ------                                     -------             ---------
1ocal    ~\scoop\buckets\1ocal                      2022-02-02 17:58:02         3
extras   git@github.com:ScoopInstaller/Extras.git   2022-02-03 00:43:11      1380
java     git@github.com:ScoopInstaller/Java.git     2022-02-02 09:58:43       215
main     git@github.com:ScoopInstaller/Main.git     2022-02-02 16:29:48       971
nuke     git@github.com:HUMORCE/nuke.git            2022-02-02 12:09:58       107
tests    git@github.com:ScoopInstaller/Tests.git    2022-01-30 01:32:15        51
versions git@github.com:ScoopInstaller/Versions.git 2022-02-03 00:54:07       276
```


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
