### PR TITLE
Prompt user to proceed uninstaller script if process is still running

### DIFF
--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -69,7 +69,8 @@ $apps | ForEach-Object {
 
     #region Workaround for #2952
     $processdir = $dir | Select-Object -ExpandProperty Path
-    if (Get-Process | Where-Object { $_.Path -like "$processdir\*" }) {
+    if ((Get-Process | Where-Object { $_.Path -like "$processdir\*" }) -and
+        (Read-Host "Application '$app' is still running. Do you want to proceed uninstallation? All unsaved data will be lost [y/N]") -ne 'y') {
         error "Application is still running. Close all instances and try again."
         continue
     }

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -58,7 +58,8 @@ if (!$apps) { exit 0 }
 
     #region Workaround for #2952
     $processdir = appdir $app $global | Resolve-Path | Select-Object -ExpandProperty Path
-    if (Get-Process | Where-Object { $_.Path -like "$processdir\*" }) {
+    if ((Get-Process | Where-Object { $_.Path -like "$processdir\*" }) -and
+        (Read-Host "Application '$app' is still running. Do you want to proceed uninstallation? All unsaved data will be lost [y/N]") -ne 'y') {
         error "Application is still running. Close all instances and try again."
         continue
     }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -238,7 +238,8 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
 
     #region Workaround for #2952
     $processdir = appdir $app $global | Resolve-Path | Select-Object -ExpandProperty Path
-    if (Get-Process | Where-Object { $_.Path -like "$processdir\*" }) {
+    if ((Get-Process | Where-Object { $_.Path -like "$processdir\*" }) -and
+        (Read-Host "Application '$app' is still running. Do you want to proceed uninstallation? All unsaved data will be lost [y/N]") -ne 'y') {
         error "Application is still running. Close all instances and try again."
         return
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
When any process of an application is still running, currently during uninstallation (`uninstall` or `update`), it unconditionally prints error message "Application is still running. Close all instances and try again" and exits. While this approach minimizes risk of data loss, manifest author has no control over the procedure.

Some apps consist of constantly running services and drivers, which has no GUI. In such case, user may have no idea how to "close all instances", and get stuck. Manifest author might be able to `Stop-Service` or call certain external command to stop those processes, but the current logic prevents this.

One simple way to fix this is adding a prompt during uninstallation, as this PR demonstrates. If Scoop detects process running, it calls `Read-Host` to ask user permission to proceed the "uninstaller" script, assuming which will take care of the process termination. In case user answers "N", there will be no change.

Currently there is no flag to guard this change, so all users will be immediately affected by this change. I have no previous experience on how Scoop usually handle these kind of changes. We could create a new property in manifest structure to activate this.

Furthermore, if this is approved, we could even always attempt to call `Stop-Process -Name $bin` after prompt, where "$bin" is the string provided in the manifest's "bin" property, if exist. This way we could streamline the app update even more.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #4710

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Install an app.
2. Launch the app without terminating it.
3. `scoop uninstall <app_name>`.
4. Observe a prompt shows during uninstallation.
4.1. Press any key other than "y" results in the "Application is still running. Close all instances and try again" message.
4.2. Press "y", the uninstallation continues.
5. If <app> manifest has uninstaller script that `Stop-Process -Name <app_name>`, app is closed and unininstalled successfully.
5.1. If not, uninstallation fails with error "Couldn't remove <app_dir>; it may be in use."

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
