### PR TITLE
fix(bucket): Return empty list correctly in `Get-LocalBucket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))
 - **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/pull/4822))
 - **install:** Fix issue with installation inside containers ([#4837](https://github.com/ScoopInstaller/Scoop/pull/4837))
+- **bucket:** Return empty list correctly in `Get-LocalBucket` ([#4885](https://github.com/ScoopInstaller/Scoop/pull/4885))
 
 ### Performance Improvements
 

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -58,8 +58,12 @@ function Get-LocalBucket {
     .SYNOPSIS
         List all local buckets.
     #>
-
-    return (Get-ChildItem -Directory $bucketsdir).Name
+    $bucketNames = (Get-ChildItem -Path $bucketsdir -Directory).Name
+    if ($null -eq $bucketNames) {
+        return @() # Return a zero-length list instead of $null.
+    } else {
+        return $bucketNames
+    }
 }
 
 function buckets {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -187,6 +187,9 @@ function filesize($length) {
     } elseif($length -gt $kb) {
         "{0:n1} KB" -f ($length / $kb)
     } else {
+        if ($null -eq $length) {
+            $length = 0
+       }
         "$($length) B"
     }
 }

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -94,7 +94,7 @@ function list_aliases {
     }
 
     if (!$aliases.count) {
-        warn 'No aliases founds.'
+        info "No alias found."
     }
     $aliases = $aliases.GetEnumerator() | Sort-Object Name
     if ($verbose) {

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -50,8 +50,14 @@ switch ($cmd) {
         exit $status
     }
     'list' {
-        list_buckets
-        exit 0
+        $buckets = list_buckets
+        if (!$buckets.Length) {
+            warn "No bucket found. Please run 'scoop bucket add main' to add the default 'main' bucket."
+            exit 2
+        } else {
+            $buckets
+            exit 0
+        }
     }
     'known' {
         known_buckets


### PR DESCRIPTION
### Description

1. Return a zero-length list instead of `$null` in `Get-LocalBucket`.

2. Adjust the output message for `scoop alias list` when there is no alias found.

3. Adjust the output message for `scoop cache show` when there is no cache found.

### Motivation and Context

1. I ran into an error when I removed all buckets and was trying to add them back using URLs of mirrors, which means running `scoop bucket list` when there is nothing in `$SCOOP\buckets`:

	```
	Get-Item: <path_to_scoop>\apps\scoop\current\lib\buckets.ps1:134:32
	Line |
	 134 |              $bucket.Updated = (Get-Item "$path\bucket").LastWriteTime
	     |                                 ~~~~~~~~~~~~~~~~~~~~~~~
	     | Cannot find path '<path_to_scoop>\buckets\main\bucket' because it does not exist.
	```

	The `Get-LocalBucket` returns `$null` in this case, so `Find-BucketDirectory` gets the default value `main` for `$Name`:

	https://github.com/ScoopInstaller/Scoop/blob/e6d03715faa600046d1793f9c155f74857e4289e/lib/buckets.ps1#L126-L128

	https://github.com/ScoopInstaller/Scoop/blob/e6d03715faa600046d1793f9c155f74857e4289e/lib/buckets.ps1#L13-L14

	To fix this, we should use a zero-length list instead and give a tip of adding the default `main` bucket.

2. No additional description.

3. `scoop cache show` shows the following message when there is no cache found:

	```
	Total: 0 files,  B
	```

	I think it's better to change it to something like this:

	```
	No cache found.
	```

### How Has This Been Tested?

Just run as usual:

```powershell
scoop bucket list
scoop alias list
scoop cache show
```

### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
