### PR TITLE
fix(shim-kiennq): Update shimexe file name

### DIFF
--- a/supporting/shims/kiennq/Makefile
+++ b/supporting/shims/kiennq/Makefile
@@ -1,6 +1,6 @@
 
 VER?=2.2.1
-ZIP=shimexe-$(VER).zip
+ZIP=shimexe.zip
 URL?=https://github.com/kiennq/scoop-better-shimexe/releases/download/$(VER)/$(ZIP)
 LATEST_URL?=https://github.com/kiennq/scoop-better-shimexe/releases/latest
 NEWVER=$(shell cat version.txt)


### PR DESCRIPTION
With the new build pipeline in https://github.com/kiennq/scoop-better-shimexe/commit/db29490243810674bfa35c5017fbdc96acede9f9, the artifact name will be `shimexe.zip` only