### PR TITLE
fix(cleanup): Hotfix for #4681

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ### Performance Improvements
 
-- **uninstall:** Avoid checking all files for unlinking persisted data ([#4681](https://github.com/ScoopInstaller/Scoop/issues/4681))
+- **uninstall:** Avoid checking all files for unlinking persisted data ([#4681](https://github.com/ScoopInstaller/Scoop/issues/4681), [#4763](https://github.com/ScoopInstaller/Scoop/issues/4763))
 
 ### Code Refactoring
 

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -49,7 +49,7 @@ function cleanup($app, $global, $verbose, $cache) {
         Write-Host " $version" -NoNewline
         $dir = versiondir $app $version $global
         # unlink all potential old link before doing recursive Remove-Item
-        unlink_persist_data $manifest $dir
+        unlink_persist_data (installed_manifest $app $version $global) $dir
         Remove-Item $dir -ErrorAction Stop -Recurse -Force
     }
     $leftVersions = Get-ChildItem $appDir


### PR DESCRIPTION
`scoop-cleanup` doesn't use `$manifest`


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] ~I have updated the tests accordingly.~
