### PR TITLE
refactor(reset_aliases): Move core function of `reset_aliases` to `scoop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Code Refactoring
 
-- **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793)
+- **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793))
+- **reset_aliases:** Move core function of `reset_aliases` to `scoop` ([#4794](https://github.com/ScoopInstaller/Scoop/issues/4794))
 
 ## [v0.1.0](https://github.com/ScoopInstaller/Scoop/compare/2021-12-26...v0.1.0) - 2022-03-01
 

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -6,8 +6,11 @@ Set-StrictMode -off
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\commands.ps1"
-
-reset_aliases
+# for aliases where there's a local function, re-alias so the function takes precedence
+$aliases = Get-Alias | Where-Object { $_.Options -notmatch 'ReadOnly|AllScope' } | ForEach-Object { $_.Name }
+Get-ChildItem Function: | Where-Object -Property Name -In -Value $aliases | ForEach-Object {
+    Set-Alias -Name $_.Name -Value Local:$($_.Name) -Scope Script
+}
 
 $commands = commands
 if ('--version' -contains $cmd -or (!$cmd -and '-v' -contains $args)) {

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -23,8 +23,6 @@ param($cmd, $name, $repo)
 . "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 $usage_add = "usage: scoop bucket add <name> [<repo>]"
 $usage_rm = "usage: scoop bucket rm <name>"
 

--- a/libexec/scoop-cat.ps1
+++ b/libexec/scoop-cat.ps1
@@ -7,8 +7,6 @@ param($app)
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 if (!$app) { error '<app> missing'; my_usage; exit 1 }
 
 $app, $bucket, $null = parse_app $app

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -17,8 +17,6 @@
 . "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'gk' 'global', 'cache'
 if ($err) { "scoop cleanup: $err"; exit 1 }
 $global = $opt.g -or $opt.global

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -130,8 +130,6 @@ param($name, $value)
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 if (!$name) {
     $scoopConfig
 } elseif ($name -like '--help') {

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -9,8 +9,6 @@
 . "$PSScriptRoot\..\lib\decompress.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'a:' 'arch='
 $app = $apps[0]
 

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -20,8 +20,6 @@
 . "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'fhua:' 'force', 'no-hash-check', 'no-update-scoop', 'arch='
 if ($err) { error "scoop download: $err"; exit 1 }
 

--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -7,7 +7,6 @@
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 
-reset_aliases
 $def_arch = default_architecture
 
 $local = installed_apps $false | ForEach-Object { @{ name = $_; global = $false } }

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -6,8 +6,6 @@ param($cmd)
 . "$PSScriptRoot\..\lib\commands.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 function print_help($cmd) {
     $file = Get-Content (command_path $cmd) -raw
 
@@ -47,4 +45,3 @@ Some useful commands are:"
 }
 
 exit 0
-

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -5,7 +5,6 @@
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
 
-reset_aliases
 $apps = $args
 
 if(!$apps) {

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -7,8 +7,6 @@ param($app)
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 
-reset_aliases
-
 if($app) {
     $manifest, $bucket = find_manifest $app
     if($manifest) {

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -9,8 +9,6 @@
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
 
-reset_aliases
-
 $opt, $app, $err = getopt $args 'v' 'verbose'
 if ($err) { error "scoop info: $err"; exit 1 }
 $verbose = $opt.v -or $opt.verbose

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -29,8 +29,6 @@
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'gikusa:' 'global', 'independent', 'no-cache', 'no-update-scoop', 'skip', 'arch='
 if ($err) { "scoop install: $err"; exit 1 }
 

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -8,7 +8,6 @@ param($query)
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 
-reset_aliases
 $def_arch = default_architecture
 if (-not (Get-FormatData ScoopApps)) {
     Update-FormatData "$PSScriptRoot\..\supporting\formats\ScoopTypes.Format.ps1xml"

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -12,7 +12,6 @@
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 
-reset_aliases
 $opt, $apps, $err = getopt $args
 if($err) { "scoop reset: $err"; exit 1 }
 

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -10,8 +10,6 @@ param($query)
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
 
-reset_aliases
-
 function bin_match($manifest, $query) {
     if(!$manifest.bin) { return $false }
     foreach($bin in $manifest.bin) {

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -7,8 +7,6 @@
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 
-reset_aliases
-
 # check if scoop needs updating
 $currentdir = fullpath $(versiondir 'scoop' 'current')
 $needs_update = $false

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -5,7 +5,6 @@
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
 
-reset_aliases
 $apps = $args
 
 if(!$apps) {

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -15,8 +15,6 @@
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
 
-reset_aliases
-
 # options
 $opt, $apps, $err = getopt $args 'gp' 'global', 'purge'
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -25,8 +25,6 @@
 . "$PSScriptRoot\..\lib\depends.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'gfiksqa' 'global', 'force', 'independent', 'no-cache', 'skip', 'quiet', 'all'
 if ($err) { "scoop update: $err"; exit 1 }
 $global = $opt.g -or $opt.global

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -44,8 +44,6 @@
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'a:snu' @('arch=', 'scan', 'no-depends', 'no-update-scoop')
 if($err) { "scoop virustotal: $err"; exit 1 }
 if(!$apps) { my_usage; exit 1 }

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -5,8 +5,6 @@ param($command)
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 if (!$command) {
     'ERROR: <command> missing'
     my_usage

--- a/test/Scoop-Alias.Tests.ps1
+++ b/test/Scoop-Alias.Tests.ps1
@@ -1,14 +1,12 @@
 . "$PSScriptRoot\..\libexec\scoop-alias.ps1" | Out-Null
 
-reset_aliases
-
 Describe 'add_alias' -Tag 'Scoop' {
     Mock shimdir { 'TestDrive:\shim' }
     Mock set_config { }
     Mock get_config { @{} }
 
     $shimdir = shimdir
-    mkdir $shimdir
+    ensure $shimdir
 
     Context "alias doesn't exist" {
         It 'creates a new alias' {
@@ -38,7 +36,7 @@ Describe 'rm_alias' -Tag 'Scoop' {
     Mock get_config { @{} }
 
     $shimdir = shimdir
-    mkdir $shimdir
+    ensure $shimdir
 
     Context 'alias exists' {
         It 'removes an existing alias' {

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -234,12 +234,12 @@ Describe 'get_app_name_from_shim' -Tag 'Scoop' {
     }
 
     It 'returns app name if file exists and is a shim to an app' -Skip:$isUnix {
-        mkdir -p "$working_dir/mockapp/current/"
+        ensure "$working_dir/mockapp/current/"
         Write-Output '' | Out-File "$working_dir/mockapp/current/mockapp1.ps1"
         shim "$working_dir/mockapp/current/mockapp1.ps1" $false 'shim-test1'
         $shim_path1 = (Get-Command 'shim-test1.ps1').Path
         get_app_name_from_shim "$shim_path1" | Should -Be 'mockapp'
-        mkdir -p "$working_dir/mockapp/1.0.0/"
+        ensure "$working_dir/mockapp/1.0.0/"
         Write-Output '' | Out-File "$working_dir/mockapp/1.0.0/mockapp2.ps1"
         shim "$working_dir/mockapp/1.0.0/mockapp2.ps1" $false 'shim-test2'
         $shim_path2 = (Get-Command 'shim-test2.ps1').Path
@@ -266,10 +266,6 @@ Describe 'get_app_name_from_shim' -Tag 'Scoop' {
 Describe 'ensure_robocopy_in_path' -Tag 'Scoop' {
     $shimdir = shimdir $false
     Mock versiondir { $repo_dir }
-
-    BeforeAll {
-        reset_aliases
-    }
 
     Context 'robocopy is not in path' {
         It 'shims robocopy when not on path' -Skip:$isUnix {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

`reset_aliases` is added since scoop uses lots of PS alias (md, cd, gci, etc.) during its early development, and this function reset all alias to PS's default.

Now Verb-Noun form of function names is used, so this is not needed.

The one added in `scoop.ps1` is force use script (scoop) function instead of user-definded alias or function in global environment outsides scoop.

Additionally, `ensure()` is refactored and `mkdir` in test files are replaced by `ensure()`

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Passed tests.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated/passed the tests accordingly.
