### PR TITLE
fix(scoop-info): Use pipe to separate bins

### DIFF
--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -99,7 +99,7 @@ if ($binaries) {
             $binary_output += $_
         }
     }
-    $item.Binaries = $binary_output -join "`n"
+    $item.Binaries = $binary_output -join " | "
 }
 $env_set = (arch_specific 'env_set' $manifest $install.architecture)
 $env_add_path = (arch_specific 'env_add_path' $manifest $install.architecture)


### PR DESCRIPTION
Hotfix for #4741

### Before

![image](https://user-images.githubusercontent.com/46838874/154494792-62d5293d-7f66-4672-bafe-d8a01931b193.png)

### After

![image](https://user-images.githubusercontent.com/46838874/154494847-b7abfa55-87a5-4d6d-8567-4435d9ed8783.png)
