### PR TITLE
chore(release): Bump to version 0.2.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,5 +29,7 @@ Relates to #XXXX
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
+- [ ] I have ensured that I am targeting the `develop` branch.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have updated the tests accordingly.
+- [ ] I have added an entry in the CHANGELOG.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **shim:** Manipulating shims with UTF8 encoding ([#4791](https://github.com/ScoopInstaller/Scoop/issues/4791), [#4813](https://github.com/ScoopInstaller/Scoop/issues/4813))
 - **shim:** Correctly quote $@ in sh->ps1 shims ([#4808](https://github.com/ScoopInstaller/Scoop/issues/4808))
 - **installed:** If no `$global`, check both local and global installed ([#4798](https://github.com/ScoopInstaller/Scoop/issues/4798))
+- **scoop-list**: Fix date in 'Updated' column showing the months in the place of minutes ([#4880](https://github.com/ScoopInstaller/Scoop/pull/4880))
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))
 - **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/pull/4822))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- **relicense:** Relicense to dual-license (Unlicense or MIT) ([#4903](https://github.com/ScoopInstaller/Scoop/issues/4903), [#4870](https://github.com/ScoopInstaller/Scoop/issues/4870))
 - **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4254))
 - **scoop-cleanup:** Add `-a/--all` switch to cleanup all apps ([#4906](https://github.com/ScoopInstaller/Scoop/issues/4906))
 
@@ -14,7 +15,7 @@
 - **shim:** Correctly quote $@ in sh->ps1 shims ([#4809](https://github.com/ScoopInstaller/Scoop/issues/4809))
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))
 - **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/issues/4822))
-- **scoop-list:**: Fix date in 'Updated' column showing the months in the place of minutes ([#4880](https://github.com/ScoopInstaller/Scoop/issues/4880))
+- **scoop-list:** Fix date in 'Updated' column showing the months in the place of minutes ([#4880](https://github.com/ScoopInstaller/Scoop/issues/4880))
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
 
 ### Performance Improvements
@@ -38,7 +39,7 @@
 - **changelog:** Rearrange CHANGELOG ([#4897](https://github.com/ScoopInstaller/Scoop/issues/4897))
 - **readme:** Update installation instruction ([#4825](https://github.com/ScoopInstaller/Scoop/issues/4825))
 - **readme:** Fix badges for Gitter and CI Tests ([#4830](https://github.com/ScoopInstaller/Scoop/issues/4830))
-- **scoop-shim:**: Fix typo ([#4836](https://github.com/ScoopInstaller/Scoop/issues/4836))
+- **scoop-shim:** Fix typo ([#4836](https://github.com/ScoopInstaller/Scoop/issues/4836))
 
 ## [v0.1.0](https://github.com/ScoopInstaller/Scoop/compare/2021-12-26...v0.1.0) - 2022-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
 
+### Bug Fixes
+
+- **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
+
 ### Code Refactoring
 
-- **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793)
+- **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793))
 
 ## [v0.1.0](https://github.com/ScoopInstaller/Scoop/compare/2021-12-26...v0.1.0) - 2022-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))
 - **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/pull/4822))
+- **install:** Fix issue with installation inside containers ([#4837](https://github.com/ScoopInstaller/Scoop/pull/4837))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- **checkver:** Add option to throw error as exception ([#4863](https://github.com/ScoopInstaller/Scoop/issues/4863))
 - **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Features
 
-- **install:** Allow downloading from private repositories ([$4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
+- **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
+- **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN ([#4832](https://github.com/ScoopInstaller/Scoop/pull/4832))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Documentation
 
+- **readme:** Update installation instruction ([#4825](https://github.com/ScoopInstaller/Scoop/issues/4825))
 - **readme:** Fix badges for Gitter and CI Tests ([#4830](https://github.com/ScoopInstaller/Scoop/issues/4830))
 - **scoop-shim:**: Fix typo ([#4836](https://github.com/ScoopInstaller/Scoop/issues/4836))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+## [v0.2.0](https://github.com/ScoopInstaller/Scoop/compare/v0.1.0...v0.2.0) - 2022-05-10
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- **shim:** Manipulating shims with UTF8 encoding ([#4791](https://github.com/ScoopInstaller/Scoop/issues/4791))
+- **shim:** Manipulating shims with UTF8 encoding ([#4791](https://github.com/ScoopInstaller/Scoop/issues/4791), [#4813](https://github.com/ScoopInstaller/Scoop/issues/4813))
 - **shim:** Correctly quote $@ in sh->ps1 shims ([#4808](https://github.com/ScoopInstaller/Scoop/issues/4808))
 - **installed:** If no `$global`, check both local and global installed ([#4798](https://github.com/ScoopInstaller/Scoop/issues/4798))
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/pull/4822))
 - **install:** Fix issue with installation inside containers ([#4837](https://github.com/ScoopInstaller/Scoop/pull/4837))
 
+### Performance Improvements
+
+- **scoop:** Load libs only once ([#4839](https://github.com/ScoopInstaller/Scoop/issues/4839))
+
 ### Code Refactoring
 
 - **bucket:** Move 'Find-Manifest' and 'list_buckets' to 'buckets' ([#4814](https://github.com/ScoopInstaller/Scoop/issues/4814))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 - **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN ([#4832](https://github.com/ScoopInstaller/Scoop/pull/4832))
 - **config:** try SCOOP_GH_TOKEN value first before gh_token value from config ([#4842](https://github.com/ScoopInstaller/Scoop/pull/4842))
 
+### Builds
+
+- **schema:** Remove 'description' from required fields ([#4853](https://github.com/ScoopInstaller/Scoop/issues/4853))
+
 ### Documentation
 
 - **readme:** Update installation instruction ([#4825](https://github.com/ScoopInstaller/Scoop/issues/4825))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Documentation
 
 - **readme:** Fix badges for Gitter and CI Tests ([#4830](https://github.com/ScoopInstaller/Scoop/issues/4830))
+- **scoop-shim:**: Fix typo ([#4836](https://github.com/ScoopInstaller/Scoop/issues/4836))
 
 ## [v0.1.0](https://github.com/ScoopInstaller/Scoop/compare/2021-12-26...v0.1.0) - 2022-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Performance Improvements
 
-- **scoop:** Load libs only once ([#4839](https://github.com/ScoopInstaller/Scoop/issues/4839))
+- **scoop:** Load libs only once ([#4839](https://github.com/ScoopInstaller/Scoop/issues/4839), [#4884](https://github.com/ScoopInstaller/Scoop/issues/4884))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+
+### Code Refactoring
+
+- **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793)
+
 ## [v0.1.0](https://github.com/ScoopInstaller/Scoop/compare/2021-12-26...v0.1.0) - 2022-03-01
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **installed:** If no `$global`, check both local and global installed ([#4798](https://github.com/ScoopInstaller/Scoop/issues/4798))
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))
+- **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/pull/4822))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- **installed:** If no `$global`, check both local and global installed ([#4798](https://github.com/ScoopInstaller/Scoop/issues/4798))
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
 
 ### Code Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))
 - **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/pull/4822))
 - **install:** Fix issue with installation inside containers ([#4837](https://github.com/ScoopInstaller/Scoop/pull/4837))
+- **bucket:** Return empty list correctly in `Get-LocalBucket` ([#4885](https://github.com/ScoopInstaller/Scoop/pull/4885))
 
 ### Performance Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **installed:** If no `$global`, check both local and global installed ([#4798](https://github.com/ScoopInstaller/Scoop/issues/4798))
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
+- **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
 
+### Features
+
+- **install:** Allow downloading from private repositories ([$4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
+
 ### Bug Fixes
 
 - **shim:** Manipulating shims with UTF8 encoding ([#4791](https://github.com/ScoopInstaller/Scoop/issues/4791), [#4813](https://github.com/ScoopInstaller/Scoop/issues/4813))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Code Refactoring
 
 - **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793))
+- **reset_aliases:** Move core function of `reset_aliases` to `scoop` ([#4794](https://github.com/ScoopInstaller/Scoop/issues/4794))
 
 ## [v0.1.0](https://github.com/ScoopInstaller/Scoop/compare/2021-12-26...v0.1.0) - 2022-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Features
 
-- **checkver:** Add option to throw error as exception ([#4863](https://github.com/ScoopInstaller/Scoop/issues/4863))
 - **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
 
 ### Bug Fixes
@@ -25,7 +24,8 @@
 
 ### Builds
 
-- **schema:** Remove 'description' from required fields ([#4853](https://github.com/ScoopInstaller/Scoop/issues/4853))
+- **checkver:** Add option to throw error as exception ([#4863](https://github.com/ScoopInstaller/Scoop/issues/4863))
+- **schema:** Remove 'description' from required fields ([#4853](https://github.com/ScoopInstaller/Scoop/issues/4853), [#4874](https://github.com/ScoopInstaller/Scoop/issues/4874))
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- **shim:** Manipulating shims with UTF8 encoding ([#4791](https://github.com/ScoopInstaller/Scoop/issues/4791))
 - **installed:** If no `$global`, check both local and global installed ([#4798](https://github.com/ScoopInstaller/Scoop/issues/4798))
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Code Refactoring
 
+- **bucket:** Move 'Find-Manifest' and 'list_buckets' to 'buckets' ([#4814](https://github.com/ScoopInstaller/Scoop/issues/4814))
 - **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793))
 - **reset_aliases:** Move core function of `reset_aliases` to `scoop` ([#4794](https://github.com/ScoopInstaller/Scoop/issues/4794))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ### Features
 
-- **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
+- **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4254))
 
 ### Bug Fixes
 
-- **shim:** Manipulating shims with UTF8 encoding ([#4791](https://github.com/ScoopInstaller/Scoop/issues/4791), [#4813](https://github.com/ScoopInstaller/Scoop/issues/4813))
-- **shim:** Correctly quote $@ in sh->ps1 shims ([#4808](https://github.com/ScoopInstaller/Scoop/issues/4808))
+- **bucket:** Return empty list correctly in `Get-LocalBucket` ([#4885](https://github.com/ScoopInstaller/Scoop/issues/4885))
+- **install:** Fix issue with installation inside containers ([#4837](https://github.com/ScoopInstaller/Scoop/issues/4837))
 - **installed:** If no `$global`, check both local and global installed ([#4798](https://github.com/ScoopInstaller/Scoop/issues/4798))
-- **scoop-list**: Fix date in 'Updated' column showing the months in the place of minutes ([#4880](https://github.com/ScoopInstaller/Scoop/pull/4880))
-- **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
+- **shim:** Manipulating shims with UTF8 encoding ([#4791](https://github.com/ScoopInstaller/Scoop/issues/4791), [#4813](https://github.com/ScoopInstaller/Scoop/issues/4813))
+- **shim:** Correctly quote $@ in sh->ps1 shims ([#4809](https://github.com/ScoopInstaller/Scoop/issues/4809))
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))
-- **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/pull/4822))
-- **install:** Fix issue with installation inside containers ([#4837](https://github.com/ScoopInstaller/Scoop/pull/4837))
-- **bucket:** Return empty list correctly in `Get-LocalBucket` ([#4885](https://github.com/ScoopInstaller/Scoop/pull/4885))
+- **scoop-download:** Add failure check ([#4822](https://github.com/ScoopInstaller/Scoop/issues/4822))
+- **scoop-list:**: Fix date in 'Updated' column showing the months in the place of minutes ([#4880](https://github.com/ScoopInstaller/Scoop/issues/4880))
+- **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
 
 ### Performance Improvements
 
@@ -25,16 +25,16 @@
 - **bucket:** Move 'Find-Manifest' and 'list_buckets' to 'buckets' ([#4814](https://github.com/ScoopInstaller/Scoop/issues/4814))
 - **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793))
 - **reset_aliases:** Move core function of `reset_aliases` to `scoop` ([#4794](https://github.com/ScoopInstaller/Scoop/issues/4794))
-- **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN ([#4832](https://github.com/ScoopInstaller/Scoop/pull/4832))
-- **config:** try SCOOP_GH_TOKEN value first before gh_token value from config ([#4842](https://github.com/ScoopInstaller/Scoop/pull/4842))
+- **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN ([#4832](https://github.com/ScoopInstaller/Scoop/issues/4832), [#4842](https://github.com/ScoopInstaller/Scoop/issues/4842))
 
 ### Builds
 
-- **checkver:** Add option to throw error as exception ([#4863](https://github.com/ScoopInstaller/Scoop/issues/4863))
+- **checkver:** Add option to throw error as exception ([#4867](https://github.com/ScoopInstaller/Scoop/issues/4867))
 - **schema:** Remove 'description' from required fields ([#4853](https://github.com/ScoopInstaller/Scoop/issues/4853), [#4874](https://github.com/ScoopInstaller/Scoop/issues/4874))
 
 ### Documentation
 
+- **changelog:** Rearrange CHANGELOG ([#4897](https://github.com/ScoopInstaller/Scoop/issues/4897))
 - **readme:** Update installation instruction ([#4825](https://github.com/ScoopInstaller/Scoop/issues/4825))
 - **readme:** Fix badges for Gitter and CI Tests ([#4830](https://github.com/ScoopInstaller/Scoop/issues/4830))
 - **scoop-shim:**: Fix typo ([#4836](https://github.com/ScoopInstaller/Scoop/issues/4836))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4254))
+- **scoop-cleanup:** Add `-a/--all` switch to cleanup all apps ([#4906](https://github.com/ScoopInstaller/Scoop/issues/4906))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Features
 
 - **install:** Allow downloading from private repositories ([#4254](https://github.com/ScoopInstaller/Scoop/issues/4243))
-- **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN ([#4832](https://github.com/ScoopInstaller/Scoop/pull/4832))
 
 ### Bug Fixes
 
@@ -20,6 +19,8 @@
 - **bucket:** Move 'Find-Manifest' and 'list_buckets' to 'buckets' ([#4814](https://github.com/ScoopInstaller/Scoop/issues/4814))
 - **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793))
 - **reset_aliases:** Move core function of `reset_aliases` to `scoop` ([#4794](https://github.com/ScoopInstaller/Scoop/issues/4794))
+- **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN ([#4832](https://github.com/ScoopInstaller/Scoop/pull/4832))
+- **config:** try SCOOP_GH_TOKEN value first before gh_token value from config ([#4842](https://github.com/ScoopInstaller/Scoop/pull/4842))
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - **shim:** Manipulating shims with UTF8 encoding ([#4791](https://github.com/ScoopInstaller/Scoop/issues/4791))
+- **shim:** Correctly quote $@ in sh->ps1 shims ([#4808](https://github.com/ScoopInstaller/Scoop/issues/4808))
 - **installed:** If no `$global`, check both local and global installed ([#4798](https://github.com/ScoopInstaller/Scoop/issues/4798))
 - **scoop-prefix:** Fix typo that breaks global installed apps ([#4795](https://github.com/ScoopInstaller/Scoop/issues/4795))
 - **update:** Skip logs starting with `(chore)` ([#4800](https://github.com/ScoopInstaller/Scoop/issues/4800))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - **relpath:** Use `$PSScriptRoot` instead of `relpath` ([#4793](https://github.com/ScoopInstaller/Scoop/issues/4793))
 - **reset_aliases:** Move core function of `reset_aliases` to `scoop` ([#4794](https://github.com/ScoopInstaller/Scoop/issues/4794))
 
+### Documentation
+
+- **readme:** Fix badges for Gitter and CI Tests ([#4830](https://github.com/ScoopInstaller/Scoop/issues/4830))
+
 ## [v0.1.0](https://github.com/ScoopInstaller/Scoop/compare/2021-12-26...v0.1.0) - 2022-03-01
 
 ### Features

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,27 @@
+SPDX-License-Identifier: UNLICENSE or MIT
+
+INFORMATION ABOUT THIS PROJECT'S LICENSE (SHORT)
+============================================================================================
+This project is licensed under the Unlicense or the MIT license,
+at your option.
+
+INFORMATION ABOUT THIS PROJECT'S LICENSE (LONG)
+============================================================================================
+This project ("Scoop") is free software, licensed under the Unlicense or the
+MIT license, at your option. Scoop was previously licensed under only the Unlicense,
+but was dual-licensed from version 0.2.0.
+
+Scoop comes with ABSOLUTELY NO WARRANTY. Use it at your own risk. Scoop is provided
+on an AS-IS BASIS and its contributors disclaim all warranties.
+
+You may use, modify, distribute, sell, copy, compile, or merge Scoop by any means.
+
+Copies of both licenses can be found below.
+
+THE LICENSE OF SCOOP
+============================================================================================
+Unlicense
+---------
 This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or
@@ -22,3 +46,28 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <http://unlicense.org/>
+
+MIT license
+-----------
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 Luke Sampson (https://github.com/lukesampson)
+Copyright (c) 2013-present Scoop contributors (https://github.com/ScoopInstaller/Scoop/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ $env:SCOOP_CACHE='F:\ScoopCache'
 # run the installer
 ```
 
-### Configure Scoop to use a GitHub API token during searching and checkver by setting `SCOOP_CHECKVER_TOKEN`
+### Configure Scoop to use a GitHub API token during searching and checkver by setting `SCOOP_GH_TOKEN`
 
 ```powershell
-$env:SCOOP_CHECKVER_TOKEN='<paste-token-here>'
-[Environment]::SetEnvironmentVariable('SCOOP_CHECKVER_TOKEN', $env:SCOOP_CHECKVER_TOKEN, 'Machine')
+$env:SCOOP_GH_TOKEN='<paste-token-here>'
+[Environment]::SetEnvironmentVariable('SCOOP_GH_TOKEN', $env:SCOOP_GH_TOKEN, 'Machine')
 # search for an app
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@
     <a href="https://github.com/ScoopInstaller/Scoop">
         <img src="https://img.shields.io/github/repo-size/ScoopInstaller/Scoop.svg" alt="Repository size" />
     </a>
-    <a href="https://ci.appveyor.com/project/ScoopInstaller/Scoop">
-        <img src="https://ci.appveyor.com/api/projects/status/05foxatmrqo0l788?svg=true" alt="Build Status" />
+    <a href="https://github.com/ScoopInstaller/Scoop/actions/workflows/ci.yml">
+        <img src="https://github.com/ScoopInstaller/Scoop/actions/workflows/ci.yml/badge.svg" alt="Scoop Core CI Tests" />
     </a>
     <a href="https://discord.gg/s9yRQHt">
         <img src="https://img.shields.io/badge/chat-on%20discord-7289DA.svg" alt="Discord Chat" />
     </a>
-    <a href="https://gitter.im/ScoopInstaller/Scoop">
-        <img src="https://badges.gitter.im/ScoopInstaller/Scoop.png" alt="Gitter Chat" />
+    <a href="https://gitter.im/lukesampson/scoop">
+        <img src="https://badges.gitter.im/lukesampson/scoop.png" alt="Gitter Chat" />
     </a>
     <a href="https://github.com/ScoopInstaller/Scoop/blob/master/LICENSE">
         <img src="https://img.shields.io/github/license/ScoopInstaller/Scoop.svg" alt="License" />

--- a/README.md
+++ b/README.md
@@ -56,60 +56,15 @@ scoop install python ruby go perl
 
 If you've built software that you'd like others to use, Scoop is an alternative to building an installer (e.g. MSI or InnoSetup) — you just need to zip your program and provide a JSON manifest that describes how to install it.
 
-## Requirements
-
-- Windows 7 SP1+ / Windows Server 2008+
-- [PowerShell 5](https://aka.ms/wmf5download) (or later, include [PowerShell Core](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-6)) and [.NET Framework 4.5](https://www.microsoft.com/net/download) (or later)
-- PowerShell must be enabled for your user account e.g. `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
-
 ## Installation
 
-Run the following command from your PowerShell to install scoop to its default location (`C:\Users\<user>\scoop`)
+Run the following command from a **non-admin** PowerShell to install scoop to its default location `C:\Users\<YOUR USERNAME>\scoop`.
 
 ```powershell
-Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-
-# or shorter
 iwr -useb get.scoop.sh | iex
 ```
 
-Once installed, run `scoop help` for instructions.
-
-The default setup is configured so all user installed programs and Scoop itself live in `C:\Users\<user>\scoop`.
-Globally installed programs (`--global`) live in `C:\ProgramData\scoop`.
-These settings can be changed through environment variables.
-
-### Install Scoop to a Custom Directory by changing `SCOOP`
-
-```powershell
-$env:SCOOP='D:\Applications\Scoop'
-[Environment]::SetEnvironmentVariable('SCOOP', $env:SCOOP, 'User')
-# run the installer
-```
-
-### Configure Scoop to install global programs to a Custom Directory by changing `SCOOP_GLOBAL`
-
-```powershell
-$env:SCOOP_GLOBAL='F:\GlobalScoopApps'
-[Environment]::SetEnvironmentVariable('SCOOP_GLOBAL', $env:SCOOP_GLOBAL, 'Machine')
-# run the installer
-```
-
-### Configure Scoop to store downloads to a Custom Directory by changing `SCOOP_CACHE`
-
-```powershell
-$env:SCOOP_CACHE='F:\ScoopCache'
-[Environment]::SetEnvironmentVariable('SCOOP_CACHE', $env:SCOOP_CACHE, 'Machine')
-# run the installer
-```
-
-### Configure Scoop to use a GitHub API token during searching and checkver by setting `SCOOP_GH_TOKEN`
-
-```powershell
-$env:SCOOP_GH_TOKEN='<paste-token-here>'
-[Environment]::SetEnvironmentVariable('SCOOP_GH_TOKEN', $env:SCOOP_GH_TOKEN, 'Machine')
-# search for an app
-```
+Advanced installation instruction and full documentation of the installer are available in [ScoopInstaller/Install](https://github.com/ScoopInstaller/Install). Please create new issues there if you have questions about the installation.
 
 ## [Documentation](https://github.com/ScoopInstaller/Scoop/wiki)
 

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -23,6 +23,8 @@
     An array of manifests, which should be updated all the time. (-ForceUpdate parameter to checkver)
 .PARAMETER SkipUpdated
     Updated manifests will not be shown.
+.PARAMETER ThrowError
+    Throw error as exception instead of just printing it.
 .EXAMPLE
     PS BUCKETROOT > .\bin\auto-pr.ps1 'someUsername/repository:branch' -Request
 .EXAMPLE
@@ -54,7 +56,8 @@ param(
     [Switch] $Request,
     [Switch] $Help,
     [string[]] $SpecialSnowflakes,
-    [Switch] $SkipUpdated
+    [Switch] $SkipUpdated,
+    [Switch] $ThrowError
 )
 
 . "$PSScriptRoot\..\lib\manifest.ps1"
@@ -160,11 +163,11 @@ if ($Push) {
     execute "hub push origin $OriginBranch"
 }
 
-. "$PSScriptRoot\checkver.ps1" -App $App -Dir $Dir -Update -SkipUpdated:$SkipUpdated
+. "$PSScriptRoot\checkver.ps1" -App $App -Dir $Dir -Update -SkipUpdated:$SkipUpdated -ThrowError:$ThrowError
 if ($SpecialSnowflakes) {
     Write-Host "Forcing update on our special snowflakes: $($SpecialSnowflakes -join ',')" -ForegroundColor DarkCyan
     $SpecialSnowflakes -split ',' | ForEach-Object {
-        . "$PSScriptRoot\checkver.ps1" $_ -Dir $Dir -ForceUpdate
+        . "$PSScriptRoot\checkver.ps1" $_ -Dir $Dir -ForceUpdate -ThrowError:$ThrowError
     }
 }
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -76,7 +76,7 @@ param(
 
 $Dir = Resolve-Path $Dir
 $Search = $App
-$GitHubToken = $env:SCOOP_GH_TOKEN, (get_config 'gh_token') | Where-Object -Property Length -Value 0 -GT | Select-Object -First 1
+$GitHubToken = Get-GitHubToken
 
 # don't use $Version with $App = '*'
 if ($App -eq '*' -and $Version -ne '') {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -76,7 +76,7 @@ param(
 
 $Dir = Resolve-Path $Dir
 $Search = $App
-$GitHubToken = $env:SCOOP_CHECKVER_TOKEN, (get_config 'checkver-token') | Where-Object -Property Length -Value 0 -GT | Select-Object -First 1
+$GitHubToken = $env:SCOOP_GH_TOKEN, (get_config 'gh_token') | Where-Object -Property Length -Value 0 -GT | Select-Object -First 1
 
 # don't use $Version with $App = '*'
 if ($App -eq '*' -and $Version -ne '') {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -17,6 +17,8 @@
     Updated manifests will not be shown.
 .PARAMETER Version
     Update manifest to specific version.
+.PARAMETER ThrowError
+    Throw error as exception instead of just printing it.
 .EXAMPLE
     PS BUCKETROOT > .\bin\checkver.ps1
     Check all manifest inside default directory.
@@ -62,7 +64,8 @@ param(
     [Switch] $Update,
     [Switch] $ForceUpdate,
     [Switch] $SkipUpdated,
-    [String] $Version = ''
+    [String] $Version = '',
+    [Switch] $ThrowError
 )
 
 . "$PSScriptRoot\..\lib\core.ps1"
@@ -336,7 +339,11 @@ while ($in_progress -gt 0) {
         try {
             Invoke-AutoUpdate $App $Dir $json $ver $matchesHashtable
         } catch {
-            error $_.Exception.Message
+            if ($ThrowError) {
+                throw $_
+            } else {
+                error $_.Exception.Message
+            }
         }
     }
 }

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -69,9 +69,9 @@ param(
 )
 
 . "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\autoupdate.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\autoupdate.ps1"
 . "$PSScriptRoot\..\lib\json.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\install.ps1" # needed for hash generation
@@ -105,7 +105,7 @@ Get-Event | ForEach-Object {
 $Queue | ForEach-Object {
     $name, $json = $_
 
-    $substitutions = Get-VersionSubstitution $json.version
+    $substitutions = Get-VersionSubstitution $json.version # 'autoupdate.ps1'
 
     $wc = New-Object Net.Webclient
     if ($json.checkver.useragent) {
@@ -337,7 +337,7 @@ while ($in_progress -gt 0) {
             Write-Host 'Forcing autoupdate!' -ForegroundColor DarkMagenta
         }
         try {
-            Invoke-AutoUpdate $App $Dir $json $ver $matchesHashtable
+            Invoke-AutoUpdate $App $Dir $json $ver $matchesHashtable # 'autoupdate.ps1'
         } catch {
             if ($ThrowError) {
                 throw $_

--- a/bin/refresh.ps1
+++ b/bin/refresh.ps1
@@ -1,7 +1,7 @@
 # for development, update the installed scripts to match local source
 . "$PSScriptRoot\..\lib\core.ps1"
 
-$src = relpath ".."
+$src = "$PSScriptRoot\.."
 $dest = ensure (versiondir 'scoop' 'current')
 
 # make sure not running from the installed directory

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -1,32 +1,56 @@
 #Requires -Version 5
-param($cmd)
+param($SubCommand)
 
-Set-StrictMode -off
+Set-StrictMode -Off
 
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\commands.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
+
 # for aliases where there's a local function, re-alias so the function takes precedence
 $aliases = Get-Alias | Where-Object { $_.Options -notmatch 'ReadOnly|AllScope' } | ForEach-Object { $_.Name }
 Get-ChildItem Function: | Where-Object -Property Name -In -Value $aliases | ForEach-Object {
     Set-Alias -Name $_.Name -Value Local:$($_.Name) -Scope Script
 }
 
-$commands = commands
-if ('--version' -contains $cmd -or (!$cmd -and '-v' -contains $args)) {
-    Write-Host "Current Scoop version:"
-    Invoke-Expression "git -C '$(versiondir 'scoop' 'current')' --no-pager log --oneline HEAD -n 1"
-    Write-Host ""
-
-    Get-LocalBucket | ForEach-Object {
-        $bucketLoc =  Find-BucketDirectory $_ -Root
-        if(Test-Path (Join-Path $bucketLoc '.git')) {
-            Write-Host "'$_' bucket:"
-            Invoke-Expression "git -C '$bucketLoc' --no-pager log --oneline HEAD -n 1"
-            Write-Host ""
+switch ($SubCommand) {
+    ({ $SubCommand -in @($null, '--help', '/?') }) {
+        if (!$SubCommand -and $Args -eq '-v') {
+            $SubCommand = '--version'
+        } else {
+            exec 'help'
         }
     }
+    ({ $SubCommand -eq '--version' }) {
+        Write-Host 'Current Scoop version:'
+        if ((Test-CommandAvailable git) -and (Test-Path "$PSScriptRoot\..\.git") -and (get_config SCOOP_BRANCH 'master') -ne 'master') {
+            Invoke-Expression "git -C '$PSScriptRoot\..' --no-pager log --oneline HEAD -n 1"
+        } else {
+            $version = Select-String -Pattern '^## \[(v[\d.]+)\].*?([\d-]+)$' -Path "$PSScriptRoot\..\CHANGELOG.md"
+            Write-Host $version.Matches.Groups[1].Value -ForegroundColor Cyan -NoNewline
+            Write-Host " - Released at $($version.Matches.Groups[2].Value)"
+        }
+        Write-Host ''
+
+        Get-LocalBucket | ForEach-Object {
+            $bucketLoc = Find-BucketDirectory $_ -Root
+            if ((Test-Path (Join-Path $bucketLoc '.git')) -and (Test-CommandAvailable git)) {
+                Write-Host "'$_' bucket:"
+                Invoke-Expression "git -C '$bucketLoc' --no-pager log --oneline HEAD -n 1"
+                Write-Host ''
+            }
+        }
+    }
+    ({ $SubCommand -in (commands) }) {
+        if ($Args -in @('-h', '--help', '/?')) {
+            exec 'help' @($SubCommand)
+        } else {
+            exec $SubCommand $Args
+        }
+    }
+    default {
+        "scoop: '$SubCommand' isn't a scoop command. See 'scoop help'."
+        exit 1
+    }
 }
-elseif (@($null, '--help', '/?') -contains $cmd -or $args[0] -contains '-h') { exec 'help' $args }
-elseif ($commands -contains $cmd) { exec $cmd $args }
-else { "scoop: '$cmd' isn't a scoop command. See 'scoop help'."; exit 1 }

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -6,8 +6,11 @@ Set-StrictMode -off
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\commands.ps1"
-
-reset_aliases
+# for aliases where there's a local function, re-alias so the function takes precedence
+$aliases = Get-Alias | Where-Object { $_.Options -notmatch 'ReadOnly|AllScope' } | ForEach-Object { $_.Name }
+Get-ChildItem Function: | Where-Object -Property Name -In -Value $aliases | ForEach-Object {
+    Set-Alias -Name $_.Name -Value Local:$($_.Name) -Scope Script
+}
 
 $commands = commands
 if ('--version' -contains $cmd -or (!$cmd -and '-v' -contains $args)) {

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -1,10 +1,4 @@
-<#
-TODO
- - clean up
-#>
-. "$PSScriptRoot\core.ps1"
-. "$PSScriptRoot\json.ps1"
-
+# Must included with 'json.ps1'
 function find_hash_in_rdf([String] $url, [String] $basename) {
     $data = $null
     try {

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -18,7 +18,9 @@ function Find-BucketDirectory {
     )
 
     # Handle info passing empty string as bucket ($install.bucket)
-    if(($null -eq $Name) -or ($Name -eq '')) { $Name = 'main' }
+    if (($null -eq $Name) -or ($Name -eq '')) {
+        $Name = 'main'
+    }
     $bucket = "$bucketsdir\$Name"
 
     if ((Test-Path "$bucket\bucket") -and !$Root) {
@@ -37,7 +39,7 @@ function bucketdir($name) {
 function known_bucket_repos {
     $json = "$PSScriptRoot\..\buckets.json"
 
-    return Get-Content $json -raw | convertfrom-json -ea stop
+    return Get-Content $json -Raw | ConvertFrom-Json -ErrorAction stop
 }
 
 function known_bucket_repo($name) {
@@ -46,11 +48,11 @@ function known_bucket_repo($name) {
 }
 
 function known_buckets {
-    known_bucket_repos | ForEach-Object { $_.psobject.properties | Select-Object -expand 'name' }
+    known_bucket_repos | ForEach-Object { $_.PSObject.Properties | Select-Object -Expand 'name' }
 }
 
 function apps_in_bucket($dir) {
-    return Get-ChildItem $dir | Where-Object { $_.Name.endswith('.json') } | ForEach-Object { $_.Name -replace '.json$', '' }
+    return Get-ChildItem $dir | Where-Object { $_.Name.EndsWith('.json') } | ForEach-Object { $_.Name -replace '.json$', '' }
 }
 
 function Get-LocalBucket {
@@ -68,57 +70,126 @@ function buckets {
     return Get-LocalBucket
 }
 
-function find_manifest($app, $bucket) {
-    if ($bucket) {
-        $manifest = manifest $app $bucket
-        if ($manifest) { return $manifest, $bucket }
-        return $null
+function Find-Manifest($app, $bucket) {
+    $manifest, $url = $null, $null
+
+    # check if app is a URL or UNC path
+    if ($app -match '^(ht|f)tps?://|\\\\') {
+        $url = $app
+        $app = appname_from_url $url
+        $manifest = url_manifest $url
+    } else {
+        if ($bucket) {
+            $manifest = manifest $app $bucket
+        } else {
+            foreach ($bucket in Get-LocalBucket) {
+                $manifest = manifest $app $bucket
+                if ($manifest) { break }
+            }
+        }
+
+        if (!$manifest) {
+            # couldn't find app in buckets: check if it's a local path
+            $path = $app
+            if (!$path.endswith('.json')) { $path += '.json' }
+            if (Test-Path $path) {
+                $url = "$(Resolve-Path $path)"
+                $app = appname_from_url $url
+                $manifest, $bucket = url_manifest $url
+            }
+        }
     }
 
-    foreach($bucket in Get-LocalBucket) {
-        $manifest = manifest $app $bucket
-        if($manifest) { return $manifest, $bucket }
+    return $app, $manifest, $bucket, $url
+}
+
+function Convert-RepositoryUri {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline = $true)]
+        [String] $Uri
+    )
+
+    process {
+        # https://git-scm.com/docs/git-clone#_git_urls
+        # https://regex101.com/r/xGmwRr/1
+        if ($Uri -match '(?:@|/{1,3})(?:www\.|.*@)?(?<provider>[^/]+?)(?::\d+)?[:/](?<user>.+)/(?<repo>.+?)(?:\.git)?/?$') {
+            $Matches.provider, $Matches.user, $Matches.repo -join '/'
+        } else {
+            error "$Uri is not a valid Git URL!"
+            error "Please see https://git-scm.com/docs/git-clone#_git_urls for valid ones."
+            return $null
+        }
     }
+}
+
+function list_buckets {
+    $buckets = @()
+    Get-LocalBucket | ForEach-Object {
+        $bucket = [Ordered]@{ Name = $_ }
+        $path = Find-BucketDirectory $_ -Root
+        if ((Test-Path (Join-Path $path '.git')) -and (Get-Command git -ErrorAction SilentlyContinue)) {
+            $bucket.Source = git -C $path config remote.origin.url
+            $bucket.Updated = git -C $path log --format='%aD' -n 1 | Get-Date
+        } else {
+            $bucket.Source = friendly_path $path
+            $bucket.Updated = (Get-Item "$path\bucket").LastWriteTime
+        }
+        $bucket.Manifests = Get-ChildItem "$path\bucket" -Force -Recurse -ErrorAction SilentlyContinue |
+                Measure-Object | Select-Object -ExpandProperty Count
+        $buckets += [PSCustomObject]$bucket
+    }
+    $buckets
 }
 
 function add_bucket($name, $repo) {
-    if (!$name) { "<name> missing"; $usage_add; exit 1 }
-    if (!$repo) {
-        $repo = known_bucket_repo $name
-        if (!$repo) { "Unknown bucket '$name'. Try specifying <repo>."; $usage_add; exit 1 }
-    }
-
     if (!(Test-CommandAvailable git)) {
-        abort "Git is required for buckets. Run 'scoop install git' and try again."
+        error "Git is required for buckets. Run 'scoop install git' and try again."
+        return 1
     }
 
     $dir = Find-BucketDirectory $name -Root
-    if (test-path $dir) {
+    if (Test-Path $dir) {
         warn "The '$name' bucket already exists. Use 'scoop bucket rm $name' to remove it."
-        exit 0
+        return 2
     }
 
-    write-host 'Checking repo... ' -nonewline
+    $uni_repo = Convert-RepositoryUri -Uri $repo
+    if ($null -eq $uni_repo) {
+        return 1
+    }
+    foreach ($bucket in Get-LocalBucket) {
+        $remote = git -C "$bucketsdir\$bucket" config --get remote.origin.url
+        if ((Convert-RepositoryUri -Uri $remote) -eq $uni_repo) {
+            warn "Bucket $bucket already exists for $repo"
+            return 2
+        }
+    }
+
+    Write-Host 'Checking repo... ' -NoNewline
     $out = git_cmd ls-remote $repo 2>&1
-    if ($lastexitcode -ne 0) {
-        abort "'$repo' doesn't look like a valid git repository`n`nError given:`n$out"
+    if ($LASTEXITCODE -ne 0) {
+        error "'$repo' doesn't look like a valid git repository`n`nError given:`n$out"
+        return 1
     }
-    write-host 'ok'
+    Write-Host 'OK'
 
-    ensure $bucketsdir > $null
+    ensure $bucketsdir | Out-Null
     $dir = ensure $dir
     git_cmd clone "$repo" "`"$dir`"" -q
     success "The $name bucket was added successfully."
+    return 0
 }
 
 function rm_bucket($name) {
-    if (!$name) { "<name> missing"; $usage_rm; exit 1 }
     $dir = Find-BucketDirectory $name -Root
-    if (!(test-path $dir)) {
-        abort "'$name' bucket not found."
+    if (!(Test-Path $dir)) {
+        error "'$name' bucket not found."
+        return 1
     }
 
-    Remove-Item $dir -r -force -ea stop
+    Remove-Item $dir -Recurse -Force -ErrorAction Stop
+    return 0
 }
 
 function new_issue_msg($app, $bucket, $title, $body) {
@@ -126,7 +197,7 @@ function new_issue_msg($app, $bucket, $title, $body) {
     $url = known_bucket_repo $bucket
     $bucket_path = "$bucketsdir\$bucket"
 
-    if (Test-path $bucket_path) {
+    if (Test-Path $bucket_path) {
         $remote = Invoke-Expression "git -C '$bucket_path' config --get remote.origin.url"
         # Support ssh and http syntax
         # git@PROVIDER:USER/REPO.git
@@ -135,7 +206,7 @@ function new_issue_msg($app, $bucket, $title, $body) {
         $url = "https://$($Matches.Provider)/$($Matches.User)/$($Matches.Repo)"
     }
 
-    if(!$url) { return 'Please contact the bucket maintainer!' }
+    if (!$url) { return 'Please contact the bucket maintainer!' }
 
     # Print only github repositories
     if ($url -like '*github*') {
@@ -143,7 +214,7 @@ function new_issue_msg($app, $bucket, $title, $body) {
         $body = [System.Web.HttpUtility]::UrlEncode($body)
         $url = $url -replace '\.git$', ''
         $url = "$url/issues/new?title=$title"
-        if($body) {
+        if ($body) {
             $url += "&body=$body"
         }
     }

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -58,8 +58,12 @@ function Get-LocalBucket {
     .SYNOPSIS
         List all local buckets.
     #>
-
-    return (Get-ChildItem -Directory $bucketsdir).Name
+    $bucketNames = (Get-ChildItem -Path $bucketsdir -Directory).Name
+    if ($null -eq $bucketNames) {
+        return @() # Return a zero-length list instead of $null.
+    } else {
+        return $bucketNames
+    }
 }
 
 function buckets {

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -1,5 +1,3 @@
-. "$PSScriptRoot\core.ps1"
-
 $bucketsdir = "$scoopdir\buckets"
 
 function Find-BucketDirectory {

--- a/lib/commands.ps1
+++ b/lib/commands.ps1
@@ -1,7 +1,6 @@
 function command_files {
-    (Get-ChildItem (relpath '..\libexec')) `
-        + (Get-ChildItem "$scoopdir\shims") `
-        | Where-Object { $_.name -match 'scoop-.*?\.ps1$' }
+    (Get-ChildItem "$PSScriptRoot\..\libexec") + (Get-ChildItem "$scoopdir\shims") |
+        Where-Object 'scoop-.*?\.ps1$' -Property Name -Match
 }
 
 function commands {
@@ -13,7 +12,7 @@ function command_name($filename) {
 }
 
 function command_path($cmd) {
-    $cmd_path = relpath "..\libexec\scoop-$cmd.ps1"
+    $cmd_path = "$PSScriptRoot\..\libexec\scoop-$cmd.ps1"
 
     # built in commands
     if (!(Test-Path $cmd_path)) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1030,6 +1030,18 @@ function handle_special_urls($url)
         # Reshapes the URL to avoid redirections
         $url = "https://downloads.sourceforge.net/project/$($matches['project'])/$($matches['file'])"
     }
+
+    # Github.com
+    if ($url -match 'github.com/(?<owner>[^/]+)/(?<repo>[^/]+)/releases/download/(?<tag>[^/]+)/(?<file>[^/#]+)(?<filename>.*)' -and ($token = get_config 'checkver_token')) {
+        $headers = @{ "Authorization" = "token $token" }
+        $privateUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)"
+        $assetUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)/releases/tags/$($Matches.tag)"
+
+        if ((Invoke-RestMethod -Uri $privateUrl -Headers $headers).Private) {
+            $url = ((Invoke-RestMethod -Uri $assetUrl -Headers $headers).Assets | Where-Object -Property Name -EQ -Value $Matches.file).Url, $Matches.filename -join ''
+        }
+    }
+
     return $url
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1032,7 +1032,7 @@ function handle_special_urls($url)
     }
 
     # Github.com
-    if ($url -match 'github.com/(?<owner>[^/]+)/(?<repo>[^/]+)/releases/download/(?<tag>[^/]+)/(?<file>[^/#]+)(?<filename>.*)' -and ($token = get_config 'checkver_token')) {
+    if ($url -match 'github.com/(?<owner>[^/]+)/(?<repo>[^/]+)/releases/download/(?<tag>[^/]+)/(?<file>[^/#]+)(?<filename>.*)' -and ($token = get_config 'gh_token')) {
         $headers = @{ "Authorization" = "token $token" }
         $privateUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)"
         $assetUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)/releases/tags/$($Matches.tag)"

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1005,6 +1005,10 @@ function get_hash([String] $multihash) {
     return $type, $hash.ToLower()
 }
 
+function Get-GitHubToken {
+    return $env:SCOOP_GH_TOKEN, (get_config 'gh_token') | Where-Object -Property Length -Value 0 -GT | Select-Object -First 1
+}
+
 function handle_special_urls($url)
 {
     # FossHub.com
@@ -1032,7 +1036,7 @@ function handle_special_urls($url)
     }
 
     # Github.com
-    if ($url -match 'github.com/(?<owner>[^/]+)/(?<repo>[^/]+)/releases/download/(?<tag>[^/]+)/(?<file>[^/#]+)(?<filename>.*)' -and ($token = get_config 'gh_token')) {
+    if ($url -match 'github.com/(?<owner>[^/]+)/(?<repo>[^/]+)/releases/download/(?<tag>[^/]+)/(?<file>[^/#]+)(?<filename>.*)' -and ($token = Get-GitHubToken)) {
         $headers = @{ "Authorization" = "token $token" }
         $privateUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)"
         $assetUrl = "https://api.github.com/repos/$($Matches.owner)/$($Matches.repo)/releases/tags/$($Matches.tag)"

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -187,6 +187,9 @@ function filesize($length) {
     } elseif($length -gt $kb) {
         "{0:n1} KB" -f ($length / $kb)
     } else {
+        if ($null -eq $length) {
+            $length = 0
+       }
         "$($length) B"
     }
 }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -697,9 +697,9 @@ function shim($path, $global, $name, $arg) {
             "#!/bin/sh",
             "# $resolved_path",
             "if command -v pwsh.exe > /dev/null 2>&1; then",
-            "    pwsh.exe -noprofile -ex unrestricted -file `"$resolved_path`" $arg $@",
+            "    pwsh.exe -noprofile -ex unrestricted -file `"$resolved_path`" $arg `"$@`"",
             "else",
-            "    powershell.exe -noprofile -ex unrestricted -file `"$resolved_path`" $arg $@",
+            "    powershell.exe -noprofile -ex unrestricted -file `"$resolved_path`" $arg `"$@`"",
             "fi"
         ) -join "`n" | Out-UTF8File $shim -NoNewLine
     } elseif ($path -match '\.jar$') {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -482,8 +482,8 @@ function Invoke-ExternalCommand {
         return $false
     }
     if ($LogPath -and ($FilePath -notmatch '(^|\W)msiexec($|\W)')) {
-        Out-File -FilePath $LogPath -Encoding Default -Append -InputObject $Process.StandardOutput.ReadToEnd()
-        Out-File -FilePath $LogPath -Encoding Default -Append -InputObject $Process.StandardError.ReadToEnd()
+        Out-UTF8File -FilePath $LogPath -Append -InputObject $Process.StandardOutput.ReadToEnd()
+        Out-UTF8File -FilePath $LogPath -Append -InputObject $Process.StandardError.ReadToEnd()
     }
     $Process.WaitForExit()
     if ($Process.ExitCode -ne 0) {
@@ -628,9 +628,9 @@ function shim($path, $global, $name, $arg) {
         # for programs with no awareness of any shell
         warn_on_overwrite "$shim.shim" $path
         Copy-Item (get_shim_path) "$shim.exe" -Force
-        Write-Output "path = `"$resolved_path`"" | Out-File "$shim.shim" -Encoding ASCII
+        Write-Output "path = `"$resolved_path`"" | Out-UTF8File "$shim.shim"
         if ($arg) {
-            Write-Output "args = $arg" | Out-File "$shim.shim" -Encoding ASCII -Append
+            Write-Output "args = $arg" | Out-UTF8File "$shim.shim" -Append
         }
     } elseif ($path -match '\.(bat|cmd)$') {
         # shim .bat, .cmd so they can be used by programs with no awareness of PSH
@@ -638,14 +638,14 @@ function shim($path, $global, $name, $arg) {
         @(
             "@rem $resolved_path",
             "@`"$resolved_path`" $arg %*"
-        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
+        ) -join "`r`n" | Out-UTF8File "$shim.cmd"
 
         warn_on_overwrite $shim $path
         @(
             "#!/bin/sh",
             "# $resolved_path",
             "MSYS2_ARG_CONV_EXCL=/C cmd.exe /C `"$resolved_path`" $arg `"$@`""
-        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
+        ) -join "`n" | Out-UTF8File $shim -NoNewLine
     } elseif ($path -match '\.ps1$') {
         # if $path points to another drive resolve-path prepends .\ which could break shims
         warn_on_overwrite "$shim.ps1" $path
@@ -664,7 +664,7 @@ function shim($path, $global, $name, $arg) {
                 "exit `$LASTEXITCODE"
             )
         }
-        $ps1text -join "`r`n" | Out-File "$shim.ps1" -Encoding ASCII
+        $ps1text -join "`r`n" | Out-UTF8File "$shim.ps1"
 
         # make ps1 accessible from cmd.exe
         warn_on_overwrite "$shim.cmd" $path
@@ -685,7 +685,7 @@ function shim($path, $global, $name, $arg) {
             ") else (",
             "    powershell -noprofile -ex unrestricted -file `"$resolved_path`" $arg %args%",
             ")"
-        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
+        ) -join "`r`n" | Out-UTF8File "$shim.cmd"
 
         warn_on_overwrite $shim $path
         @(
@@ -696,33 +696,33 @@ function shim($path, $global, $name, $arg) {
             "else",
             "    powershell.exe -noprofile -ex unrestricted -file `"$resolved_path`" $arg $@",
             "fi"
-        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
+        ) -join "`n" | Out-UTF8File $shim -NoNewLine
     } elseif ($path -match '\.jar$') {
         warn_on_overwrite "$shim.cmd" $path
         @(
             "@rem $resolved_path",
             "@java -jar `"$resolved_path`" $arg %*"
-        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
+        ) -join "`r`n" | Out-UTF8File "$shim.cmd"
 
         warn_on_overwrite $shim $path
         @(
             "#!/bin/sh",
             "# $resolved_path",
             "java.exe -jar `"$resolved_path`" $arg `"$@`""
-        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
+        ) -join "`n" | Out-UTF8File $shim -NoNewLine
     } elseif ($path -match '\.py$') {
         warn_on_overwrite "$shim.cmd" $path
         @(
             "@rem $resolved_path",
             "@python `"$resolved_path`" $arg %*"
-        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
+        ) -join "`r`n" | Out-UTF8File "$shim.cmd"
 
         warn_on_overwrite $shim $path
         @(
             "#!/bin/sh",
             "# $resolved_path",
             "python.exe `"$resolved_path`" $arg `"$@`""
-        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
+        ) -join "`n" | Out-UTF8File $shim -NoNewLine
     } else {
         warn_on_overwrite "$shim.cmd" $path
         # find path to Git's bash so that batch scripts can run bash scripts
@@ -733,14 +733,14 @@ function shim($path, $global, $name, $arg) {
         @(
             "@rem $resolved_path",
             "@`"$(Join-Path (Join-Path $gitdir.FullName 'bin') 'bash.exe')`" `"$resolved_path`" $arg %*"
-        ) -join "`r`n" | Out-File "$shim.cmd" -Encoding ASCII
+        ) -join "`r`n" | Out-UTF8File "$shim.cmd"
 
         warn_on_overwrite $shim $path
         @(
             "#!/bin/sh",
             "# $resolved_path",
             "`"$resolved_path`" $arg `"$@`""
-        ) -join "`n" | Out-File $shim -Encoding ASCII -NoNewline
+        ) -join "`n" | Out-UTF8File $shim -NoNewLine
     }
 }
 
@@ -1104,14 +1104,25 @@ function Out-UTF8File {
         [Parameter(Mandatory = $True, Position = 0)]
         [Alias("Path")]
         [String] $FilePath,
+        [Switch] $Append,
+        [Switch] $NoNewLine,
         [Parameter(ValueFromPipeline = $True)]
         [PSObject] $InputObject
     )
     process {
-        # Ref: https://stackoverflow.com/questions/5596982
-        # Performance Note: `WriteAllLines` throttles memory usage while
-        # `WriteAllText` needs to keep the complete string in memory.
-        [System.IO.File]::WriteAllLines($FilePath, $InputObject)
+        if ($Append) {
+            [System.IO.File]::AppendAllText($FilePath, $InputObject)
+        } else {
+            if (!$NoNewLine) {
+                # Ref: https://stackoverflow.com/questions/5596982
+                # Performance Note: `WriteAllLines` throttles memory usage while
+                # `WriteAllText` needs to keep the complete string in memory.
+                [System.IO.File]::WriteAllLines($FilePath, $InputObject)
+            } else {
+                # However `WriteAllText` does not add ending newline.
+                [System.IO.File]::WriteAllText($FilePath, $InputObject)
+            }
+        }
     }
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -404,7 +404,12 @@ function url_remote_filename($url) {
     return $basename
 }
 
-function ensure($dir) { if(!(test-path $dir)) { mkdir $dir > $null }; resolve-path $dir }
+function ensure($dir) {
+    if (!(Test-Path -Path $dir)) {
+        New-Item -Path $dir -ItemType Directory | Out-Null
+    }
+    Convert-Path -Path $dir
+}
 function fullpath($path) {
     # should be ~ rooted
     $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($path)
@@ -886,55 +891,6 @@ function wraptext($text, $width) {
 
 function pluralize($count, $singular, $plural) {
     if($count -eq 1) { $singular } else { $plural }
-}
-
-function reset_alias($name, $value) {
-    if($existing = get-alias $name -ea ignore | Where-Object { $_.options -match 'readonly' }) {
-        if($existing.definition -ne $value) {
-            write-host "Alias $name is read-only; can't reset it." -f darkyellow
-        }
-        return # already set
-    }
-    if($value -is [scriptblock]) {
-        if(!(test-path -path "function:script:$name")) {
-            new-item -path function: -name "script:$name" -value $value | out-null
-        }
-        return
-    }
-
-    set-alias $name $value -scope script -option allscope
-}
-
-function reset_aliases() {
-    # for aliases where there's a local function, re-alias so the function takes precedence
-    $aliases = get-alias | Where-Object { $_.options -notmatch 'readonly|allscope' } | ForEach-Object { $_.name }
-    get-childitem function: | ForEach-Object {
-        $fn = $_.name
-        if($aliases -contains $fn) {
-            set-alias $fn local:$fn -scope script
-        }
-    }
-
-    # for dealing with user aliases
-    $default_aliases = @{
-        'cp' = 'copy-item'
-        'echo' = 'write-output'
-        'gc' = 'get-content'
-        'gci' = 'get-childitem'
-        'gcm' = 'get-command'
-        'gm' = 'get-member'
-        'iex' = 'invoke-expression'
-        'ls' = 'get-childitem'
-        'mkdir' = { new-item -type directory @args }
-        'mv' = 'move-item'
-        'rm' = 'remove-item'
-        'sc' = 'set-content'
-        'select' = 'select-object'
-        'sls' = 'select-string'
-    }
-
-    # set default aliases
-    $default_aliases.keys | ForEach-Object { reset_alias $_ $default_aliases[$_] }
 }
 
 # convert list of apps to list of ($app, $global) tuples

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -402,10 +402,10 @@ function url_remote_filename($url) {
 }
 
 function ensure($dir) { if(!(test-path $dir)) { mkdir $dir > $null }; resolve-path $dir }
-function fullpath($path) { # should be ~ rooted
-    $executionContext.sessionState.path.getUnresolvedProviderPathFromPSPath($path)
+function fullpath($path) {
+    # should be ~ rooted
+    $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($path)
 }
-function relpath($path) { "$($myinvocation.psscriptroot)\$path" } # relative to calling script
 function friendly_path($path) {
     $h = (Get-PsProvider 'FileSystem').home; if(!$h.endswith('\')) { $h += '\' }
     if($h -eq '\') { return $path }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -918,7 +918,7 @@ function show_app($app, $bucket, $version) {
 
 function last_scoop_update() {
     # PowerShell 6 returns an DateTime Object
-    $last_update = (scoop config lastupdate)
+    $last_update = (get_config lastupdate)
 
     if ($null -ne $last_update -and $last_update.GetType() -eq [System.String]) {
         try {
@@ -934,7 +934,7 @@ function is_scoop_outdated() {
     $last_update = $(last_scoop_update)
     $now = [System.DateTime]::Now
     if($null -eq $last_update) {
-        scoop config lastupdate $now.ToString('o')
+        set_config lastupdate $now.ToString('o')
         # enforce an update for the first time
         return $true
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -215,6 +215,9 @@ function cache_path($app, $version, $url) { "$cachedir\$app#$version#$($url -rep
 # apps
 function sanitary_path($path) { return [regex]::replace($path, "[/\\?:*<>|]", "") }
 function installed($app, $global) {
+    if (-not $PSBoundParameters.ContainsKey('global')) {
+        return (installed $app $false) -or (installed $app $true)
+    }
     # Dependencies of the format "bucket/dependency" install in a directory of form
     # "dependency". So we need to extract the bucket from the name and only give the app
     # name to is_directory

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -55,7 +55,8 @@ function Expand-7zipArchive {
         # Check for tar
         $Status = Invoke-ExternalCommand $7zPath @('l', "`"$Path`"") -LogPath $LogPath
         if ($Status) {
-            $TarFile = (Get-Content -Path $LogPath)[-5] -replace '.{53}(.*)', '$1' # get inner tar file name
+            # get inner tar file name
+            $TarFile = (Select-String -Path $LogPath -Pattern '[^ ]*tar$').Matches.Value
             Expand-7zipArchive -Path "$DestinationPath\$TarFile" -DestinationPath $DestinationPath -ExtractDir $ExtractDir -Removal
         } else {
             abort "Failed to list files in $Path.`nNot a 7-Zip supported archive file."

--- a/lib/diagnostic.ps1
+++ b/lib/diagnostic.ps1
@@ -3,8 +3,6 @@ Diagnostic tests.
 Return $true if the test passed, otherwise $false.
 Use 'warn' to highlight the issue, and follow up with the recommended actions to rectify.
 #>
-. "$PSScriptRoot\buckets.ps1"
-
 function check_windows_defender($global) {
     $defender = Get-Service -Name WinDefend -ErrorAction SilentlyContinue
     if (Test-CommandAvailable Get-MpPreference) {
@@ -55,4 +53,3 @@ function check_long_paths {
 
     return $true
 }
-

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1,3 +1,4 @@
+. "$PSScriptRoot\core.ps1"
 . "$PSScriptRoot\autoupdate.ps1"
 . "$PSScriptRoot\buckets.ps1"
 
@@ -364,7 +365,7 @@ function dl($url, $to, $cookies, $progress) {
         }
         if ($url -match 'api\.github\.com/repos') {
             $wreq.Accept = 'application/octet-stream'
-            $wreq.Headers['Authorization'] = "token $(get_config 'gh_token')"
+            $wreq.Headers['Authorization'] = "token $(Get-GitHubToken)"
         }
         if ($cookies) {
             $wreq.Headers.Add('Cookie', (cookie_header $cookies))

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -396,13 +396,13 @@ function dl($url, $to, $cookies, $progress) {
         }
         if ($url -match 'api\.github\.com/repos') {
             $wreq.Accept = 'application/octet-stream'
-            $wreq.Headers['Authorization'] = "token $(get_config 'checkver_token')"
+            $wreq.Headers['Authorization'] = "token $(get_config 'gh_token')"
         }
         if ($cookies) {
             $wreq.Headers.Add('Cookie', (cookie_header $cookies))
         }
 
-        get_config 'private_hosts' | Where-Object { $url -match $_.match } | ForEach-Object {
+        get_config 'private_hosts' | Where-Object { $_ -ne $null -and $url -match $_.match } | ForEach-Object {
             (ConvertFrom-StringData -StringData $_.Headers).GetEnumerator() | ForEach-Object {
                 $wreq.Headers[$_.Key] = $_.Value
             }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -83,38 +83,6 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     show_notes $manifest $dir $original_dir $persist_dir
 }
 
-function locate($app, $bucket) {
-    Show-DeprecatedWarning $MyInvocation 'Find-Manifest'
-    return Find-Manifest $app $bucket
-}
-
-function Find-Manifest($app, $bucket) {
-    $manifest, $url = $null, $null
-
-    # check if app is a URL or UNC path
-    if($app -match '^(ht|f)tps?://|\\\\') {
-        $url = $app
-        $app = appname_from_url $url
-        $manifest = url_manifest $url
-    } else {
-        # check buckets
-        $manifest, $bucket = find_manifest $app $bucket
-
-        if(!$manifest) {
-            # couldn't find app in buckets: check if it's a local path
-            $path = $app
-            if(!$path.endswith('.json')) { $path += '.json' }
-            if(test-path $path) {
-                $url = "$(resolve-path $path)"
-                $app = appname_from_url $url
-                $manifest, $bucket = url_manifest $url
-            }
-        }
-    }
-
-    return $app, $manifest, $bucket, $url
-}
-
 function dl_with_cache($app, $version, $url, $to, $cookies = $null, $use_cache = $true) {
     $cached = fullpath (cache_path $app $version $url)
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1,7 +1,3 @@
-. "$PSScriptRoot\core.ps1"
-. "$PSScriptRoot\autoupdate.ps1"
-. "$PSScriptRoot\buckets.ps1"
-
 function nightly_version($date, $quiet = $false) {
     $date_str = $date.tostring("yyyyMMdd")
     if (!$quiet) {

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -1,6 +1,3 @@
-. "$PSScriptRoot\core.ps1"
-. "$PSScriptRoot\autoupdate.ps1"
-
 function manifest_path($app, $bucket) {
     fullpath "$(Find-BucketDirectory $bucket)\$(sanitary_path $app).json"
 }
@@ -88,7 +85,7 @@ function supports_architecture($manifest, $architecture) {
     return -not [String]::IsNullOrEmpty((arch_specific 'url' $manifest $architecture))
 }
 
-function generate_user_manifest($app, $bucket, $version) {
+function generate_user_manifest($app, $bucket, $version) { # 'autoupdate.ps1' 'buckets.ps1' 'manifest.ps1'
     $null, $manifest, $bucket, $null = Find-Manifest $app $bucket
     if ("$($manifest.version)" -eq "$version") {
         return manifest_path $app $bucket

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -45,7 +45,7 @@ function save_install_info($info, $dir) {
     $nulls = $info.keys | Where-Object { $null -eq $info[$_] }
     $nulls | ForEach-Object { $info.remove($_) } # strip null-valued
 
-    $file_content = $info | ConvertToPrettyJson
+    $file_content = $info | ConvertToPrettyJson # in 'json.ps1'
     [System.IO.File]::WriteAllLines("$dir\install.json", $file_content)
 }
 

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -26,7 +26,7 @@ function install_psmodule($manifest, $dir, $global) {
         Remove-Item -Path $linkfrom -Force -ErrorAction SilentlyContinue
     }
 
-    New-Item -Path $linkfrom -ItemType Junction -Value $dir | Out-Null
+    New-DirectoryJunction $linkfrom $dir | Out-Null
 }
 
 function uninstall_psmodule($manifest, $dir, $global) {

--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -1,4 +1,3 @@
-# versions
 function Get-LatestVersion {
     <#
     .SYNOPSIS
@@ -29,7 +28,7 @@ function Get-LatestVersion {
     }
 }
 
-function Select-CurrentVersion {
+function Select-CurrentVersion { # 'manifest.ps1'
     <#
     .SYNOPSIS
         Select current version of installed app, from 'current\manifest.json' or modified time of version directory

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -94,7 +94,7 @@ function list_aliases {
     }
 
     if (!$aliases.count) {
-        warn 'No aliases founds.'
+        info "No alias found."
     }
     $aliases = $aliases.GetEnumerator() | Sort-Object Name
     if ($verbose) {

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -23,9 +23,7 @@ param(
     [Switch]$verbose = $false
 )
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\install.ps1" # shim related
 
 $script:config_alias = 'alias'
 

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -58,7 +58,7 @@ function add_alias($name, $command) {
 # Summary: $description
 $command
 "@
-    $script | Out-File "$shimdir\$alias_file.ps1" -Encoding ASCII
+    $script | Out-UTF8File "$shimdir\$alias_file.ps1"
 
     # add alias to config
     $aliases | Add-Member -MemberType NoteProperty -Name $name -Value $alias_file

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -23,8 +23,6 @@ param($cmd, $name, $repo)
 . "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 $usage_add = "usage: scoop bucket add <name> [<repo>]"
 $usage_rm = "usage: scoop bucket rm <name>"
 

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -23,42 +23,47 @@ param($cmd, $name, $repo)
 . "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-$usage_add = "usage: scoop bucket add <name> [<repo>]"
-$usage_rm = "usage: scoop bucket rm <name>"
-
-function list_buckets {
-    $buckets = @()
-
-    foreach ($bucket in Get-LocalBucket) {
-        $source = Find-BucketDirectory $bucket -Root
-        $manifests = (
-            Get-ChildItem "$source\bucket" -Force -Recurse -ErrorAction SilentlyContinue |
-            Measure-Object | Select-Object -ExpandProperty Count
-        )
-        $updated = 'N/A'
-        if ((Test-Path (Join-Path $source '.git')) -and (Get-Command git -ErrorAction SilentlyContinue)) {
-            $updated = git -C $source log --format='%aD' -n 1 | Get-Date
-            $source = git -C $source config remote.origin.url
-        } else {
-            $updated = (Get-Item "$source\bucket").LastWriteTime
-            $source = friendly_path $source
-        }
-        $buckets += New-Object PSObject -Property @{
-            Name      = $bucket
-            Source    = $source
-            Updated   = $updated
-            Manifests = $manifests
-        }
-    }
-    return $buckets | Select-Object Name, Source, Updated, Manifests
-}
+$usage_add = 'usage: scoop bucket add <name> [<repo>]'
+$usage_rm = 'usage: scoop bucket rm <name>'
 
 switch ($cmd) {
-    'add' { add_bucket $name $repo }
-    'rm' { rm_bucket $name }
-    'list' { list_buckets }
-    'known' { known_buckets }
-    default { "scoop bucket: cmd '$cmd' not supported"; my_usage; exit 1 }
+    'add' {
+        if (!$name) {
+            '<name> missing'
+            $usage_add
+            exit 1
+        }
+        if (!$repo) {
+            $repo = known_bucket_repo $name
+            if (!$repo) {
+                "Unknown bucket '$name'. Try specifying <repo>."
+                $usage_add
+                exit 1
+            }
+        }
+        $status = add_bucket $name $repo
+        exit $status
+    }
+    'rm' {
+        if (!$name) {
+            '<name> missing'
+            $usage_rm
+            exit 1
+        }
+        $status = rm_bucket $name
+        exit $status
+    }
+    'list' {
+        list_buckets
+        exit 0
+    }
+    'known' {
+        known_buckets
+        exit 0
+    }
+    default {
+        "scoop bucket: cmd '$cmd' not supported"
+        my_usage
+        exit 1
+    }
 }
-
-exit 0

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -19,10 +19,6 @@
 #     scoop bucket known
 param($cmd, $name, $repo)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-
 $usage_add = 'usage: scoop bucket add <name> [<repo>]'
 $usage_rm = 'usage: scoop bucket rm <name>'
 

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -50,8 +50,14 @@ switch ($cmd) {
         exit $status
     }
     'list' {
-        list_buckets
-        exit 0
+        $buckets = list_buckets
+        if (!$buckets.Length) {
+            warn "No bucket found. Please run 'scoop bucket add main' to add the default 'main' bucket."
+            exit 2
+        } else {
+            $buckets
+            exit 0
+        }
     }
     'known' {
         known_buckets

--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -12,8 +12,6 @@
 #     scoop cache rm *
 param($cmd)
 
-. "$PSScriptRoot\..\lib\help.ps1"
-
 function cacheinfo($file) {
     $app, $version, $url = $file.Name -split '#'
     New-Object PSObject -Property @{ Name = $app; Version = $version; Length = $file.Length; URL = $url }

--- a/libexec/scoop-cat.ps1
+++ b/libexec/scoop-cat.ps1
@@ -7,8 +7,6 @@ param($app)
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 if (!$app) { error '<app> missing'; my_usage; exit 1 }
 
 $app, $bucket, $null = parse_app $app

--- a/libexec/scoop-cat.ps1
+++ b/libexec/scoop-cat.ps1
@@ -3,9 +3,8 @@
 
 param($app)
 
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\json.ps1" # 'ConvertToPrettyJson'
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
 
 if (!$app) { error '<app> missing'; my_usage; exit 1 }
 

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -3,7 +3,6 @@
 # Help: Performs a series of diagnostic tests to try to identify things that may
 # cause problems with Scoop.
 
-. "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\diagnostic.ps1"
 
 $issues = 0

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -9,13 +9,10 @@
 #   -g, --global       Cleanup a globally installed app
 #   -k, --cache        Remove outdated download cache
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Select-CurrentVersion' (indirectly)
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
+. "$PSScriptRoot\..\lib\install.ps1" # persist related
 
 $opt, $apps, $err = getopt $args 'gk' 'global', 'cache'
 if ($err) { "scoop cleanup: $err"; exit 1 }

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -3,9 +3,10 @@
 # Help: 'scoop cleanup' cleans Scoop apps by removing old versions.
 # 'scoop cleanup <app>' cleans up the old versions of that app if said versions exist.
 #
-# You can use '*' in place of <app> to cleanup all apps.
+# You can use '*' in place of <app> or `-a`/`--all` switch to cleanup all apps.
 #
 # Options:
+#   -a, --all          Cleanup all apps (alternative to '*')
 #   -g, --global       Cleanup a globally installed app
 #   -k, --cache        Remove outdated download cache
 
@@ -14,12 +15,13 @@
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\install.ps1" # persist related
 
-$opt, $apps, $err = getopt $args 'gk' 'global', 'cache'
+$opt, $apps, $err = getopt $args 'agk' 'all', 'global', 'cache'
 if ($err) { "scoop cleanup: $err"; exit 1 }
 $global = $opt.g -or $opt.global
 $cache = $opt.k -or $opt.cache
+$all = $opt.a -or $opt.all
 
-if (!$apps) { 'ERROR: <app> missing'; my_usage; exit 1 }
+if (!$apps -and !$all) { 'ERROR: <app> missing'; my_usage; exit 1 }
 
 if ($global -and !(is_admin)) {
     'ERROR: you need admin rights to cleanup global apps'; exit 1
@@ -59,8 +61,8 @@ function cleanup($app, $global, $verbose, $cache) {
     Write-Host ''
 }
 
-if ($apps) {
-    if ($apps -eq '*') {
+if ($apps -or $all) {
+    if ($apps -eq '*' -or $all) {
         $verbose = $false
         $apps = applist (installed_apps $false) $false
         if ($global) {

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -17,8 +17,6 @@
 . "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'gk' 'global', 'cache'
 if ($err) { "scoop cleanup: $err"; exit 1 }
 $global = $opt.g -or $opt.global

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -76,7 +76,7 @@
 # cachePath:
 #       For downloads, defaults to 'cache' folder under Scoop root directory.
 #
-# checkver_token:
+# gh_token:
 #       GitHub API token used to make authenticated requests.
 #       This is essential for checkver and similar functions to run without
 #       incurring rate limits and download from private repositories.

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -78,8 +78,8 @@
 #
 # checkver_token:
 #       GitHub API token used to make authenticated requests.
-#       This is essential for checkver and similar functions
-#       to run without incurring rate limits.
+#       This is essential for checkver and similar functions to run without
+#       incurring rate limits and download from private repositories.
 #
 # virustotal_api_key:
 #       API key used for uploading/scanning files using virustotal.
@@ -95,6 +95,11 @@
 #       When set to $false (default), Scoop would stop its procedure immediately if it detects
 #       any target app process is running. Procedure here refers to reset/uninstall/update.
 #       When set to $true, Scoop only displays a warning message and continues procedure.
+#
+# private_hosts:
+#       Array of private hosts that need additional authentication.
+#       For example, if you want to access a private GitHub repository,
+#       you need to add the host to this list with 'match' and 'headers' strings.
 #
 # ARIA2 configuration
 # -------------------

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -132,9 +132,6 @@
 
 param($name, $value)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-
 if (!$name) {
     $scoopConfig
 } elseif ($name -like '--help') {

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -130,8 +130,6 @@ param($name, $value)
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 if (!$name) {
     $scoopConfig
 } elseif ($name -like '--help') {

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -1,13 +1,9 @@
 # Usage: scoop depends <app>
 # Summary: List dependencies for an app
 
-. "$PSScriptRoot\..\lib\depends.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\decompress.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\depends.ps1" # 'Get-Dependency'
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture'
 
 $opt, $apps, $err = getopt $args 'a:' 'arch='
 $app = $apps[0]

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -9,8 +9,6 @@
 . "$PSScriptRoot\..\lib\decompress.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'a:' 'arch='
 $app = $apps[0]
 

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -20,8 +20,6 @@
 . "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'fhua:' 'force', 'no-hash-check', 'no-update-scoop', 'arch='
 if ($err) { error "scoop download: $err"; exit 1 }
 

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -98,6 +98,7 @@ foreach ($curr_app in $apps) {
             } catch {
                 write-host -f darkred $_
                 error "URL $url is not valid"
+                $dl_failure = $true
                 continue
             }
 
@@ -124,7 +125,9 @@ foreach ($curr_app in $apps) {
         }
     }
 
-    success "'$app' ($version) was downloaded successfully!"
+    if (!$dl_failure) {
+        success "'$app' ($version) was downloaded successfully!"
+    }
 }
 
 exit 0

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -15,10 +15,11 @@
 #   -u, --no-update-scoop     Don't update Scoop before downloading if it's outdated
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' (indirectly)
+. "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'generate_user_manifest' 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\install.ps1"
 
 $opt, $apps, $err = getopt $args 'fhua:' 'force', 'no-hash-check', 'no-update-scoop', 'arch='
 if ($err) { error "scoop download: $err"; exit 1 }

--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -2,10 +2,8 @@
 # Summary: Exports (an importable) list of installed apps
 # Help: Lists all installed apps.
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'Select-CurrentVersion' (indirectly)
 
 $def_arch = default_architecture
 

--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -7,7 +7,6 @@
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 
-reset_aliases
 $def_arch = default_architecture
 
 $local = installed_apps $false | ForEach-Object { @{ name = $_; global = $false } }

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -2,10 +2,6 @@
 # Summary: Show help for a command
 param($cmd)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\commands.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-
 function print_help($cmd) {
     $file = Get-Content (command_path $cmd) -raw
 

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -6,8 +6,6 @@ param($cmd)
 . "$PSScriptRoot\..\lib\commands.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 function print_help($cmd) {
     $file = Get-Content (command_path $cmd) -raw
 
@@ -47,4 +45,3 @@ Some useful commands are:"
 }
 
 exit 0
-

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -5,7 +5,6 @@
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
 
-reset_aliases
 $apps = $args
 
 if(!$apps) {

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -1,6 +1,7 @@
 # Usage: scoop hold <apps>
 # Summary: Hold an app to disable updates
 
+. "$PSScriptRoot\..\lib\json.ps1" # 'save_install_info' (indirectly)
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'install_info' 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -1,9 +1,8 @@
 # Usage: scoop hold <apps>
 # Summary: Hold an app to disable updates
 
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'install_info' 'Select-CurrentVersion' (indirectly)
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 $apps = $args
 

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -7,8 +7,6 @@ param($app)
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 
-reset_aliases
-
 if($app) {
     $manifest, $bucket = find_manifest $app
     if($manifest) {

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -7,17 +7,20 @@ param($app)
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 
-if($app) {
-    $manifest, $bucket = find_manifest $app
-    if($manifest) {
-        if([string]::isnullorempty($manifest.homepage)) {
+if ($app) {
+    $null, $manifest, $bucket, $null = Find-Manifest $app
+    if ($manifest) {
+        if ($manifest.homepage) {
+            Start-Process $manifest.homepage
+        } else {
             abort "Could not find homepage in manifest for '$app'."
         }
-        Start-Process $manifest.homepage
-    }
-    else {
+    } else {
         abort "Could not find manifest for '$app'."
     }
-} else { my_usage }
+} else {
+    my_usage
+    exit 1
+}
 
 exit 0

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -2,10 +2,7 @@
 # Summary: Opens the app homepage
 param($app)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
 
 if ($app) {
     $null, $manifest, $bucket, $null = Find-Manifest $app

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -9,8 +9,6 @@
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
 
-reset_aliases
-
 $opt, $app, $err = getopt $args 'v' 'verbose'
 if ($err) { error "scoop info: $err"; exit 1 }
 $verbose = $opt.v -or $opt.verbose

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -3,11 +3,9 @@
 # Options:
 #   -v, --verbose       Show full paths and URLs
 
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-InstalledVersion'
 
 $opt, $app, $err = getopt $args 'v' 'verbose'
 if ($err) { error "scoop info: $err"; exit 1 }

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -29,8 +29,6 @@
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'gikusa:' 'global', 'independent', 'no-cache', 'no-update-scoop', 'skip', 'arch='
 if ($err) { "scoop install: $err"; exit 1 }
 

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -17,16 +17,15 @@
 #   -s, --skip                Skip hash validation (use with caution!)
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\decompress.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' (indirectly)
+. "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'generate_user_manifest' 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\decompress.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 
 $opt, $apps, $err = getopt $args 'gikusa:' 'global', 'independent', 'no-cache', 'no-update-scoop', 'skip', 'arch='

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -18,7 +18,7 @@
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' (indirectly)
+. "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' 'manifest.ps1' (indirectly)
 . "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'generate_user_manifest' 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\install.ps1"

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -3,10 +3,8 @@
 # Help: Lists all installed apps, or the apps matching the supplied query.
 param($query)
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'parse_json' 'Select-CurrentVersion' (indirectly)
 
 $def_arch = default_architecture
 if (-not (Get-FormatData ScoopApps)) {

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -8,7 +8,6 @@ param($query)
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\buckets.ps1"
 
-reset_aliases
 $def_arch = default_architecture
 if (-not (Get-FormatData ScoopApps)) {
     Update-FormatData "$PSScriptRoot\..\supporting\formats\ScoopTypes.Format.ps1xml"

--- a/libexec/scoop-prefix.ps1
+++ b/libexec/scoop-prefix.ps1
@@ -13,7 +13,7 @@ if (!$app) {
 
 $app_path = currentdir $app $false
 if (!(Test-Path $app_path)) {
-    $app_path = currentdir $app$true
+    $app_path = currentdir $app $true
 }
 
 if (Test-Path $app_path) {

--- a/libexec/scoop-prefix.ps1
+++ b/libexec/scoop-prefix.ps1
@@ -2,14 +2,12 @@
 # Summary: Returns the path to the specified app
 param($app)
 
+. "$PSScriptRoot\..\lib\versions.ps1" # 'currentdir' (indirectly)
+
 if (!$app) {
-    . "$PSScriptRoot\..\lib\help.ps1"
     my_usage
     exit 1
 }
-
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
 
 $app_path = currentdir $app $false
 if (!(Test-Path $app_path)) {

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -4,12 +4,10 @@
 # if you've installed 'python' and 'python27', you can use 'scoop reset' to switch between
 # using one or the other.
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 
 $opt, $apps, $err = getopt $args

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -12,7 +12,6 @@
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 
-reset_aliases
 $opt, $apps, $err = getopt $args
 if($err) { "scoop reset: $err"; exit 1 }
 

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -5,10 +5,9 @@
 # If used with [query], shows app names that match the query.
 # Without [query], shows all the available apps.
 param($query)
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
+
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'manifest'
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-LatestVersion'
 
 function bin_match($manifest, $query) {
     if(!$manifest.bin) { return $false }

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -10,8 +10,6 @@ param($query)
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
 
-reset_aliases
-
 function bin_match($manifest, $query) {
     if(!$manifest.bin) { return $false }
     foreach($bin in $manifest.bin) {

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -29,7 +29,6 @@
 
 param($SubCommand, $ShimName, [Switch]$global)
 
-. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\install.ps1" # for rm_shim
 
 if ($SubCommand -notin @('add', 'rm', 'list', 'info', 'alter')) {

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -2,7 +2,7 @@
 # Summary: Manipulate Scoop shims
 # Help: Manipulate Scoop shims: add, rm, list, info, alter, etc.
 #
-# To add a costom shim, use the 'add' subcommand:
+# To add a custom shim, use the 'add' subcommand:
 #
 #     scoop shim add <shim_name> <command_path> [<args>...]
 #

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -1,29 +1,24 @@
 # Usage: scoop status
 # Summary: Show status and check for new app versions
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'manifest' 'parse_json' "install_info"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 # check if scoop needs updating
 $currentdir = fullpath $(versiondir 'scoop' 'current')
 $needs_update = $false
 
-if(Test-Path "$currentdir\.git") {
+if (Test-Path "$currentdir\.git") {
     git_cmd -C "`"$currentdir`"" fetch -q origin
-    $commits = $(git -C $currentdir log "HEAD..origin/$(scoop config SCOOP_BRANCH)" --oneline)
-    if($commits) { $needs_update = $true }
-}
-else {
+    $commits = $(git -C $currentdir log "HEAD..origin/$(get_config SCOOP_BRANCH)" --oneline)
+    if ($commits) { $needs_update = $true }
+} else {
     $needs_update = $true
 }
 
-if($needs_update) {
+if ($needs_update) {
     warn "Scoop is out of date. Run 'scoop update' to get the latest changes."
-}
-else { success "Scoop is up to date."}
+} else { success 'Scoop is up to date.' }
 
 $failed = @()
 $outdated = @()
@@ -34,30 +29,30 @@ $onhold = @()
 $true, $false | ForEach-Object { # local and global apps
     $global = $_
     $dir = appsdir $global
-    if(!(Test-Path $dir)) { return }
+    if (!(Test-Path $dir)) { return }
 
-    Get-ChildItem $dir | Where-Object name -ne 'scoop' | ForEach-Object {
+    Get-ChildItem $dir | Where-Object name -NE 'scoop' | ForEach-Object {
         $app = $_.name
         $status = app_status $app $global
-        if($status.failed) {
+        if ($status.failed) {
             $failed += @{ $app = $status.version }
         }
-        if($status.removed) {
+        if ($status.removed) {
             $removed += @{ $app = $status.version }
         }
-        if($status.outdated) {
+        if ($status.outdated) {
             $outdated += @{ $app = @($status.version, $status.latest_version) }
-            if($status.hold) {
+            if ($status.hold) {
                 $onhold += @{ $app = @($status.version, $status.latest_version) }
             }
         }
-        if($status.missing_deps) {
-            $missing_deps += ,(@($app) + @($status.missing_deps))
+        if ($status.missing_deps) {
+            $missing_deps += , (@($app) + @($status.missing_deps))
         }
     }
 }
 
-if($outdated) {
+if ($outdated) {
     Write-Host -f DarkCyan 'Updates are available for:'
     $outdated.keys | ForEach-Object {
         $versions = $outdated.$_
@@ -65,7 +60,7 @@ if($outdated) {
     }
 }
 
-if($onhold) {
+if ($onhold) {
     Write-Host -f DarkCyan 'These apps are outdated and on hold:'
     $onhold.keys | ForEach-Object {
         $versions = $onhold.$_
@@ -73,21 +68,21 @@ if($onhold) {
     }
 }
 
-if($removed) {
+if ($removed) {
     Write-Host -f DarkCyan 'These app manifests have been removed:'
     $removed.keys | ForEach-Object {
         "    $_"
     }
 }
 
-if($failed) {
+if ($failed) {
     Write-Host -f DarkCyan 'These apps failed to install:'
     $failed.keys | ForEach-Object {
         "    $_"
     }
 }
 
-if($missing_deps) {
+if ($missing_deps) {
     Write-Host -f DarkCyan 'Missing runtime dependencies:'
     $missing_deps | ForEach-Object {
         $app, $deps = $_
@@ -95,8 +90,8 @@ if($missing_deps) {
     }
 }
 
-if(!$old -and !$removed -and !$failed -and !$missing_deps -and !$needs_update) {
-    success "Everything is ok!"
+if (!$old -and !$removed -and !$failed -and !$missing_deps -and !$needs_update) {
+    success 'Everything is ok!'
 }
 
 exit 0

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -7,8 +7,6 @@
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 
-reset_aliases
-
 # check if scoop needs updating
 $currentdir = fullpath $(versiondir 'scoop' 'current')
 $needs_update = $false

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -5,7 +5,6 @@
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
 
-reset_aliases
 $apps = $args
 
 if(!$apps) {

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -1,9 +1,8 @@
 # Usage: scoop unhold <app>
 # Summary: Unhold an app to enable updates
 
-. "$PSScriptRoot\..\lib\help.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'install_info' 'Select-CurrentVersion' (indirectly)
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 $apps = $args
 

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -1,6 +1,7 @@
 # Usage: scoop unhold <app>
 # Summary: Unhold an app to enable updates
 
+. "$PSScriptRoot\..\lib\json.ps1" # 'save_install_info' (indirectly)
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'install_info' 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -6,14 +6,12 @@
 #   -g, --global   Uninstall a globally installed app
 #   -p, --purge    Remove all persistent data
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 # options
 $opt, $apps, $err = getopt $args 'gp' 'global', 'purge'

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -15,8 +15,6 @@
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
 
-reset_aliases
-
 # options
 $opt, $apps, $err = getopt $args 'gp' 'global', 'purge'
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -15,6 +15,7 @@
 #   -a, --all                 Update all apps (alternative to '*')
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\json.ps1" # 'save_install_info' in 'manifest.ps1' (indirectly)
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"
 . "$PSScriptRoot\..\lib\decompress.ps1"

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -14,14 +14,12 @@
 #   -q, --quiet               Hide extraneous messages
 #   -a, --all                 Update all apps (alternative to '*')
 
-. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"
 . "$PSScriptRoot\..\lib\decompress.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
-. "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -25,8 +25,6 @@
 . "$PSScriptRoot\..\lib\depends.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'gfiksqa' 'global', 'force', 'independent', 'no-cache', 'skip', 'quiet', 'all'
 if ($err) { "scoop update: $err"; exit 1 }
 $global = $opt.g -or $opt.global

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -111,7 +111,7 @@ function update_scoop() {
 
         $res = $lastexitcode
         if ($show_update_log) {
-            Invoke-Expression "git -C '$currentdir' --no-pager log --no-decorate --grep='^chore' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
+            Invoke-Expression "git -C '$currentdir' --no-pager log --no-decorate --grep='^(chore)' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
         }
 
         if ($res -ne 0) {
@@ -148,7 +148,7 @@ function update_scoop() {
         $previousCommit = (Invoke-Expression "git -C '$bucketLoc' rev-parse HEAD")
         git_cmd -C "`"$bucketLoc`"" pull -q
         if ($show_update_log) {
-            Invoke-Expression "git -C '$bucketLoc' --no-pager log --no-decorate --grep='^chore' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
+            Invoke-Expression "git -C '$bucketLoc' --no-pager log --no-decorate --grep='^(chore)' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
         }
     }
 

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -34,24 +34,20 @@
 #   -n, --no-depends          By default, all dependencies are checked too. This flag avoids it.
 #   -u, --no-update-scoop     Don't update Scoop before checking if it's outdated
 
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1"
-. "$PSScriptRoot\..\lib\buckets.ps1"
-. "$PSScriptRoot\..\lib\json.ps1"
-. "$PSScriptRoot\..\lib\decompress.ps1"
-. "$PSScriptRoot\..\lib\install.ps1"
-. "$PSScriptRoot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\json.ps1" # 'json_path'
+. "$PSScriptRoot\..\lib\install.ps1" # 'hash_for_url'
+. "$PSScriptRoot\..\lib\depends.ps1" # 'Get-Dependency'
 
 $opt, $apps, $err = getopt $args 'a:snu' @('arch=', 'scan', 'no-depends', 'no-update-scoop')
-if($err) { "scoop virustotal: $err"; exit 1 }
-if(!$apps) { my_usage; exit 1 }
+if ($err) { "scoop virustotal: $err"; exit 1 }
+if (!$apps) { my_usage; exit 1 }
 $architecture = ensure_architecture ($opt.a + $opt.arch)
 
 if (is_scoop_outdated) {
     if ($opt.u -or $opt.'no-update-scoop') {
-        warn "Scoop is out of date."
+        warn 'Scoop is out of date.'
     } else {
         scoop update
     }
@@ -59,7 +55,7 @@ if (is_scoop_outdated) {
 
 $apps_param = $apps
 
-if($apps_param -eq '*') {
+if ($apps_param -eq '*') {
     $apps = installed_apps $false
     $apps += installed_apps $true
 }
@@ -97,13 +93,13 @@ Function Get-VirusTotalResult($hash, $app) {
     $unsafe = [int]$malicious + [int]$suspicious
     $see_url = "see https://www.virustotal.com/#/file/$hash/detection"
     switch ($unsafe) {
-        0 { if ($undetected -eq 0) { $fg = "Yellow" } else { $fg = "DarkGreen" } }
-        1 { $fg = "DarkYellow" }
-        2 { $fg = "Yellow" }
-        default { $fg = "Red" }
+        0 { if ($undetected -eq 0) { $fg = 'Yellow' } else { $fg = 'DarkGreen' } }
+        1 { $fg = 'DarkYellow' }
+        2 { $fg = 'Yellow' }
+        default { $fg = 'Red' }
     }
-    write-host -f $fg "$app`: $unsafe/$undetected, $see_url"
-    if($unsafe -gt 0) {
+    Write-Host -f $fg "$app`: $unsafe/$undetected, $see_url"
+    if ($unsafe -gt 0) {
         return $_ERR_UNSAFE
     }
     return 0
@@ -130,16 +126,15 @@ Function Submit-RedirectedUrl {
     # Adapted according to Roy's response (January 23, 2014 at 11:59 am)
     # Adapted to always return an URL
     Param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [String]$URL
     )
     $request = [System.Net.WebRequest]::Create($url)
-    $request.AllowAutoRedirect=$false
-    $response=$request.GetResponse()
+    $request.AllowAutoRedirect = $false
+    $response = $request.GetResponse()
     if (([int]$response.StatusCode -ge 300) -and ([int]$response.StatusCode -lt 400)) {
-        $redir = $response.GetResponseHeader("Location")
-    }
-    else {
+        $redir = $response.GetResponseHeader('Location')
+    } else {
         $redir = $URL
     }
     $response.Close()
@@ -156,8 +151,8 @@ Function Submit-RedirectedUrl {
 #              submitting the file after a delay if the rate limit is
 #              exceeded, without risking an infinite loop (as stack
 #              overflow) if the submission keeps failing.
-Function Submit-ToVirusTotal ($url, $app, $do_scan, $retrying=$False) {
-    $api_key = get_config("virustotal_api_key")
+Function Submit-ToVirusTotal ($url, $app, $do_scan, $retrying = $False) {
+    $api_key = get_config virustotal_api_key
     if ($do_scan -and !$api_key -and !$warned_no_api_key) {
         $warned_no_api_key = $true
         info "Submitting unknown apps needs a VirusTotal API key.  " +

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -207,7 +207,7 @@ Function Submit-ToVirusTotal ($url, $app, $do_scan, $retrying=$False) {
 $apps | ForEach-Object {
     $app = $_
     # write-host $app
-    $manifest, $bucket = find_manifest $app
+    $null, $manifest, $bucket, $null = Find-Manifest $app
     if(!$manifest) {
         $exit_code = $exit_code -bor $_ERR_NO_INFO
         warn "$app`: manifest not found"

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -44,8 +44,6 @@
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
 
-reset_aliases
-
 $opt, $apps, $err = getopt $args 'a:snu' @('arch=', 'scan', 'no-depends', 'no-update-scoop')
 if($err) { "scoop virustotal: $err"; exit 1 }
 if(!$apps) { my_usage; exit 1 }

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -2,8 +2,6 @@
 # Summary: Locate a shim/executable (similar to 'which' on Linux)
 # Help: Locate the path to a shim/executable that was installed with Scoop (similar to 'which' on Linux)
 param($command)
-. "$PSScriptRoot\..\lib\core.ps1"
-. "$PSScriptRoot\..\lib\help.ps1"
 
 if (!$command) {
     'ERROR: <command> missing'

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -5,8 +5,6 @@ param($command)
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-reset_aliases
-
 if (!$command) {
     'ERROR: <command> missing'
     my_usage

--- a/schema.json
+++ b/schema.json
@@ -604,7 +604,6 @@
     },
     "required": [
         "version",
-        "description",
         "homepage",
         "license"
     ],

--- a/supporting/formats/ScoopTypes.Format.ps1xml
+++ b/supporting/formats/ScoopTypes.Format.ps1xml
@@ -21,7 +21,7 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Updated</PropertyName>
-                                <FormatString>yyyy-MM-dd HH:MM:ss</FormatString>
+                                <FormatString>yyyy-MM-dd HH:mm:ss</FormatString>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Info</PropertyName>

--- a/supporting/shims/kiennq/Makefile
+++ b/supporting/shims/kiennq/Makefile
@@ -1,6 +1,6 @@
 
 VER?=2.2.1
-ZIP=shimexe-$(VER).zip
+ZIP=shimexe.zip
 URL?=https://github.com/kiennq/scoop-better-shimexe/releases/download/$(VER)/$(ZIP)
 LATEST_URL?=https://github.com/kiennq/scoop-better-shimexe/releases/latest
 NEWVER=$(shell cat version.txt)

--- a/test/Import-Bucket-Tests.ps1
+++ b/test/Import-Bucket-Tests.ps1
@@ -125,4 +125,3 @@ Describe 'manifest validates against the schema' -Tag 'Manifests' {
         }
     }
 }
-

--- a/test/Import-Bucket-Tests.ps1
+++ b/test/Import-Bucket-Tests.ps1
@@ -64,7 +64,7 @@ Describe 'Manifest Validator' -Tag 'Validator' {
             $validator.Validate("$working_dir\invalid_wget.json") | Should -BeFalse
             $validator.Errors.Count | Should -Be 16
             $validator.Errors | Select-Object -First 1 | Should -Match "Property 'randomproperty' has not been defined and the schema does not allow additional properties\."
-            $validator.Errors | Select-Object -Last 1 | Should -Match 'Required properties are missing from object: version, description\.'
+            $validator.Errors | Select-Object -Last 1 | Should -Match 'Required properties are missing from object: version\.'
         }
     }
 }

--- a/test/Scoop-Alias.Tests.ps1
+++ b/test/Scoop-Alias.Tests.ps1
@@ -3,12 +3,12 @@
 reset_aliases
 
 Describe 'add_alias' -Tag 'Scoop' {
-    Mock shimdir { 'TestDrive:\shim' }
+    Mock shimdir { "$env:TEMP\shims" }
     Mock set_config { }
     Mock get_config { @{} }
 
     $shimdir = shimdir
-    mkdir $shimdir
+    New-Item -ItemType Directory -Path $shimdir -ErrorAction Ignore
 
     Context "alias doesn't exist" {
         It 'creates a new alias' {
@@ -23,7 +23,7 @@ Describe 'add_alias' -Tag 'Scoop' {
     Context 'alias exists' {
         It 'does not change existing alias' {
             $alias_file = "$shimdir\scoop-rm.ps1"
-            New-Item $alias_file -type file
+            New-Item $alias_file -Type File -Force
             $alias_file | Should -Exist
 
             add_alias 'rm' 'test'
@@ -33,12 +33,12 @@ Describe 'add_alias' -Tag 'Scoop' {
 }
 
 Describe 'rm_alias' -Tag 'Scoop' {
-    Mock shimdir { 'TestDrive:\shim' }
+    Mock shimdir { "$env:TEMP\shims" }
     Mock set_config { }
     Mock get_config { @{} }
 
     $shimdir = shimdir
-    mkdir $shimdir
+    New-Item -ItemType Directory -Path $shimdir -ErrorAction Ignore
 
     Context 'alias exists' {
         It 'removes an existing alias' {

--- a/test/Scoop-Alias.Tests.ps1
+++ b/test/Scoop-Alias.Tests.ps1
@@ -1,14 +1,12 @@
 . "$PSScriptRoot\..\libexec\scoop-alias.ps1" | Out-Null
 
-reset_aliases
-
 Describe 'add_alias' -Tag 'Scoop' {
     Mock shimdir { "$env:TEMP\shims" }
     Mock set_config { }
     Mock get_config { @{} }
 
     $shimdir = shimdir
-    New-Item -ItemType Directory -Path $shimdir -ErrorAction Ignore
+    ensure $shimdir
 
     Context "alias doesn't exist" {
         It 'creates a new alias' {
@@ -38,7 +36,7 @@ Describe 'rm_alias' -Tag 'Scoop' {
     Mock get_config { @{} }
 
     $shimdir = shimdir
-    New-Item -ItemType Directory -Path $shimdir -ErrorAction Ignore
+    ensure $shimdir
 
     Context 'alias exists' {
         It 'removes an existing alias' {

--- a/test/Scoop-Alias.Tests.ps1
+++ b/test/Scoop-Alias.Tests.ps1
@@ -1,3 +1,6 @@
+. "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\help.ps1"
 . "$PSScriptRoot\..\libexec\scoop-alias.ps1" | Out-Null
 
 Describe 'add_alias' -Tag 'Scoop' {

--- a/test/Scoop-Config.Tests.ps1
+++ b/test/Scoop-Config.Tests.ps1
@@ -1,3 +1,4 @@
+. "$PSScriptRoot\Scoop-TestLib.ps1"
 . "$PSScriptRoot\..\lib\core.ps1"
 
 Describe 'config' -Tag 'Scoop' {

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -1,7 +1,7 @@
+. "$PSScriptRoot\Scoop-TestLib.ps1"
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\unix.ps1"
-. "$PSScriptRoot\Scoop-TestLib.ps1"
 
 $repo_dir = (Get-Item $MyInvocation.MyCommand.Path).directory.parent.FullName
 $isUnix = is_unix

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -234,12 +234,12 @@ Describe 'get_app_name_from_shim' -Tag 'Scoop' {
     }
 
     It 'returns app name if file exists and is a shim to an app' -Skip:$isUnix {
-        mkdir -p "$working_dir/mockapp/current/"
+        ensure "$working_dir/mockapp/current/"
         Write-Output '' | Out-File "$working_dir/mockapp/current/mockapp1.ps1"
         shim "$working_dir/mockapp/current/mockapp1.ps1" $false 'shim-test1'
         $shim_path1 = (Get-Command 'shim-test1.ps1').Path
         get_app_name_from_shim "$shim_path1" | Should -Be 'mockapp'
-        mkdir -p "$working_dir/mockapp/1.0.0/"
+        ensure "$working_dir/mockapp/1.0.0/"
         Write-Output '' | Out-File "$working_dir/mockapp/1.0.0/mockapp2.ps1"
         shim "$working_dir/mockapp/1.0.0/mockapp2.ps1" $false 'shim-test2'
         $shim_path2 = (Get-Command 'shim-test2.ps1').Path
@@ -266,10 +266,6 @@ Describe 'get_app_name_from_shim' -Tag 'Scoop' {
 Describe 'ensure_robocopy_in_path' -Tag 'Scoop' {
     $shimdir = shimdir $false
     Mock versiondir { $repo_dir }
-
-    BeforeAll {
-        reset_aliases
-    }
 
     Context 'robocopy is not in path' {
         It 'shims robocopy when not on path' -Skip:$isUnix {

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -1,9 +1,10 @@
 . "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\decompress.ps1"
-. "$PSScriptRoot\..\lib\unix.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\unix.ps1"
 
 $isUnix = is_unix
 

--- a/test/Scoop-Depends.Tests.ps1
+++ b/test/Scoop-Depends.Tests.ps1
@@ -1,5 +1,7 @@
 . "$PSScriptRoot\Scoop-TestLib.ps1"
+. "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1"
+. "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -1,8 +1,8 @@
+. "$PSScriptRoot\Scoop-TestLib.ps1"
 . "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\unix.ps1"
-. "$PSScriptRoot\Scoop-TestLib.ps1"
 
 $isUnix = is_unix
 


### PR DESCRIPTION
## CHANGELOG

### BREAKING CHANGES

- The license of Scoop has changed to dual-license Unlicense or MIT (#4903)
- Rename `checkver_token` to `gh_token` and `SCOOP_CHECKVER_TOKEN` to `SCOOP_GH_TOKEN` (#4832, #4842)

### Features

- **relicense:** Relicense to dual-license (Unlicense or MIT) (#4903, #4870)
- **install:** Allow downloading from private repositories (#4254)
- **scoop-cleanup:** Add -a/--all switch to cleanup all apps (#4906)

### Bug Fixes

- **bucket:** Return empty list correctly in `Get-LocalBucket` (#4885)
- **shim:** Manipulating shims with UTF8 encoding (#4791, #4813)
- **shim:** Correctly quote $@ in sh->ps1 shims (#4809)
- **install:** Fix issue with installation inside containers (#4837)
- **installed:** If no `$global`, check both local and global installed (#4798)
- **update:** Skip logs starting with `(chore)` (#4800)
- **scoop-download:** Add failure check (#4822)
- **scoop-list:** Fix date in 'Updated' column showing the months in the place of minutes (#4880)
- **scoop-prefix:** Fix typo that breaks global installed apps (#4795)

### Performance Improvements

- **scoop:** Load libs only once (#4839, #4884)

### Code Refactoring

- **bucket:** Move 'Find-Manifest' and 'list_buckets' to 'buckets' (#4814)
- **relpath:** Use `$PSScriptRoot` instead of `relpath` (#4793)
- **reset_aliases:** Move core function of `reset_aliases` to `scoop` (#4794)
- **config:** Rename checkver_token to gh_token and SCOOP_CHECKVER_TOKEN to SCOOP_GH_TOKEN (#4832, #4842)

### Builds

- **checkver:** Add option to throw error as exception (#4867)
- **schema:** Remove 'description' from required fields (#4853, #4874)

### Documentation

- **changelog:** Rearrange CHANGELOG (#4897)
- **readme:** Update installation instruction (#4825)
- **readme:** Fix badges for Gitter and CI Tests (#4830)
- **scoop-shim:** Fix typo (#4836)

## Close Issues

- Closes #4243
- Closes #4784
- Closes #2573
- Closes #2230
- Closes #4808
- Closes #4792
- Closes #4819
- Closes #4833
- Closes #4841
- Closes #4799
- Closes #4810
- Closes #4790
- Closes #3418
- Closes #2123
- Closes #4863
- Closes #4829
- Closes #4835
- Closes #4887
- Closes #4868

## Credits

Thanks to the following contributors (ordered by PR merging time):

@niheaven @rashil2000 @chawyehsu @e6c31d @tech189 @tmsmith @astelmachonak-nydig @kingster @kiennq @CrendKing @cskrisz @lewis-yeung
