### PR TITLE
perf(scoop): Load libs only once

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -66,9 +66,9 @@ param(
 )
 
 . "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\autoupdate.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\autoupdate.ps1"
 . "$PSScriptRoot\..\lib\json.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\install.ps1" # needed for hash generation
@@ -102,7 +102,7 @@ Get-Event | ForEach-Object {
 $Queue | ForEach-Object {
     $name, $json = $_
 
-    $substitutions = Get-VersionSubstitution $json.version
+    $substitutions = Get-VersionSubstitution $json.version # 'autoupdate.ps1'
 
     $wc = New-Object Net.Webclient
     if ($json.checkver.useragent) {
@@ -334,7 +334,7 @@ while ($in_progress -gt 0) {
             Write-Host 'Forcing autoupdate!' -ForegroundColor DarkMagenta
         }
         try {
-            Invoke-AutoUpdate $App $Dir $json $ver $matchesHashtable
+            Invoke-AutoUpdate $App $Dir $json $ver $matchesHashtable # 'autoupdate.ps1'
         } catch {
             error $_.Exception.Message
         }

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 5
-param($cmd)
+param($SubCommand)
 
 Set-StrictMode -Off
 
@@ -14,25 +14,33 @@ Get-ChildItem Function: | Where-Object -Property Name -In -Value $aliases | ForE
     Set-Alias -Name $_.Name -Value Local:$($_.Name) -Scope Script
 }
 
-$commands = commands
-if ('--version' -contains $cmd -or (!$cmd -and $Args -eq '-v')) {
-    Write-Host 'Current Scoop version:'
-    Invoke-Expression "git -C '$(versiondir 'scoop' 'current')' --no-pager log --oneline HEAD -n 1"
-    Write-Host ''
+switch ($SubCommand) {
+    ({ $SubCommand -in @($null, '--help', '/?') }) {
+        exec 'help'
+    }
+    ({ $SubCommand -eq '--version' -or (!$SubCommand -and $Args -eq '-v') }) {
+        Write-Host 'Current Scoop version:'
+        Invoke-Expression "git -C '$(versiondir 'scoop' 'current')' --no-pager log --oneline HEAD -n 1"
+        Write-Host ''
 
-    Get-LocalBucket | ForEach-Object {
-        $bucketLoc = Find-BucketDirectory $_ -Root
-        if (Test-Path (Join-Path $bucketLoc '.git')) {
-            Write-Host "'$_' bucket:"
-            Invoke-Expression "git -C '$bucketLoc' --no-pager log --oneline HEAD -n 1"
-            Write-Host ''
+        Get-LocalBucket | ForEach-Object {
+            $bucketLoc = Find-BucketDirectory $_ -Root
+            if (Test-Path (Join-Path $bucketLoc '.git')) {
+                Write-Host "'$_' bucket:"
+                Invoke-Expression "git -C '$bucketLoc' --no-pager log --oneline HEAD -n 1"
+                Write-Host ''
+            }
         }
     }
-} elseif (@($null, '--help', '/?') -contains $cmd -or $Args[0] -eq '-h') {
-    exec 'help' "$cmd"
-} elseif ($commands -contains $cmd) {
-    exec $cmd $Args
-} else {
-    "scoop: '$cmd' isn't a scoop command. See 'scoop help'."
-    exit 1
+    ({ $SubCommand -in (commands) }) {
+        if ($Args -in @('-h', '--help', '/?')) {
+            exec 'help' @($SubCommand)
+        } else {
+            exec $SubCommand $Args
+        }
+    }
+    default {
+        "scoop: '$SubCommand' isn't a scoop command. See 'scoop help'."
+        exit 1
+    }
 }

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -1,10 +1,4 @@
-<#
-TODO
- - clean up
-#>
-. "$PSScriptRoot\core.ps1"
-. "$PSScriptRoot\json.ps1"
-
+# Must included with 'json.ps1'
 function find_hash_in_rdf([String] $url, [String] $basename) {
     $data = $null
     try {

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -1,5 +1,3 @@
-. "$PSScriptRoot\core.ps1"
-
 $bucketsdir = "$scoopdir\buckets"
 
 function Find-BucketDirectory {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -918,7 +918,7 @@ function show_app($app, $bucket, $version) {
 
 function last_scoop_update() {
     # PowerShell 6 returns an DateTime Object
-    $last_update = (scoop config lastupdate)
+    $last_update = (get_config lastupdate)
 
     if ($null -ne $last_update -and $last_update.GetType() -eq [System.String]) {
         try {
@@ -934,7 +934,7 @@ function is_scoop_outdated() {
     $last_update = $(last_scoop_update)
     $now = [System.DateTime]::Now
     if($null -eq $last_update) {
-        scoop config lastupdate $now.ToString('o')
+        set_config lastupdate $now.ToString('o')
         # enforce an update for the first time
         return $true
     }

--- a/lib/diagnostic.ps1
+++ b/lib/diagnostic.ps1
@@ -3,8 +3,6 @@ Diagnostic tests.
 Return $true if the test passed, otherwise $false.
 Use 'warn' to highlight the issue, and follow up with the recommended actions to rectify.
 #>
-. "$PSScriptRoot\buckets.ps1"
-
 function check_windows_defender($global) {
     $defender = Get-Service -Name WinDefend -ErrorAction SilentlyContinue
     if (Test-CommandAvailable Get-MpPreference) {
@@ -55,4 +53,3 @@ function check_long_paths {
 
     return $true
 }
-

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1,6 +1,3 @@
-. "$PSScriptRoot\autoupdate.ps1"
-. "$PSScriptRoot\buckets.ps1"
-
 function nightly_version($date, $quiet = $false) {
     $date_str = $date.tostring("yyyyMMdd")
     if (!$quiet) {

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -1,6 +1,3 @@
-. "$PSScriptRoot\core.ps1"
-. "$PSScriptRoot\autoupdate.ps1"
-
 function manifest_path($app, $bucket) {
     fullpath "$(Find-BucketDirectory $bucket)\$(sanitary_path $app).json"
 }
@@ -88,7 +85,7 @@ function supports_architecture($manifest, $architecture) {
     return -not [String]::IsNullOrEmpty((arch_specific 'url' $manifest $architecture))
 }
 
-function generate_user_manifest($app, $bucket, $version) {
+function generate_user_manifest($app, $bucket, $version) { # 'autoupdate.ps1' 'buckets.ps1' 'manifest.ps1'
     $null, $manifest, $bucket, $null = Find-Manifest $app $bucket
     if ("$($manifest.version)" -eq "$version") {
         return manifest_path $app $bucket

--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -1,4 +1,3 @@
-# versions
 function Get-LatestVersion {
     <#
     .SYNOPSIS
@@ -29,7 +28,7 @@ function Get-LatestVersion {
     }
 }
 
-function Select-CurrentVersion {
+function Select-CurrentVersion { # 'manifest.ps1'
     <#
     .SYNOPSIS
         Select current version of installed app, from 'current\manifest.json' or modified time of version directory

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -23,9 +23,7 @@ param(
     [Switch]$verbose = $false
 )
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\install.ps1" # shim related
 
 $script:config_alias = 'alias'
 

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -19,10 +19,6 @@
 #     scoop bucket known
 param($cmd, $name, $repo)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-
 $usage_add = 'usage: scoop bucket add <name> [<repo>]'
 $usage_rm = 'usage: scoop bucket rm <name>'
 

--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -12,8 +12,6 @@
 #     scoop cache rm *
 param($cmd)
 
-. "$PSScriptRoot\..\lib\help.ps1"
-
 function cacheinfo($file) {
     $app, $version, $url = $file.Name -split '#'
     New-Object PSObject -Property @{ Name = $app; Version = $version; Length = $file.Length; URL = $url }

--- a/libexec/scoop-cat.ps1
+++ b/libexec/scoop-cat.ps1
@@ -3,9 +3,8 @@
 
 param($app)
 
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\json.ps1" # 'ConvertToPrettyJson'
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
 
 if (!$app) { error '<app> missing'; my_usage; exit 1 }
 

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -3,7 +3,6 @@
 # Help: Performs a series of diagnostic tests to try to identify things that may
 # cause problems with Scoop.
 
-. "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\diagnostic.ps1"
 
 $issues = 0

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -9,13 +9,10 @@
 #   -g, --global       Cleanup a globally installed app
 #   -k, --cache        Remove outdated download cache
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Select-CurrentVersion' (indirectly)
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
+. "$PSScriptRoot\..\lib\install.ps1" # persist related
 
 $opt, $apps, $err = getopt $args 'gk' 'global', 'cache'
 if ($err) { "scoop cleanup: $err"; exit 1 }

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -132,9 +132,6 @@
 
 param($name, $value)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-
 if (!$name) {
     $scoopConfig
 } elseif ($name -like '--help') {

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -1,13 +1,9 @@
 # Usage: scoop depends <app>
 # Summary: List dependencies for an app
 
-. "$PSScriptRoot\..\lib\depends.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\decompress.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\depends.ps1" # 'Get-Dependency'
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture'
 
 $opt, $apps, $err = getopt $args 'a:' 'arch='
 $app = $apps[0]

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -15,10 +15,11 @@
 #   -u, --no-update-scoop     Don't update Scoop before downloading if it's outdated
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' (indirectly)
+. "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'generate_user_manifest' 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\install.ps1"
 
 $opt, $apps, $err = getopt $args 'fhua:' 'force', 'no-hash-check', 'no-update-scoop', 'arch='
 if ($err) { error "scoop download: $err"; exit 1 }

--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -2,10 +2,8 @@
 # Summary: Exports (an importable) list of installed apps
 # Help: Lists all installed apps.
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'Select-CurrentVersion' (indirectly)
 
 $def_arch = default_architecture
 

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -2,10 +2,6 @@
 # Summary: Show help for a command
 param($cmd)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\commands.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-
 function print_help($cmd) {
     $file = Get-Content (command_path $cmd) -raw
 

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -1,9 +1,8 @@
 # Usage: scoop hold <apps>
 # Summary: Hold an app to disable updates
 
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'install_info' 'Select-CurrentVersion' (indirectly)
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 $apps = $args
 

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -2,10 +2,7 @@
 # Summary: Opens the app homepage
 param($app)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
 
 if ($app) {
     $null, $manifest, $bucket, $null = Find-Manifest $app

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -3,11 +3,9 @@
 # Options:
 #   -v, --verbose       Show full paths and URLs
 
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-InstalledVersion'
 
 $opt, $app, $err = getopt $args 'v' 'verbose'
 if ($err) { error "scoop info: $err"; exit 1 }

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -17,16 +17,15 @@
 #   -s, --skip                Skip hash validation (use with caution!)
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\decompress.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' (indirectly)
+. "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'generate_user_manifest' 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\decompress.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 
 $opt, $apps, $err = getopt $args 'gikusa:' 'global', 'independent', 'no-cache', 'no-update-scoop', 'skip', 'arch='

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -3,10 +3,8 @@
 # Help: Lists all installed apps, or the apps matching the supplied query.
 param($query)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'parse_json' 'Select-CurrentVersion' (indirectly)
 
 $def_arch = default_architecture
 if (-not (Get-FormatData ScoopApps)) {

--- a/libexec/scoop-prefix.ps1
+++ b/libexec/scoop-prefix.ps1
@@ -2,14 +2,12 @@
 # Summary: Returns the path to the specified app
 param($app)
 
+. "$PSScriptRoot\..\lib\versions.ps1" # 'currentdir' (indirectly)
+
 if (!$app) {
-    . "$PSScriptRoot\..\lib\help.ps1"
     my_usage
     exit 1
 }
-
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
 
 $app_path = currentdir $app $false
 if (!(Test-Path $app_path)) {

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -4,12 +4,10 @@
 # if you've installed 'python' and 'python27', you can use 'scoop reset' to switch between
 # using one or the other.
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 
 $opt, $apps, $err = getopt $args

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -5,10 +5,9 @@
 # If used with [query], shows app names that match the query.
 # Without [query], shows all the available apps.
 param($query)
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
+
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'manifest'
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-LatestVersion'
 
 function bin_match($manifest, $query) {
     if(!$manifest.bin) { return $false }

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -29,7 +29,6 @@
 
 param($SubCommand, $ShimName, [Switch]$global)
 
-. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\install.ps1" # for rm_shim
 
 if ($SubCommand -notin @('add', 'rm', 'list', 'info', 'alter')) {

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -1,29 +1,24 @@
 # Usage: scoop status
 # Summary: Show status and check for new app versions
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'manifest' 'parse_json' "install_info"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 # check if scoop needs updating
 $currentdir = fullpath $(versiondir 'scoop' 'current')
 $needs_update = $false
 
-if(Test-Path "$currentdir\.git") {
+if (Test-Path "$currentdir\.git") {
     git_cmd -C "`"$currentdir`"" fetch -q origin
-    $commits = $(git -C $currentdir log "HEAD..origin/$(scoop config SCOOP_BRANCH)" --oneline)
-    if($commits) { $needs_update = $true }
-}
-else {
+    $commits = $(git -C $currentdir log "HEAD..origin/$(get_config SCOOP_BRANCH)" --oneline)
+    if ($commits) { $needs_update = $true }
+} else {
     $needs_update = $true
 }
 
-if($needs_update) {
+if ($needs_update) {
     warn "Scoop is out of date. Run 'scoop update' to get the latest changes."
-}
-else { success "Scoop is up to date."}
+} else { success 'Scoop is up to date.' }
 
 $failed = @()
 $outdated = @()
@@ -34,30 +29,30 @@ $onhold = @()
 $true, $false | ForEach-Object { # local and global apps
     $global = $_
     $dir = appsdir $global
-    if(!(Test-Path $dir)) { return }
+    if (!(Test-Path $dir)) { return }
 
-    Get-ChildItem $dir | Where-Object name -ne 'scoop' | ForEach-Object {
+    Get-ChildItem $dir | Where-Object name -NE 'scoop' | ForEach-Object {
         $app = $_.name
         $status = app_status $app $global
-        if($status.failed) {
+        if ($status.failed) {
             $failed += @{ $app = $status.version }
         }
-        if($status.removed) {
+        if ($status.removed) {
             $removed += @{ $app = $status.version }
         }
-        if($status.outdated) {
+        if ($status.outdated) {
             $outdated += @{ $app = @($status.version, $status.latest_version) }
-            if($status.hold) {
+            if ($status.hold) {
                 $onhold += @{ $app = @($status.version, $status.latest_version) }
             }
         }
-        if($status.missing_deps) {
-            $missing_deps += ,(@($app) + @($status.missing_deps))
+        if ($status.missing_deps) {
+            $missing_deps += , (@($app) + @($status.missing_deps))
         }
     }
 }
 
-if($outdated) {
+if ($outdated) {
     Write-Host -f DarkCyan 'Updates are available for:'
     $outdated.keys | ForEach-Object {
         $versions = $outdated.$_
@@ -65,7 +60,7 @@ if($outdated) {
     }
 }
 
-if($onhold) {
+if ($onhold) {
     Write-Host -f DarkCyan 'These apps are outdated and on hold:'
     $onhold.keys | ForEach-Object {
         $versions = $onhold.$_
@@ -73,21 +68,21 @@ if($onhold) {
     }
 }
 
-if($removed) {
+if ($removed) {
     Write-Host -f DarkCyan 'These app manifests have been removed:'
     $removed.keys | ForEach-Object {
         "    $_"
     }
 }
 
-if($failed) {
+if ($failed) {
     Write-Host -f DarkCyan 'These apps failed to install:'
     $failed.keys | ForEach-Object {
         "    $_"
     }
 }
 
-if($missing_deps) {
+if ($missing_deps) {
     Write-Host -f DarkCyan 'Missing runtime dependencies:'
     $missing_deps | ForEach-Object {
         $app, $deps = $_
@@ -95,8 +90,8 @@ if($missing_deps) {
     }
 }
 
-if(!$old -and !$removed -and !$failed -and !$missing_deps -and !$needs_update) {
-    success "Everything is ok!"
+if (!$old -and !$removed -and !$failed -and !$missing_deps -and !$needs_update) {
+    success 'Everything is ok!'
 }
 
 exit 0

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -1,9 +1,8 @@
 # Usage: scoop unhold <app>
 # Summary: Unhold an app to enable updates
 
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'install_info' 'Select-CurrentVersion' (indirectly)
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 $apps = $args
 

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -6,14 +6,12 @@
 #   -g, --global   Uninstall a globally installed app
 #   -p, --purge    Remove all persistent data
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 # options
 $opt, $apps, $err = getopt $args 'gp' 'global', 'purge'

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -14,14 +14,12 @@
 #   -q, --quiet               Hide extraneous messages
 #   -a, --all                 Update all apps (alternative to '*')
 
-. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"
 . "$PSScriptRoot\..\lib\decompress.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -34,24 +34,20 @@
 #   -n, --no-depends          By default, all dependencies are checked too. This flag avoids it.
 #   -u, --no-update-scoop     Don't update Scoop before checking if it's outdated
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\json.ps1"
-. "$PSScriptRoot\..\lib\decompress.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\json.ps1" # 'json_path'
+. "$PSScriptRoot\..\lib\install.ps1" # 'hash_for_url'
+. "$PSScriptRoot\..\lib\depends.ps1" # 'Get-Dependency'
 
 $opt, $apps, $err = getopt $args 'a:snu' @('arch=', 'scan', 'no-depends', 'no-update-scoop')
-if($err) { "scoop virustotal: $err"; exit 1 }
-if(!$apps) { my_usage; exit 1 }
+if ($err) { "scoop virustotal: $err"; exit 1 }
+if (!$apps) { my_usage; exit 1 }
 $architecture = ensure_architecture ($opt.a + $opt.arch)
 
 if (is_scoop_outdated) {
     if ($opt.u -or $opt.'no-update-scoop') {
-        warn "Scoop is out of date."
+        warn 'Scoop is out of date.'
     } else {
         scoop update
     }
@@ -59,7 +55,7 @@ if (is_scoop_outdated) {
 
 $apps_param = $apps
 
-if($apps_param -eq '*') {
+if ($apps_param -eq '*') {
     $apps = installed_apps $false
     $apps += installed_apps $true
 }
@@ -97,13 +93,13 @@ Function Get-VirusTotalResult($hash, $app) {
     $unsafe = [int]$malicious + [int]$suspicious
     $see_url = "see https://www.virustotal.com/#/file/$hash/detection"
     switch ($unsafe) {
-        0 { if ($undetected -eq 0) { $fg = "Yellow" } else { $fg = "DarkGreen" } }
-        1 { $fg = "DarkYellow" }
-        2 { $fg = "Yellow" }
-        default { $fg = "Red" }
+        0 { if ($undetected -eq 0) { $fg = 'Yellow' } else { $fg = 'DarkGreen' } }
+        1 { $fg = 'DarkYellow' }
+        2 { $fg = 'Yellow' }
+        default { $fg = 'Red' }
     }
-    write-host -f $fg "$app`: $unsafe/$undetected, $see_url"
-    if($unsafe -gt 0) {
+    Write-Host -f $fg "$app`: $unsafe/$undetected, $see_url"
+    if ($unsafe -gt 0) {
         return $_ERR_UNSAFE
     }
     return 0
@@ -130,16 +126,15 @@ Function Submit-RedirectedUrl {
     # Adapted according to Roy's response (January 23, 2014 at 11:59 am)
     # Adapted to always return an URL
     Param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [String]$URL
     )
     $request = [System.Net.WebRequest]::Create($url)
-    $request.AllowAutoRedirect=$false
-    $response=$request.GetResponse()
+    $request.AllowAutoRedirect = $false
+    $response = $request.GetResponse()
     if (([int]$response.StatusCode -ge 300) -and ([int]$response.StatusCode -lt 400)) {
-        $redir = $response.GetResponseHeader("Location")
-    }
-    else {
+        $redir = $response.GetResponseHeader('Location')
+    } else {
         $redir = $URL
     }
     $response.Close()
@@ -156,8 +151,8 @@ Function Submit-RedirectedUrl {
 #              submitting the file after a delay if the rate limit is
 #              exceeded, without risking an infinite loop (as stack
 #              overflow) if the submission keeps failing.
-Function Submit-ToVirusTotal ($url, $app, $do_scan, $retrying=$False) {
-    $api_key = get_config("virustotal_api_key")
+Function Submit-ToVirusTotal ($url, $app, $do_scan, $retrying = $False) {
+    $api_key = get_config virustotal_api_key
     if ($do_scan -and !$api_key -and !$warned_no_api_key) {
         $warned_no_api_key = $true
         info "Submitting unknown apps needs a VirusTotal API key.  " +

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -2,8 +2,6 @@
 # Summary: Locate a shim/executable (similar to 'which' on Linux)
 # Help: Locate the path to a shim/executable that was installed with Scoop (similar to 'which' on Linux)
 param($command)
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
 
 if (!$command) {
     'ERROR: <command> missing'

--- a/test/Scoop-Alias.Tests.ps1
+++ b/test/Scoop-Alias.Tests.ps1
@@ -1,3 +1,6 @@
+. "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\libexec\scoop-alias.ps1" | Out-Null
 
 Describe 'add_alias' -Tag 'Scoop' {

--- a/test/Scoop-Config.Tests.ps1
+++ b/test/Scoop-Config.Tests.ps1
@@ -1,3 +1,4 @@
+. "$PSScriptRoot\Scoop-TestLib.ps1"
 . "$PSScriptRoot\..\lib\core.ps1"
 
 Describe 'config' -Tag 'Scoop' {

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -1,7 +1,7 @@
+. "$PSScriptRoot\Scoop-TestLib.ps1"
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\unix.ps1"
-. "$PSScriptRoot\Scoop-TestLib.ps1"
 
 $repo_dir = (Get-Item $MyInvocation.MyCommand.Path).directory.parent.FullName
 $isUnix = is_unix

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -1,9 +1,10 @@
 . "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\decompress.ps1"
-. "$PSScriptRoot\..\lib\unix.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\unix.ps1"
 
 $isUnix = is_unix
 

--- a/test/Scoop-Depends.Tests.ps1
+++ b/test/Scoop-Depends.Tests.ps1
@@ -1,5 +1,7 @@
 . "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -1,8 +1,8 @@
+. "$PSScriptRoot\Scoop-TestLib.ps1"
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\unix.ps1"
-. "$PSScriptRoot\Scoop-TestLib.ps1"
 
 $isUnix = is_unix
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Only import libs once, and necessary libs (e.g. `core.ps1`, `buckets.ps1`, `commands.ps1` and `help.ps1`) are sourced in `bin\scoop.ps1`.

Also refactor `bin\scoop.ps1` file and fix help system. Now `scoop help <cmd>`, `scoop <cmd> --help`, `scoop <cmd> -h`, `scoop <cmd> /?` give subcommand help, and `scoop`, `scoop help`, `scoop --help`, `scoop -h`, `scoop /?` give scoop help.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tests are passed, and all command w/o args haven't error. More tests (subcommands') are needed.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
