### PR TITLE
fix(scoop-update): Enforce $null array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - **shim:** Fix `sh` shim error in WSL ([#4637](https://github.com/ScoopInstaller/Scoop/issues/4637))
 - **versions:** Fix wrong version number when only one version dir ([#4679](https://github.com/ScoopInstaller/Scoop/issues/4679))
 - **versions:** Get current version from failed installation if possible ([#4720](https://github.com/ScoopInstaller/Scoop/issues/4720))
+  - **scoop-update:** Enforce $null array ([#4725](https://github.com/ScoopInstaller/Scoop/issues/4725))
 - **scoop-cleanup:** Remove apps other than current version ([#4665](https://github.com/ScoopInstaller/Scoop/issues/4665))
 - **scoop-update:** Skip updating non git buckets ([#4670](https://github.com/ScoopInstaller/Scoop/issues/4670))
   - **scoop-update:** Remove 'Done.' output ([#4672](https://github.com/ScoopInstaller/Scoop/issues/4672))

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1075,7 +1075,7 @@ function ensure_none_failed($apps) {
         foreach ($global in $true, $false) {
             if (failed $app $global) {
                 if (installed $app $global) {
-                    warn "Repair previous failed installation of $app."
+                    info "Repair previous failed installation of $app."
                     & "$PSScriptRoot\..\libexec\scoop-reset.ps1" $app$(if ($global) { ' --global' })
                 } else {
                     warn "Purging previous failed installation of $app."

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -274,18 +274,20 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
         install_app $app $architecture $global $suggested $use_cache $check_hash
     } else {
         # Also add missing dependencies
-        $apps = (Get-Dependency $app $architecture) -ne $app
+        $apps = @(Get-Dependency $app $architecture) -ne $app
         ensure_none_failed $apps
-        @($apps) + $app | Where-Object { !(installed $_) } | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
+        $apps.Where({ !(installed $_) }) + $app | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
     }
 }
 
 if (-not ($apps -or $all)) {
     if ($global) {
-        "scoop update: --global is invalid when <app> is not specified."; exit 1
+        error 'scoop update: --global is invalid when <app> is not specified.'
+        exit 1
     }
     if (!$use_cache) {
-        "scoop update: --no-cache is invalid when <app> is not specified."; exit 1
+        error 'scoop update: --no-cache is invalid when <app> is not specified.'
+        exit 1
     }
     update_scoop
 } else {
@@ -320,7 +322,7 @@ if (-not ($apps -or $all)) {
                 }
             } elseif ($apps_param -ne '*') {
                 if ($status.installed) {
-                    ensure_none_failed $app $global
+                    ensure_none_failed $app
                     Write-Host "$app`: $($status.version) (latest version)" -ForegroundColor Green
                 } else {
                     info 'Please reinstall it or fix the manifest.'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Hotfix for #4720

If `Get-Dependency()` output `$null`, `(Get-Dependency $app $architecture) -ne $app` gives `$false` while `@(Get-Dependency $app $architecture) -ne $app` gives `$null` which is needed to `ensure_none_failed()`

Also some small fixes.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Relates to #4720

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Before:

![image](https://user-images.githubusercontent.com/5832170/153178417-35bde3dc-7ca8-446a-a928-1a03b5243d7d.png)

After:

![image](https://user-images.githubusercontent.com/5832170/153178467-22728104-8287-4422-8f6c-d5bd91d69132.png)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
