### PR TITLE
style: Use correct casing for `$PSScriptRoot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 ### Styles
 
 - **test:** Format scripts by VSCode's PowerShell extension ([#4609](https://github.com/ScoopInstaller/Scoop/issues/4609))
+- **style** Use correct casing for `$PSScriptRoot` ([#4775](https://github.com/ScoopInstaller/Scoop/issues/4775))
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 ### Styles
 
 - **test:** Format scripts by VSCode's PowerShell extension ([#4609](https://github.com/ScoopInstaller/Scoop/issues/4609))
-- **style** Use correct casing for `$PSScriptRoot` ([#4775](https://github.com/ScoopInstaller/Scoop/issues/4775))
+- **style:** Use correct casing for `$PSScriptRoot` ([#4775](https://github.com/ScoopInstaller/Scoop/issues/4775))
 
 ### Tests
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -65,14 +65,14 @@ param(
     [String] $Version = ''
 )
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-. "$psscriptroot\..\lib\autoupdate.ps1"
-. "$psscriptroot\..\lib\json.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
-. "$psscriptroot\..\lib\install.ps1" # needed for hash generation
-. "$psscriptroot\..\lib\unix.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\autoupdate.ps1"
+. "$PSScriptRoot\..\lib\json.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\install.ps1" # needed for hash generation
+. "$PSScriptRoot\..\lib\unix.ps1"
 
 $Dir = Resolve-Path $Dir
 $Search = $App

--- a/bin/refresh.ps1
+++ b/bin/refresh.ps1
@@ -1,5 +1,5 @@
 # for development, update the installed scripts to match local source
-. "$psscriptroot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
 
 $src = relpath ".."
 $dest = ensure (versiondir 'scoop' 'current')

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -2,10 +2,10 @@
 TODO
  - clean up
 #>
-. "$psscriptroot\..\lib\json.ps1"
+. "$PSScriptRoot\..\lib\json.ps1"
 
-. "$psscriptroot/core.ps1"
-. "$psscriptroot/json.ps1"
+. "$PSScriptRoot/core.ps1"
+. "$PSScriptRoot/json.ps1"
 
 function find_hash_in_rdf([String] $url, [String] $basename) {
     $data = $null

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -2,10 +2,8 @@
 TODO
  - clean up
 #>
-. "$PSScriptRoot\..\lib\json.ps1"
-
-. "$PSScriptRoot/core.ps1"
-. "$PSScriptRoot/json.ps1"
+. "$PSScriptRoot\core.ps1"
+. "$PSScriptRoot\json.ps1"
 
 function find_hash_in_rdf([String] $url, [String] $basename) {
     $data = $null

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1,5 +1,5 @@
-. "$PSScriptRoot/autoupdate.ps1"
-. "$PSScriptRoot/buckets.ps1"
+. "$PSScriptRoot\autoupdate.ps1"
+. "$PSScriptRoot\buckets.ps1"
 
 function nightly_version($date, $quiet = $false) {
     $date_str = $date.tostring("yyyyMMdd")

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -93,7 +93,7 @@ function ConvertToPrettyJson {
 }
 
 function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitutions, [Boolean] $reverse, [Boolean] $single) {
-    Add-Type -Path "$psscriptroot\..\supporting\validator\bin\Newtonsoft.Json.dll"
+    Add-Type -Path "$PSScriptRoot\..\supporting\validator\bin\Newtonsoft.Json.dll"
     if ($null -ne $substitutions) {
         $jsonpath = substitute $jsonpath $substitutions ($jsonpath -like "*=~*")
     }

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -1,5 +1,5 @@
-. "$PSScriptRoot/core.ps1"
-. "$PSScriptRoot/autoupdate.ps1"
+. "$PSScriptRoot\core.ps1"
+. "$PSScriptRoot\autoupdate.ps1"
 
 function manifest_path($app, $bucket) {
     fullpath "$(Find-BucketDirectory $bucket)\$(sanitary_path $app).json"

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -1,5 +1,5 @@
-. "$psscriptroot/core.ps1"
-. "$psscriptroot/autoupdate.ps1"
+. "$PSScriptRoot/core.ps1"
+. "$PSScriptRoot/autoupdate.ps1"
 
 function manifest_path($app, $bucket) {
     fullpath "$(Find-BucketDirectory $bucket)\$(sanitary_path $app).json"

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -23,9 +23,9 @@ param(
     [Switch]$verbose = $false
 )
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
 
 $script:config_alias = 'alias'
 

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -3,8 +3,8 @@
 # Help: Performs a series of diagnostic tests to try to identify things that may
 # cause problems with Scoop.
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\diagnostic.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\diagnostic.ps1"
 
 $issues = 0
 $defenderIssues = 0

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -9,13 +9,13 @@
 #   -g, --global       Cleanup a globally installed app
 #   -k, --cache        Remove outdated download cache
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
-. "$psscriptroot\..\lib\getopt.ps1"
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -1,13 +1,13 @@
 # Usage: scoop depends <app>
 # Summary: List dependencies for an app
 
-. "$psscriptroot\..\lib\depends.ps1"
-. "$psscriptroot\..\lib\install.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-. "$psscriptroot\..\lib\getopt.ps1"
-. "$psscriptroot\..\lib\decompress.ps1"
-. "$psscriptroot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\decompress.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -15,10 +15,10 @@
 #   -u, --no-update-scoop     Don't update Scoop before downloading if it's outdated
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\install.ps1"
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -2,10 +2,10 @@
 # Summary: Exports (an importable) list of installed apps
 # Help: Lists all installed apps.
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
 
 reset_aliases
 $def_arch = default_architecture

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -2,9 +2,9 @@
 # Summary: Show help for a command
 param($cmd)
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\commands.ps1"
-. "$psscriptroot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\commands.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -1,9 +1,9 @@
 # Usage: scoop hold <apps>
 # Summary: Hold an app to disable updates
 
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
 
 reset_aliases
 $apps = $args

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -2,10 +2,10 @@
 # Summary: Opens the app homepage
 param($app)
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -17,17 +17,17 @@
 #   -s, --skip                Skip hash validation (use with caution!)
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-. "$psscriptroot\..\lib\decompress.ps1"
-. "$psscriptroot\..\lib\install.ps1"
-. "$psscriptroot\..\lib\shortcuts.ps1"
-. "$psscriptroot\..\lib\psmodules.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\getopt.ps1"
-. "$psscriptroot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\decompress.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\shortcuts.ps1"
+. "$PSScriptRoot\..\lib\psmodules.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\depends.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -4,13 +4,13 @@
 # if you've installed 'python' and 'python27', you can use 'scoop reset' to switch between
 # using one or the other.
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\getopt.ps1"
-. "$psscriptroot\..\lib\install.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
-. "$psscriptroot\..\lib\shortcuts.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\shortcuts.ps1"
 
 reset_aliases
 $opt, $apps, $err = getopt $args

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -5,10 +5,10 @@
 # If used with [query], shows app names that match the query.
 # Without [query], shows all the available apps.
 param($query)
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -1,11 +1,11 @@
 # Usage: scoop status
 # Summary: Show status and check for new app versions
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
-. "$psscriptroot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\depends.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -1,9 +1,9 @@
 # Usage: scoop unhold <app>
 # Summary: Unhold an app to enable updates
 
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
 
 reset_aliases
 $apps = $args

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -14,16 +14,16 @@
 #   -q, --quiet               Hide extraneous messages
 #   -a, --all                 Update all apps (alternative to '*')
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\shortcuts.ps1"
-. "$psscriptroot\..\lib\psmodules.ps1"
-. "$psscriptroot\..\lib\decompress.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
-. "$psscriptroot\..\lib\getopt.ps1"
-. "$psscriptroot\..\lib\depends.ps1"
-. "$psscriptroot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\shortcuts.ps1"
+. "$PSScriptRoot\..\lib\psmodules.ps1"
+. "$PSScriptRoot\..\lib\decompress.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -34,15 +34,15 @@
 #   -n, --no-depends          By default, all dependencies are checked too. This flag avoids it.
 #   -u, --no-update-scoop     Don't update Scoop before checking if it's outdated
 
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\help.ps1"
-. "$psscriptroot\..\lib\getopt.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\buckets.ps1"
-. "$psscriptroot\..\lib\json.ps1"
-. "$psscriptroot\..\lib\decompress.ps1"
-. "$psscriptroot\..\lib\install.ps1"
-. "$psscriptroot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\json.ps1"
+. "$PSScriptRoot\..\lib\decompress.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\depends.ps1"
 
 reset_aliases
 

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -2,8 +2,8 @@
 # Summary: Locate a shim/executable (similar to 'which' on Linux)
 # Help: Locate the path to a shim/executable that was installed with Scoop (similar to 'which' on Linux)
 param($command)
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
 
 reset_aliases
 

--- a/test/00-Project.Tests.ps1
+++ b/test/00-Project.Tests.ps1
@@ -71,4 +71,4 @@ Describe 'Project code' {
 
 }
 
-. "$psscriptroot\Import-File-Tests.ps1"
+. "$PSScriptRoot\Import-File-Tests.ps1"

--- a/test/Scoop-Alias.Tests.ps1
+++ b/test/Scoop-Alias.Tests.ps1
@@ -1,4 +1,4 @@
-. "$psscriptroot\..\libexec\scoop-alias.ps1" | Out-Null
+. "$PSScriptRoot\..\libexec\scoop-alias.ps1" | Out-Null
 
 reset_aliases
 

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -1,7 +1,7 @@
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\install.ps1"
-. "$psscriptroot\..\lib\unix.ps1"
-. "$psscriptroot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\unix.ps1"
+. "$PSScriptRoot\Scoop-TestLib.ps1"
 
 $repo_dir = (Get-Item $MyInvocation.MyCommand.Path).directory.parent.FullName
 $isUnix = is_unix

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -1,9 +1,9 @@
-. "$psscriptroot\Scoop-TestLib.ps1"
-. "$psscriptroot\..\lib\decompress.ps1"
-. "$psscriptroot\..\lib\unix.ps1"
-. "$psscriptroot\..\lib\install.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
+. "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\decompress.ps1"
+. "$PSScriptRoot\..\lib\unix.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
 
 $isUnix = is_unix
 

--- a/test/Scoop-Depends.Tests.ps1
+++ b/test/Scoop-Depends.Tests.ps1
@@ -1,7 +1,7 @@
-. "$psscriptroot\Scoop-TestLib.ps1"
-. "$psscriptroot\..\lib\depends.ps1"
-. "$psscriptroot\..\lib\install.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
+. "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
 
 Describe 'Package Dependencies' -Tag 'Scoop' {
     Context 'Requirement function' {

--- a/test/Scoop-Format-Manifest.Tests.ps1
+++ b/test/Scoop-Format-Manifest.Tests.ps1
@@ -1,6 +1,6 @@
-. "$psscriptroot\Scoop-TestLib.ps1"
-. "$psscriptroot\..\lib\json.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
+. "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\json.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
 
 Describe 'Pretty json formating' -Tag 'Scoop' {
     BeforeAll {

--- a/test/Scoop-GetOpts.Tests.ps1
+++ b/test/Scoop-GetOpts.Tests.ps1
@@ -1,5 +1,5 @@
-. "$psscriptroot\Scoop-TestLib.ps1"
-. "$psscriptroot\..\lib\getopt.ps1"
+. "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
 
 Describe 'getopt' -Tag 'Scoop' {
     It 'handle short option with required argument missing' {

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -1,8 +1,8 @@
-. "$psscriptroot\..\lib\core.ps1"
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\install.ps1"
-. "$psscriptroot\..\lib\unix.ps1"
-. "$psscriptroot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\unix.ps1"
+. "$PSScriptRoot\Scoop-TestLib.ps1"
 
 $isUnix = is_unix
 
@@ -70,8 +70,8 @@ Describe 'is_in_dir' -Tag 'Scoop' {
         is_in_dir 'C:\test' 'C:\foo' | Should -BeFalse
         is_in_dir 'C:\test' 'C:\test\foo\baz.zip' | Should -BeTrue
 
-        is_in_dir 'test' "$psscriptroot" | Should -BeTrue
-        is_in_dir "$psscriptroot\..\" "$psscriptroot" | Should -BeFalse
+        is_in_dir 'test' "$PSScriptRoot" | Should -BeTrue
+        is_in_dir "$PSScriptRoot\..\" "$PSScriptRoot" | Should -BeFalse
     }
 }
 
@@ -80,7 +80,7 @@ Describe 'env add and remove path' -Tag 'Scoop' {
     $manifest = @{
         'env_add_path' = @('foo', 'bar')
     }
-    $testdir = Join-Path $psscriptroot 'path-test-directory'
+    $testdir = Join-Path $PSScriptRoot 'path-test-directory'
     $global = $false
 
     # store the original path to prevent leakage of tests

--- a/test/Scoop-TestLib.ps1
+++ b/test/Scoop-TestLib.ps1
@@ -66,7 +66,7 @@ function script:fmt($var) {
 
 # copies fixtures to a working directory
 function setup_working($name) {
-    $fixtures = "$psscriptroot/fixtures/$name"
+    $fixtures = "$PSScriptRoot/fixtures/$name"
     if (!(Test-Path $fixtures)) {
         Write-Host "couldn't find fixtures for $name at $fixtures" -f red
         exit 1

--- a/test/Scoop-Versions.Tests.ps1
+++ b/test/Scoop-Versions.Tests.ps1
@@ -1,5 +1,5 @@
-. "$psscriptroot\Scoop-TestLib.ps1"
-. "$psscriptroot\..\lib\versions.ps1"
+. "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
 
 Describe 'versions comparison' -Tag 'Scoop' {
     Context 'semver compliant versions' {


### PR DESCRIPTION
- Use correct casing for `$PSScriptRoot`
- Fix imports in `lib/autoupdate.ps1`
- Use back slash instead of forward slash


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] ~I have updated the tests accordingly.~
