### PR TITLE
refactor(scoop-config): Use underscores everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - **COMSPEC:** Deprecate use of subshell cmd.exe ([#4692](https://github.com/ScoopInstaller/Scoop/issues/4692))
 - **git:** Use 'git -C' to specify the work directory instead of 'Push-Location'/'Pop-Location' ([#4697](https://github.com/ScoopInstaller/Scoop/issues/4697))
 - **scoop-info:** Use List View for output ([#4741](https://github.com/ScoopInstaller/Scoop/issues/4741))
+- **scoop-config:** Use underscores everywhere ([#4745](https://github.com/ScoopInstaller/Scoop/issues/4745))
 
 ### Builds
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -343,7 +343,7 @@ function app_status($app, $global) {
 
     $status.outdated = $false
     if ($status.version -and $status.latest_version) {
-        if (get_config 'force-update' $false) {
+        if (get_config 'force_update' $false) {
             $status.outdated = ((Compare-Version -ReferenceVersion $status.version -DifferenceVersion $status.latest_version) -ne 0)
         } else {
             $status.outdated = ((Compare-Version -ReferenceVersion $status.version -DifferenceVersion $status.latest_version) -gt 0)

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -59,7 +59,7 @@ function install_info($app, $version, $global) {
 }
 
 function default_architecture {
-    $arch = get_config 'default-architecture'
+    $arch = get_config 'default_architecture'
     $system = if ([Environment]::Is64BitOperatingSystem) { '64bit' } else { '32bit' }
     if ($null -eq $arch) {
         $arch = $system

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -43,14 +43,14 @@
 #       * An empty or unset value for proxy is equivalent to 'default' (with no username or password)
 #       * To bypass the system proxy and connect directly, use 'none' (with no username or password)
 #
-# default-architecture: 64bit|32bit
+# default_architecture: 64bit|32bit
 #       Allow to configure preferred architecture for application installation.
 #       If not specified, architecture is determined be system.
 #
 # debug: $true|$false
 #       Additional and detailed output will be shown.
 #
-# force-update: $true|$false
+# force_update: $true|$false
 #       Force apps updating to bucket's version.
 #
 # show_update_log: $true|$false


### PR DESCRIPTION
Config variables are quite messy. Here are a couple of fixes.
