### PR TITLE
Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Features
 
-- **install:** Allow downloading from private repositories ([$4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
+- **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
+- **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN ([#4832](https://github.com/ScoopInstaller/Scoop/pull/4832))
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ $env:SCOOP_CACHE='F:\ScoopCache'
 # run the installer
 ```
 
-### Configure Scoop to use a GitHub API token during searching and checkver by setting `SCOOP_CHECKVER_TOKEN`
+### Configure Scoop to use a GitHub API token during searching and checkver by setting `SCOOP_GH_TOKEN`
 
 ```powershell
-$env:SCOOP_CHECKVER_TOKEN='<paste-token-here>'
-[Environment]::SetEnvironmentVariable('SCOOP_CHECKVER_TOKEN', $env:SCOOP_CHECKVER_TOKEN, 'Machine')
+$env:SCOOP_GH_TOKEN='<paste-token-here>'
+[Environment]::SetEnvironmentVariable('SCOOP_GH_TOKEN', $env:SCOOP_GH_TOKEN, 'Machine')
 # search for an app
 ```
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -76,7 +76,7 @@ param(
 
 $Dir = Resolve-Path $Dir
 $Search = $App
-$GitHubToken = $env:SCOOP_CHECKVER_TOKEN, (get_config 'checkver-token') | Where-Object -Property Length -Value 0 -GT | Select-Object -First 1
+$GitHubToken = $env:SCOOP_GH_TOKEN, (get_config 'gh_token') | Where-Object -Property Length -Value 0 -GT | Select-Object -First 1
 
 # don't use $Version with $App = '*'
 if ($App -eq '*' -and $Version -ne '') {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1032,7 +1032,7 @@ function handle_special_urls($url)
     }
 
     # Github.com
-    if ($url -match 'github.com/(?<owner>[^/]+)/(?<repo>[^/]+)/releases/download/(?<tag>[^/]+)/(?<file>[^/#]+)(?<filename>.*)' -and ($token = get_config 'checkver_token')) {
+    if ($url -match 'github.com/(?<owner>[^/]+)/(?<repo>[^/]+)/releases/download/(?<tag>[^/]+)/(?<file>[^/#]+)(?<filename>.*)' -and ($token = get_config 'gh_token')) {
         $headers = @{ "Authorization" = "token $token" }
         $privateUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)"
         $assetUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)/releases/tags/$($Matches.tag)"

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -396,7 +396,7 @@ function dl($url, $to, $cookies, $progress) {
         }
         if ($url -match 'api\.github\.com/repos') {
             $wreq.Accept = 'application/octet-stream'
-            $wreq.Headers['Authorization'] = "token $(get_config 'checkver_token')"
+            $wreq.Headers['Authorization'] = "token $(get_config 'gh_token')"
         }
         if ($cookies) {
             $wreq.Headers.Add('Cookie', (cookie_header $cookies))

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -402,7 +402,7 @@ function dl($url, $to, $cookies, $progress) {
             $wreq.Headers.Add('Cookie', (cookie_header $cookies))
         }
 
-        get_config 'private_hosts' | Where-Object { $url -match $_.match } | ForEach-Object {
+        get_config 'private_hosts' | Where-Object { $_ -ne $null -and $url -match $_.match } | ForEach-Object {
             (ConvertFrom-StringData -StringData $_.Headers).GetEnumerator() | ForEach-Object {
                 $wreq.Headers[$_.Key] = $_.Value
             }

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -76,7 +76,7 @@
 # cachePath:
 #       For downloads, defaults to 'cache' folder under Scoop root directory.
 #
-# checkver_token:
+# gh_token:
 #       GitHub API token used to make authenticated requests.
 #       This is essential for checkver and similar functions to run without
 #       incurring rate limits and download from private repositories.


### PR DESCRIPTION
- Rename `checkver_token` to `gh_token` and `SCOOP_CHECKVER_TOKEN` to `SCOOP_GH_TOKEN`
- Follow up fix for https://github.com/ScoopInstaller/Scoop/pull/4254 (filtering null input in dl function when private_hosts is not set in config)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
