### PR TITLE
feat(checkver): Add option to throw error as exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- **checkver:** Add option to throw error as exception ([#4863](https://github.com/ScoopInstaller/Scoop/issues/4863))
 - **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
 
 ### Bug Fixes

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -23,6 +23,8 @@
     An array of manifests, which should be updated all the time. (-ForceUpdate parameter to checkver)
 .PARAMETER SkipUpdated
     Updated manifests will not be shown.
+.PARAMETER ThrowError
+    Throw error as exception instead of just printing it.
 .EXAMPLE
     PS BUCKETROOT > .\bin\auto-pr.ps1 'someUsername/repository:branch' -Request
 .EXAMPLE
@@ -54,7 +56,8 @@ param(
     [Switch] $Request,
     [Switch] $Help,
     [string[]] $SpecialSnowflakes,
-    [Switch] $SkipUpdated
+    [Switch] $SkipUpdated,
+    [Switch] $ThrowError
 )
 
 . "$PSScriptRoot\..\lib\manifest.ps1"
@@ -160,11 +163,11 @@ if ($Push) {
     execute "hub push origin $OriginBranch"
 }
 
-. "$PSScriptRoot\checkver.ps1" -App $App -Dir $Dir -Update -SkipUpdated:$SkipUpdated
+. "$PSScriptRoot\checkver.ps1" -App $App -Dir $Dir -Update -SkipUpdated:$SkipUpdated -ThrowError:$ThrowError
 if ($SpecialSnowflakes) {
     Write-Host "Forcing update on our special snowflakes: $($SpecialSnowflakes -join ',')" -ForegroundColor DarkCyan
     $SpecialSnowflakes -split ',' | ForEach-Object {
-        . "$PSScriptRoot\checkver.ps1" $_ -Dir $Dir -ForceUpdate
+        . "$PSScriptRoot\checkver.ps1" $_ -Dir $Dir -ForceUpdate -ThrowError:$ThrowError
     }
 }
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -17,6 +17,8 @@
     Updated manifests will not be shown.
 .PARAMETER Version
     Update manifest to specific version.
+.PARAMETER ThrowError
+    Throw error as exception instead of just printing it.
 .EXAMPLE
     PS BUCKETROOT > .\bin\checkver.ps1
     Check all manifest inside default directory.
@@ -62,7 +64,8 @@ param(
     [Switch] $Update,
     [Switch] $ForceUpdate,
     [Switch] $SkipUpdated,
-    [String] $Version = ''
+    [String] $Version = '',
+    [Switch] $ThrowError
 )
 
 . "$PSScriptRoot\..\lib\core.ps1"
@@ -336,7 +339,11 @@ while ($in_progress -gt 0) {
         try {
             Invoke-AutoUpdate $App $Dir $json $ver $matchesHashtable
         } catch {
-            error $_.Exception.Message
+            if ($ThrowError) {
+                throw $_
+            } else {
+                error $_.Exception.Message
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/ScoopInstaller/Scoop/issues/4863

This is the core part of the change. The GitHub Action part is at https://github.com/ScoopInstaller/GithubActions/pull/5.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I created a Scoop bucket repo with some manifests in it. One manifest is intentionally old and requires update.

1. Make the manifest's `autoupdate` url wrong so it can't complete the autoupdate process.
2. Run the excavator workflow, observe the run completes successfully, though there is error message in the log (the option is disabled as default).
3. Add `THROW_ERROR` option to excavator.yml, make it '0'. Rerun the workflow. Observe the exact same result (because option is disabled as default).
4. Change `THROW_ERROR` to '1'. Rerun the workflow. Observe the run is now failed and GitHub sends notification to me. The log shows an error is thrown.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
