### PR TITLE
refactor(bucket): Move 'Find-Manifest' and 'list_buckets' to 'buckets'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Code Refactoring
 
+- **bucket:** Move 'Find-Manifest' and 'list_buckets' to 'buckets' ([#4814](https://github.com/ScoopInstaller/Scoop/issues/4814))
 - **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793))
 - **reset_aliases:** Move core function of `reset_aliases` to `scoop` ([#4794](https://github.com/ScoopInstaller/Scoop/issues/4794))
 

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -18,7 +18,9 @@ function Find-BucketDirectory {
     )
 
     # Handle info passing empty string as bucket ($install.bucket)
-    if(($null -eq $Name) -or ($Name -eq '')) { $Name = 'main' }
+    if (($null -eq $Name) -or ($Name -eq '')) {
+        $Name = 'main'
+    }
     $bucket = "$bucketsdir\$Name"
 
     if ((Test-Path "$bucket\bucket") -and !$Root) {
@@ -37,7 +39,7 @@ function bucketdir($name) {
 function known_bucket_repos {
     $json = "$PSScriptRoot\..\buckets.json"
 
-    return Get-Content $json -raw | convertfrom-json -ea stop
+    return Get-Content $json -Raw | ConvertFrom-Json -ErrorAction stop
 }
 
 function known_bucket_repo($name) {
@@ -46,11 +48,11 @@ function known_bucket_repo($name) {
 }
 
 function known_buckets {
-    known_bucket_repos | ForEach-Object { $_.psobject.properties | Select-Object -expand 'name' }
+    known_bucket_repos | ForEach-Object { $_.PSObject.Properties | Select-Object -Expand 'name' }
 }
 
 function apps_in_bucket($dir) {
-    return Get-ChildItem $dir | Where-Object { $_.Name.endswith('.json') } | ForEach-Object { $_.Name -replace '.json$', '' }
+    return Get-ChildItem $dir | Where-Object { $_.Name.EndsWith('.json') } | ForEach-Object { $_.Name -replace '.json$', '' }
 }
 
 function Get-LocalBucket {
@@ -68,42 +70,75 @@ function buckets {
     return Get-LocalBucket
 }
 
-function find_manifest($app, $bucket) {
-    if ($bucket) {
-        $manifest = manifest $app $bucket
-        if ($manifest) { return $manifest, $bucket }
-        return $null
+function Find-Manifest($app, $bucket) {
+    $manifest, $url = $null, $null
+
+    # check if app is a URL or UNC path
+    if ($app -match '^(ht|f)tps?://|\\\\') {
+        $url = $app
+        $app = appname_from_url $url
+        $manifest = url_manifest $url
+    } else {
+        if ($bucket) {
+            $manifest = manifest $app $bucket
+        } else {
+            foreach ($bucket in Get-LocalBucket) {
+                $manifest = manifest $app $bucket
+                if ($manifest) { break }
+            }
+        }
+
+        if (!$manifest) {
+            # couldn't find app in buckets: check if it's a local path
+            $path = $app
+            if (!$path.endswith('.json')) { $path += '.json' }
+            if (Test-Path $path) {
+                $url = "$(Resolve-Path $path)"
+                $app = appname_from_url $url
+                $manifest, $bucket = url_manifest $url
+            }
+        }
     }
 
-    foreach($bucket in Get-LocalBucket) {
-        $manifest = manifest $app $bucket
-        if($manifest) { return $manifest, $bucket }
+    return $app, $manifest, $bucket, $url
+}
+
+function list_buckets {
+    $buckets = @()
+    Get-LocalBucket | ForEach-Object {
+        $bucket = [Ordered]@{ Name = $_ }
+        $path = Find-BucketDirectory $_ -Root
+        if ((Test-Path (Join-Path $path '.git')) -and (Get-Command git -ErrorAction SilentlyContinue)) {
+            $bucket.Source = git -C $path config remote.origin.url
+            $bucket.Updated = git -C $path log --format='%aD' -n 1 | Get-Date
+        } else {
+            $bucket.Source = friendly_path $path
+            $bucket.Updated = (Get-Item "$path\bucket").LastWriteTime
+        }
+        $bucket.Manifests = Get-ChildItem "$path\bucket" -Force -Recurse -ErrorAction SilentlyContinue |
+                Measure-Object | Select-Object -ExpandProperty Count
+        $buckets += [PSCustomObject]$bucket
     }
+    $buckets
 }
 
 function add_bucket($name, $repo) {
-    if (!$name) { "<name> missing"; $usage_add; exit 1 }
-    if (!$repo) {
-        $repo = known_bucket_repo $name
-        if (!$repo) { "Unknown bucket '$name'. Try specifying <repo>."; $usage_add; exit 1 }
-    }
-
     if (!(Test-CommandAvailable git)) {
         abort "Git is required for buckets. Run 'scoop install git' and try again."
     }
 
     $dir = Find-BucketDirectory $name -Root
-    if (test-path $dir) {
+    if (Test-Path $dir) {
         warn "The '$name' bucket already exists. Use 'scoop bucket rm $name' to remove it."
         exit 0
     }
 
-    write-host 'Checking repo... ' -nonewline
+    Write-Host 'Checking repo... ' -NoNewline
     $out = git_cmd ls-remote $repo 2>&1
     if ($lastexitcode -ne 0) {
         abort "'$repo' doesn't look like a valid git repository`n`nError given:`n$out"
     }
-    write-host 'ok'
+    Write-Host 'ok'
 
     ensure $bucketsdir > $null
     $dir = ensure $dir
@@ -112,13 +147,12 @@ function add_bucket($name, $repo) {
 }
 
 function rm_bucket($name) {
-    if (!$name) { "<name> missing"; $usage_rm; exit 1 }
     $dir = Find-BucketDirectory $name -Root
-    if (!(test-path $dir)) {
+    if (!(Test-Path $dir)) {
         abort "'$name' bucket not found."
     }
 
-    Remove-Item $dir -r -force -ea stop
+    Remove-Item $dir -Recurse -Force -ErrorAction stop
 }
 
 function new_issue_msg($app, $bucket, $title, $body) {
@@ -126,7 +160,7 @@ function new_issue_msg($app, $bucket, $title, $body) {
     $url = known_bucket_repo $bucket
     $bucket_path = "$bucketsdir\$bucket"
 
-    if (Test-path $bucket_path) {
+    if (Test-Path $bucket_path) {
         $remote = Invoke-Expression "git -C '$bucket_path' config --get remote.origin.url"
         # Support ssh and http syntax
         # git@PROVIDER:USER/REPO.git
@@ -135,7 +169,7 @@ function new_issue_msg($app, $bucket, $title, $body) {
         $url = "https://$($Matches.Provider)/$($Matches.User)/$($Matches.Repo)"
     }
 
-    if(!$url) { return 'Please contact the bucket maintainer!' }
+    if (!$url) { return 'Please contact the bucket maintainer!' }
 
     # Print only github repositories
     if ($url -like '*github*') {
@@ -143,7 +177,7 @@ function new_issue_msg($app, $bucket, $title, $body) {
         $body = [System.Web.HttpUtility]::UrlEncode($body)
         $url = $url -replace '\.git$', ''
         $url = "$url/issues/new?title=$title"
-        if($body) {
+        if ($body) {
             $url += "&body=$body"
         }
     }

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -117,6 +117,8 @@ function Convert-RepositoryUri {
             $Matches.provider, $Matches.user, $Matches.repo -join '/'
         } else {
             error "$Uri is not a valid Git URL!"
+            error "Please see https://git-scm.com/docs/git-clone#_git_urls for valid ones."
+            exit 1
         }
     }
 }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -83,38 +83,6 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     show_notes $manifest $dir $original_dir $persist_dir
 }
 
-function locate($app, $bucket) {
-    Show-DeprecatedWarning $MyInvocation 'Find-Manifest'
-    return Find-Manifest $app $bucket
-}
-
-function Find-Manifest($app, $bucket) {
-    $manifest, $url = $null, $null
-
-    # check if app is a URL or UNC path
-    if($app -match '^(ht|f)tps?://|\\\\') {
-        $url = $app
-        $app = appname_from_url $url
-        $manifest = url_manifest $url
-    } else {
-        # check buckets
-        $manifest, $bucket = find_manifest $app $bucket
-
-        if(!$manifest) {
-            # couldn't find app in buckets: check if it's a local path
-            $path = $app
-            if(!$path.endswith('.json')) { $path += '.json' }
-            if(test-path $path) {
-                $url = "$(resolve-path $path)"
-                $app = appname_from_url $url
-                $manifest, $bucket = url_manifest $url
-            }
-        }
-    }
-
-    return $app, $manifest, $bucket, $url
-}
-
 function dl_with_cache($app, $version, $url, $to, $cookies = $null, $use_cache = $true) {
     $cached = fullpath (cache_path $app $version $url)
 

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -41,7 +41,8 @@ switch ($cmd) {
                 exit 1
             }
         }
-        add_bucket $name $repo
+        $status = add_bucket $name $repo
+        exit $status
     }
     'rm' {
         if (!$name) {
@@ -49,13 +50,16 @@ switch ($cmd) {
             $usage_rm
             exit 1
         }
-        rm_bucket $name
+        $status = rm_bucket $name
+        exit $status
     }
     'list' {
         list_buckets
+        exit 0
     }
     'known' {
         known_buckets
+        exit 0
     }
     default {
         "scoop bucket: cmd '$cmd' not supported"
@@ -63,5 +67,3 @@ switch ($cmd) {
         exit 1
     }
 }
-
-exit 0

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -23,42 +23,45 @@ param($cmd, $name, $repo)
 . "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-$usage_add = "usage: scoop bucket add <name> [<repo>]"
-$usage_rm = "usage: scoop bucket rm <name>"
-
-function list_buckets {
-    $buckets = @()
-
-    foreach ($bucket in Get-LocalBucket) {
-        $source = Find-BucketDirectory $bucket -Root
-        $manifests = (
-            Get-ChildItem "$source\bucket" -Force -Recurse -ErrorAction SilentlyContinue |
-            Measure-Object | Select-Object -ExpandProperty Count
-        )
-        $updated = 'N/A'
-        if ((Test-Path (Join-Path $source '.git')) -and (Get-Command git -ErrorAction SilentlyContinue)) {
-            $updated = git -C $source log --format='%aD' -n 1 | Get-Date
-            $source = git -C $source config remote.origin.url
-        } else {
-            $updated = (Get-Item "$source\bucket").LastWriteTime
-            $source = friendly_path $source
-        }
-        $buckets += New-Object PSObject -Property @{
-            Name      = $bucket
-            Source    = $source
-            Updated   = $updated
-            Manifests = $manifests
-        }
-    }
-    return $buckets | Select-Object Name, Source, Updated, Manifests
-}
+$usage_add = 'usage: scoop bucket add <name> [<repo>]'
+$usage_rm = 'usage: scoop bucket rm <name>'
 
 switch ($cmd) {
-    'add' { add_bucket $name $repo }
-    'rm' { rm_bucket $name }
-    'list' { list_buckets }
-    'known' { known_buckets }
-    default { "scoop bucket: cmd '$cmd' not supported"; my_usage; exit 1 }
+    'add' {
+        if (!$name) {
+            '<name> missing'
+            $usage_add
+            exit 1
+        }
+        if (!$repo) {
+            $repo = known_bucket_repo $name
+            if (!$repo) {
+                "Unknown bucket '$name'. Try specifying <repo>."
+                $usage_add
+                exit 1
+            }
+        }
+        add_bucket $name $repo
+    }
+    'rm' {
+        if (!$name) {
+            '<name> missing'
+            $usage_rm
+            exit 1
+        }
+        rm_bucket $name
+    }
+    'list' {
+        list_buckets
+    }
+    'known' {
+        known_buckets
+    }
+    default {
+        "scoop bucket: cmd '$cmd' not supported"
+        my_usage
+        exit 1
+    }
 }
 
 exit 0

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -7,17 +7,20 @@ param($app)
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 
-if($app) {
-    $manifest, $bucket = find_manifest $app
-    if($manifest) {
-        if([string]::isnullorempty($manifest.homepage)) {
+if ($app) {
+    $null, $manifest, $bucket, $null = Find-Manifest $app
+    if ($manifest) {
+        if ($manifest.homepage) {
+            Start-Process $manifest.homepage
+        } else {
             abort "Could not find homepage in manifest for '$app'."
         }
-        Start-Process $manifest.homepage
-    }
-    else {
+    } else {
         abort "Could not find manifest for '$app'."
     }
-} else { my_usage }
+} else {
+    my_usage
+    exit 1
+}
 
 exit 0

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -207,7 +207,7 @@ Function Submit-ToVirusTotal ($url, $app, $do_scan, $retrying=$False) {
 $apps | ForEach-Object {
     $app = $_
     # write-host $app
-    $manifest, $bucket = find_manifest $app
+    $null, $manifest, $bucket, $null = Find-Manifest $app
     if(!$manifest) {
         $exit_code = $exit_code -bor $_ERR_NO_INFO
         warn "$app`: manifest not found"

--- a/test/Import-Bucket-Tests.ps1
+++ b/test/Import-Bucket-Tests.ps1
@@ -125,4 +125,3 @@ Describe 'manifest validates against the schema' -Tag 'Manifests' {
         }
     }
 }
-


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

`find_manifest()` and `Find-Manifest()` (former `locate()`) have similar functionality and now be merged into `Find-Manifest()`.

Also move `list_buckets()` from `libexec\scoop-bucket.ps1` to `lib\buckets.ps1`.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Discussed with @rashil2000 

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`scoop bucket` and `scoop 

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
