### PR TITLE
fix(scoop-download): Add failure check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **installed:** If no `$global`, check both local and global installed ([#4798](https://github.com/ScoopInstaller/Scoop/issues/4798))
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))
+- **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/pull/4822))
 
 ### Code Refactoring
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -328,13 +328,7 @@ function Test-HelperInstalled {
 }
 
 function Test-Aria2Enabled {
-    $aria2_installed = Test-HelperInstalled -Helper Aria2
-    $aria2_enabled = get_config 'aria2-enabled' $true
-
-    if (!($aria2_installed) -and ($aria2_enabled)) {
-        warn "aria2 is enabled but not installed, using standard download instead."
-    }
-    return ($aria2_installed) -and ($aria2_enabled)
+    return (Test-HelperInstalled -Helper Aria2) -and (get_config 'aria2-enabled' $true)
 }
 
 function app_status($app, $global) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -328,7 +328,13 @@ function Test-HelperInstalled {
 }
 
 function Test-Aria2Enabled {
-    return (Test-HelperInstalled -Helper Aria2) -and (get_config 'aria2-enabled' $true)
+    $aria2_installed = Test-HelperInstalled -Helper Aria2
+    $aria2_enabled = get_config 'aria2-enabled' $true
+
+    if (!($aria2_installed) -and ($aria2_enabled)) {
+        warn "aria2 is enabled but not installed, using standard download instead."
+    }
+    return ($aria2_installed) -and ($aria2_enabled)
 }
 
 function app_status($app, $global) {

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -98,6 +98,7 @@ foreach ($curr_app in $apps) {
             } catch {
                 write-host -f darkred $_
                 error "URL $url is not valid"
+                $dl_failure = $true
                 continue
             }
 
@@ -124,7 +125,9 @@ foreach ($curr_app in $apps) {
         }
     }
 
-    success "'$app' ($version) was downloaded successfully!"
+    if (!$dl_failure) {
+        success "'$app' ($version) was downloaded successfully!"
+    }
 }
 
 exit 0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
- When `scoop-download` catches an error in `dl_with_cache`, now a variable is saved so that the final success message will not appear.
- ~When `aria2` is enabled but not installed, `Test-Aria2Enabled` now warns the user that the standard download method will be used instead of `aria2`~

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #4810

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I tested running this without internet and the failure was successfully caught, I tested both with aria2 and without so I have tested `dl_with_cache` and `dl_with_cache_aria2`.

This shows both changes in action:
```
❯ scoop config aria2-enabled
True

~
❯ c:\Users\me\Documents\GitHub\Scoop\libexec\scoop-download.ps1 protobuf
INFO  Starting download for protobuf...
WARN  aria2 is enabled but not installed, using standard download instead.
No such host is known. (github.com:443)
ERROR URL https://github.com/google/protobuf/releases/download/v3.19.4/protoc-3.19.4-win64.zip is not valid
```
^^ see no "success" and a warning about aria2!

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

^^ is there any documentation I should add and are there any tests to update?