### PR TITLE
refactor(shim): Use `-file` instead of `-command` in ps1 script shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - **diagnostic** Skip check for 'exclusionPath' if defender realtime protect is disabled ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Skip 'check_windows_defender' when have not admin privileges ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Separate defender issues, mark as performance problem instead potential problem ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
-- **shim** Use `-file` instead of `-command` in ps1 script shims ([#4721](https://github.com/ScoopInstaller/Scoop/pull/4721))
+- **shim:** Use `-file` instead of `-command` in ps1 script shims ([#4721](https://github.com/ScoopInstaller/Scoop/pull/4721))
 
 ### Builds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - **diagnostic** Skip check for 'exclusionPath' if defender realtime protect is disabled ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Skip 'check_windows_defender' when have not admin privileges ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
 - **scoop-checkup** Separate defender issues, mark as performance problem instead potential problem ([#4699](https://github.com/ScoopInstaller/Scoop/pull/4699))
+- **shim** Use `-file` instead of `-command` in ps1 script shims ([#4721](https://github.com/ScoopInstaller/Scoop/pull/4721))
 
 ### Builds
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -642,9 +642,9 @@ function shim($path, $global, $name, $arg) {
             "if !args! == !invalid! ( set args= )",
             "where /q pwsh.exe",
             "if %errorlevel% equ 0 (",
-            "    pwsh -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"",
+            "    pwsh -noprofile -ex unrestricted -file `"$resolved_path`" $arg %args%",
             ") else (",
-            "    powershell -noprofile -ex unrestricted -command `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"",
+            "    powershell -noprofile -ex unrestricted -file `"$resolved_path`" $arg %args%",
             ")"
         ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
 
@@ -653,9 +653,9 @@ function shim($path, $global, $name, $arg) {
             "#!/bin/sh",
             "# $resolved_path",
             "if command -v pwsh.exe > /dev/null 2>&1; then",
-            "    pwsh.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
+            "    pwsh.exe -noprofile -ex unrestricted -file `"$resolved_path`" $arg $@",
             "else",
-            "    powershell.exe -noprofile -ex unrestricted -command `"& '$resolved_path' $arg $@;exit \`$lastexitcode`"",
+            "    powershell.exe -noprofile -ex unrestricted -file `"$resolved_path`" $arg $@",
             "fi"
         ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
     } elseif ($path -match '\.jar$') {


### PR DESCRIPTION
See https://github.com/ScoopInstaller/Scoop/pull/4718#issuecomment-1031681710