### PR TITLE
refactor(relpath): Use `$PSScriptRoot` instead of `relpath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+
+### Code Refactoring
+
+- **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793)
+
 ## [v0.1.0](https://github.com/ScoopInstaller/Scoop/compare/2021-12-26...v0.1.0) - 2022-03-01
 
 ### Features

--- a/bin/refresh.ps1
+++ b/bin/refresh.ps1
@@ -1,7 +1,7 @@
 # for development, update the installed scripts to match local source
 . "$PSScriptRoot\..\lib\core.ps1"
 
-$src = relpath ".."
+$src = "$PSScriptRoot\.."
 $dest = ensure (versiondir 'scoop' 'current')
 
 # make sure not running from the installed directory

--- a/lib/commands.ps1
+++ b/lib/commands.ps1
@@ -1,7 +1,6 @@
 function command_files {
-    (Get-ChildItem (relpath '..\libexec')) `
-        + (Get-ChildItem "$scoopdir\shims") `
-        | Where-Object { $_.name -match 'scoop-.*?\.ps1$' }
+    (Get-ChildItem "$PSScriptRoot\..\libexec") + (Get-ChildItem "$scoopdir\shims") |
+        Where-Object 'scoop-.*?\.ps1$' -Property Name -Match
 }
 
 function commands {
@@ -13,7 +12,7 @@ function command_name($filename) {
 }
 
 function command_path($cmd) {
-    $cmd_path = relpath "..\libexec\scoop-$cmd.ps1"
+    $cmd_path = "$PSScriptRoot\..\libexec\scoop-$cmd.ps1"
 
     # built in commands
     if (!(Test-Path $cmd_path)) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -402,10 +402,10 @@ function url_remote_filename($url) {
 }
 
 function ensure($dir) { if(!(test-path $dir)) { mkdir $dir > $null }; resolve-path $dir }
-function fullpath($path) { # should be ~ rooted
-    $executionContext.sessionState.path.getUnresolvedProviderPathFromPSPath($path)
+function fullpath($path) {
+    # should be ~ rooted
+    $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($path)
 }
-function relpath($path) { "$($myinvocation.psscriptroot)\$path" } # relative to calling script
 function friendly_path($path) {
     $h = (Get-PsProvider 'FileSystem').home; if(!$h.endswith('\')) { $h += '\' }
     if($h -eq '\') { return $path }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

`relpath` seems to be added in PS 2.0 era, using `$PSScriptRoot` instead.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Passed tests.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated/passed the tests accordingly.
