### PR TITLE
feat(config): Try SCOOP_GH_TOKEN value first before gh_token value from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Features
 
 - **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
-- **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN ([#4832](https://github.com/ScoopInstaller/Scoop/pull/4832))
 
 ### Bug Fixes
 
@@ -20,6 +19,8 @@
 - **bucket:** Move 'Find-Manifest' and 'list_buckets' to 'buckets' ([#4814](https://github.com/ScoopInstaller/Scoop/issues/4814))
 - **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793))
 - **reset_aliases:** Move core function of `reset_aliases` to `scoop` ([#4794](https://github.com/ScoopInstaller/Scoop/issues/4794))
+- **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN ([#4832](https://github.com/ScoopInstaller/Scoop/pull/4832))
+- **config:** try SCOOP_GH_TOKEN value first before gh_token value from config ([#4842](https://github.com/ScoopInstaller/Scoop/pull/4842))
 
 ### Documentation
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -76,7 +76,7 @@ param(
 
 $Dir = Resolve-Path $Dir
 $Search = $App
-$GitHubToken = $env:SCOOP_GH_TOKEN, (get_config 'gh_token') | Where-Object -Property Length -Value 0 -GT | Select-Object -First 1
+$GitHubToken = Get-GitHubToken
 
 # don't use $Version with $App = '*'
 if ($App -eq '*' -and $Version -ne '') {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1005,6 +1005,10 @@ function get_hash([String] $multihash) {
     return $type, $hash.ToLower()
 }
 
+function Get-GitHubToken {
+    return $env:SCOOP_GH_TOKEN, (get_config 'gh_token') | Where-Object -Property Length -Value 0 -GT | Select-Object -First 1
+}
+
 function handle_special_urls($url)
 {
     # FossHub.com
@@ -1032,7 +1036,7 @@ function handle_special_urls($url)
     }
 
     # Github.com
-    if ($url -match 'github.com/(?<owner>[^/]+)/(?<repo>[^/]+)/releases/download/(?<tag>[^/]+)/(?<file>[^/#]+)(?<filename>.*)' -and ($token = get_config 'gh_token')) {
+    if ($url -match 'github.com/(?<owner>[^/]+)/(?<repo>[^/]+)/releases/download/(?<tag>[^/]+)/(?<file>[^/#]+)(?<filename>.*)' -and ($token = Get-GitHubToken)) {
         $headers = @{ "Authorization" = "token $token" }
         $privateUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)"
         $assetUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)/releases/tags/$($Matches.tag)"

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1,3 +1,4 @@
+. "$PSScriptRoot\core.ps1"
 . "$PSScriptRoot\autoupdate.ps1"
 . "$PSScriptRoot\buckets.ps1"
 
@@ -364,7 +365,7 @@ function dl($url, $to, $cookies, $progress) {
         }
         if ($url -match 'api\.github\.com/repos') {
             $wreq.Accept = 'application/octet-stream'
-            $wreq.Headers['Authorization'] = "token $(get_config 'gh_token')"
+            $wreq.Headers['Authorization'] = "token $(Get-GitHubToken)"
         }
         if ($cookies) {
             $wreq.Headers.Add('Cookie', (cookie_header $cookies))


### PR DESCRIPTION
#### Description
There are multiple usages of GitHub token value in the scoop (in checkver.ps1, core.ps1, install.ps1), but only in once place (in checkver.ps1), there is a logic to try using token value from `SCOOP_GH_TOKEN` environment variable first. This PR unifies the token value obtain logic and puts it into the function, which is used everywhere token value is needed.

#### Motivation
Using token in environment variable is needed for GitHub Actions setup (I am setting up GitHub Actions for private bucket right now and token is required for accessing artifacts located in private repository).

#### How Has This Been Tested?
Tested with private GitHub repositories using both `gh_token` and `SCOOP_GH_TOKEN` values.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
