### PR TITLE
fix(versions): Get current version from failed installation if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **shim:** Fix PS1 shim error when in different drive in PS7 ([#4614](https://github.com/ScoopInstaller/Scoop/issues/4614))
 - **shim:** Fix `sh` shim error in WSL ([#4637](https://github.com/ScoopInstaller/Scoop/issues/4637))
 - **versions:** Fix wrong version number when only one version dir ([#4679](https://github.com/ScoopInstaller/Scoop/issues/4679))
+- **versions:** Get current version from failed installation if possible ([#4720](https://github.com/ScoopInstaller/Scoop/issues/4720))
 - **scoop-cleanup:** Remove apps other than current version ([#4665](https://github.com/ScoopInstaller/Scoop/issues/4665))
 - **scoop-update:** Skip updating non git buckets ([#4670](https://github.com/ScoopInstaller/Scoop/issues/4670))
   - **scoop-update:** Remove 'Done.' output ([#4672](https://github.com/ScoopInstaller/Scoop/issues/4672))

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -210,7 +210,10 @@ function installed_apps($global) {
 
 # check whether the app failed to install
 function failed($app, $global) {
-    return (is_directory (appdir $app $global)) -and !(Select-CurrentVersion -AppName $app -Global:$global)
+    $app = ($app -split '/|\\')[-1]
+    $appPath = appdir $app $global
+    $hasCurrent = (get_config NO_JUNCTIONS) -or (Test-Path "$appPath\current")
+    return (Test-Path $appPath) -and !($hasCurrent -and (installed $app $global))
 }
 
 function file_path($app, $file) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1077,12 +1077,19 @@ function prune_installed($apps, $global) {
     return @($uninstalled), @($installed)
 }
 
-function ensure_none_failed($apps, $global) {
+function ensure_none_failed($apps) {
     foreach ($app in $apps) {
         $app = ($app -split '/|\\')[-1] -replace '\.json$', ''
-        if (failed $app $global) {
-            warn "Purging previous failed installation of $app."
-            & "$PSScriptRoot\..\libexec\scoop-uninstall.ps1" $app$(if ($global) { ' --global' })
+        foreach ($global in $true, $false) {
+            if (failed $app $global) {
+                if (installed $app $global) {
+                    warn "Repair previous failed installation of $app."
+                    & "$PSScriptRoot\..\libexec\scoop-reset.ps1" $app$(if ($global) { ' --global' })
+                } else {
+                    warn "Purging previous failed installation of $app."
+                    & "$PSScriptRoot\..\libexec\scoop-uninstall.ps1" $app$(if ($global) { ' --global' })
+                }
+            }
         }
     }
 }

--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -51,17 +51,18 @@ function Select-CurrentVersion {
     )
     process {
         $currentPath = "$(appdir $AppName $Global)\current"
-        if ((get_config NO_JUNCTIONS) -or !(Test-Path $currentPath)) {
+        if (!(get_config NO_JUNCTIONS)) {
+            $currentVersion = (parse_json "$currentPath\manifest.json").version
+            if ($currentVersion -eq 'nightly') {
+                $currentVersion = (Get-Item $currentPath).Target | Split-Path -Leaf
+            }
+        }
+        if ($null -eq $currentVersion) {
             $installedVersion = Get-InstalledVersion -AppName $AppName -Global:$Global
             if ($installedVersion) {
                 $currentVersion = @($installedVersion)[-1]
             } else {
                 $currentVersion = $null
-            }
-        } else {
-            $currentVersion = (parse_json "$currentPath\manifest.json").version
-            if ($currentVersion -eq 'nightly') {
-                $currentVersion = (Get-Item $currentPath).Target | Split-Path -Leaf
             }
         }
         return $currentVersion

--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -50,8 +50,8 @@ function Select-CurrentVersion {
         $Global
     )
     process {
-        $appPath = appdir $AppName $Global
-        if (get_config NO_JUNCTIONS) {
+        $currentPath = "$(appdir $AppName $Global)\current"
+        if ((get_config NO_JUNCTIONS) -or !(Test-Path $currentPath)) {
             $installedVersion = Get-InstalledVersion -AppName $AppName -Global:$Global
             if ($installedVersion) {
                 $currentVersion = @($installedVersion)[-1]
@@ -59,9 +59,9 @@ function Select-CurrentVersion {
                 $currentVersion = $null
             }
         } else {
-            $currentVersion = (installed_manifest $AppName 'current' $Global).version
+            $currentVersion = (parse_json "$currentPath\manifest.json").version
             if ($currentVersion -eq 'nightly') {
-                $currentVersion = (Get-Item "$appPath\current").Target | Split-Path -Leaf
+                $currentVersion = (Get-Item $currentPath).Target | Split-Path -Leaf
             }
         }
         return $currentVersion

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -59,6 +59,8 @@ if (is_scoop_outdated) {
     }
 }
 
+ensure_none_failed $apps
+
 if ($apps.length -eq 1) {
     $app, $null, $version = parse_app $apps
     if ($app.EndsWith('.json')) {
@@ -102,7 +104,7 @@ $explicit_apps = $apps
 if (!$independent) {
     $apps = $apps | Get-Dependency -Architecture $architecture | Select-Object -Unique # adds dependencies
 }
-ensure_none_failed $apps $global
+ensure_none_failed $apps
 
 $apps, $skip = prune_installed $apps $global
 

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -29,7 +29,7 @@ if($apps) {
 
         if($global) { write-host -f DarkGreen ' *global*' -NoNewline }
 
-        if (!$install_info) { Write-Host ' *failed*' -ForegroundColor DarkRed -NoNewline }
+        if (failed $app $global) { Write-Host ' *failed*' -ForegroundColor DarkRed -NoNewline }
         if ($install_info.hold) { Write-Host ' *hold*' -ForegroundColor DarkMagenta -NoNewline }
 
         if ($install_info.bucket) {

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -274,8 +274,9 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
         install_app $app $architecture $global $suggested $use_cache $check_hash
     } else {
         # Also add missing dependencies
-        $apps = Get-Dependency $app $architecture | Where-Object { !(installed $_) }
-        $apps | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
+        $apps = (Get-Dependency $app $architecture) -ne $app
+        ensure_none_failed $apps
+        @($apps) + $app | Where-Object { !(installed $_) } | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
     }
 }
 
@@ -311,14 +312,15 @@ if (-not ($apps -or $all)) {
             ($app, $global) = $_
             $status = app_status $app $global
             if ($status.installed -and ($force -or $status.outdated)) {
-                if(!$status.hold) {
+                if (!$status.hold) {
                     $outdated += applist $app $global
-                    Write-Host -f yellow ("$app`: $($status.version) -> $($status.latest_version){0}" -f ('',' (global)')[$global])
+                    Write-Host -f yellow ("$app`: $($status.version) -> $($status.latest_version){0}" -f ('', ' (global)')[$global])
                 } else {
                     warn "'$app' is held to version $($status.version)"
                 }
             } elseif ($apps_param -ne '*') {
                 if ($status.installed) {
+                    ensure_none_failed $app $global
                     Write-Host "$app`: $($status.version) (latest version)" -ForegroundColor Green
                 } else {
                     info 'Please reinstall it or fix the manifest.'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

This PR changes some UX after https://github.com/ScoopInstaller/Scoop/pull/3721, which cause `scoop reset <app>` not works as before (some use cases that I missed)

- `lib\versions.ps1`: `Select-CurrentVersion()` now get version from `current` folder or latest installed version
- `lib\install.ps1`: `ensure_none_failed()` just reset failed app if it is installed successfully before
- `lib\core.ps1`: `failed()` could figure out failed installation with new `Select-CurrentVersion()` function
- `libexec\scoop-list.ps1`: Correctly mark failed app
- `libexec\scoop-install.ps1`: Use `ensure_none_failed()` before installing apps
- `libexec\scoop-update.ps1`: Use `ensure_none_failed()` before updating apps

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Fixes #4573
- Fixes #4684
<!-- or -->
- Relates to https://github.com/ScoopInstaller/Scoop/issues/4508#issuecomment-1015075463

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Remove `current` junction in `7zip`

Before:

```pwsh
❯ Get-ChildItem D:\Scoop\apps\7zip

    Directory: D:\Scoop\apps\7zip

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----            2022/2/8     1:01                21.07

❯ scoop list 7zip
Installed apps matching '7zip':

  7zip  *failed*
  7zip-zstd v21.03-v1.5.0-R2 [versions]

❯ scoop reset 7zip
ERROR '7zip' isn't installed

❯ scoop uninstall 7zip
ERROR '7zip' isn't installed correctly.
Removing older version (21.07).
'7zip' was uninstalled.
```

After:

```pwsh
❯ Get-ChildItem D:\Scoop\apps\7zip

    Directory: D:\Scoop\apps\7zip

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----            2022/2/8     1:43                21.07

❯ scoop list 7zip
Installed apps matching '7zip':

  7zip 21.07 *failed* [main]
  7zip-zstd v21.03-v1.5.0-R2 [versions]

❯ scoop reset 7zip
Resetting 7zip (21.07).
Linking D:\Scoop\apps\7zip\current => D:\Scoop\apps\7zip\21.07
Creating shim for '7z'.
Creating shortcut for 7-Zip (7zFM.exe)
Persisting Codecs
Persisting Formats

# Remove `current` junction again
❯ scoop install 7zip
WARN  Repair previous failed installation of 7zip.
Resetting 7zip (21.07).
Linking D:\Scoop\apps\7zip\current => D:\Scoop\apps\7zip\21.07
Creating shim for '7z'.
Creating shortcut for 7-Zip (7zFM.exe)
Persisting Codecs
Persisting Formats
WARN  '7zip' (21.07) is already installed.
Use 'scoop update 7zip' to install a new version.

# Now remove `current` junction in `7zip` and all content under `7zip-zstd`
❯ scoop list 7zip
Installed apps matching '7zip':

  7zip 21.07 *failed* [main]
  7zip-zstd  *failed*

❯ scoop update 7zip-zstd
ERROR '7zip-zstd' isn't installed correctly.
INFO  Please reinstall it or fix the manifest.
Latest versions for all apps are installed! For more information try 'scoop status'

❯ scoop install 7zip-zstd
WARN  Purging previous failed installation of 7zip-zstd.
ERROR '7zip-zstd' isn't installed correctly.
'7zip-zstd' was uninstalled.
WARN  Repair previous failed installation of 7zip.
Resetting 7zip (21.07).
Linking D:\Scoop\apps\7zip\current => D:\Scoop\apps\7zip\21.07
Creating shim for '7z'.
WARN  Overwriting shim ('7z.exe' -> '7z.exe') installed from 7zip-zstd
Creating shortcut for 7-Zip (7zFM.exe)
Persisting Codecs
Persisting Formats
Installing '7zip-zstd' (v21.03-v1.5.0-R2) [64bit]
Loading 7z21.03-zstd-x64.exe from cache.
Checking hash of 7z21.03-zstd-x64.exe ... ok.
Extracting dl.7z ... done.
Linking D:\Scoop\apps\7zip-zstd\current => D:\Scoop\apps\7zip-zstd\v21.03-v1.5.0-R2
Creating shim for '7z'.
WARN  Overwriting shim ('7z.exe' -> '7z.exe') installed from 7zip
Creating shim for '7zG'.
Creating shortcut for 7-Zip (7zFM.exe)
'7zip-zstd' (v21.03-v1.5.0-R2) was installed successfully!
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] ~I have updated the tests accordingly.~
