### PR TITLE
fix(buckets): Don't check remote URL of non-git buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+
+### Bug Fixes
+
+- **bucket:** Don't check remote URL of non-git buckets ([#4923](https://github.com/ScoopInstaller/Scoop/issues/4923))
+
 ## [v0.2.0](https://github.com/ScoopInstaller/Scoop/compare/v0.1.0...v0.2.0) - 2022-05-10
 
 ### Features

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -109,6 +109,7 @@ function Convert-RepositoryUri {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory, Position = 0, ValueFromPipeline = $true)]
+        [AllowEmptyString()]
         [String] $Uri
     )
 
@@ -161,10 +162,12 @@ function add_bucket($name, $repo) {
         return 1
     }
     foreach ($bucket in Get-LocalBucket) {
-        $remote = git -C "$bucketsdir\$bucket" config --get remote.origin.url
-        if ((Convert-RepositoryUri -Uri $remote) -eq $uni_repo) {
-            warn "Bucket $bucket already exists for $repo"
-            return 2
+        if (Test-Path -Path "$bucketsdir\$bucket\.git") {
+            $remote = git -C "$bucketsdir\$bucket" config --get remote.origin.url
+            if ((Convert-RepositoryUri -Uri $remote) -eq $uni_repo) {
+                warn "Bucket $bucket already exists for $repo"
+                return 2
+            }
         }
     }
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -133,9 +133,15 @@ function update_scoop() {
         if (!(Test-Path (Join-Path $bucketLoc '.git'))) {
             if ($bucket -eq 'main') {
                 # Make sure main bucket, which was downloaded as zip, will be properly "converted" into git
-                Write-Host " Converting 'main' bucket to git..."
-                rm_bucket 'main'
-                add_bucket 'main'
+                Write-Host " Converting 'main' bucket to git repo..."
+                $status = rm_bucket 'main'
+                if ($status -ne 0) {
+                    abort "Failed to remove local 'main' bucket."
+                }
+                $status = add_bucket 'main' (known_bucket_repo 'main')
+                if ($status -ne 0) {
+                    abort "Failed to add remote 'main' bucket."
+                }
             } else {
                 Write-Host "'$bucket' is not a git repository. Skipped."
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

1. Add missing 'main' repo URL in `scoop update` when user first install scoop and 'main' is extracted from zip archive.
2. Skip checking remote URL when bucket is a non-git local one.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #4917 
<!-- or -->
Relates to #4814

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

All tests passed, and all bugs in original post have been corrected.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
