### PR TITLE
fix(buckets): Don't write message OK before bucket is cloned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - **bucket:** Don't check remote URL of non-git buckets ([#4923](https://github.com/ScoopInstaller/Scoop/issues/4923))
+- **bucket:** Don't write message OK before bucket is cloned ([#4925](https://github.com/ScoopInstaller/Scoop/issues/4925))
 
 ## [v0.2.0](https://github.com/ScoopInstaller/Scoop/compare/v0.1.0...v0.2.0) - 2022-05-10
 

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -177,11 +177,10 @@ function add_bucket($name, $repo) {
         error "'$repo' doesn't look like a valid git repository`n`nError given:`n$out"
         return 1
     }
-    Write-Host 'OK'
-
     ensure $bucketsdir | Out-Null
     $dir = ensure $dir
     git_cmd clone "$repo" "`"$dir`"" -q
+    Write-Host 'OK'
     success "The $name bucket was added successfully."
     return 0
 }


### PR DESCRIPTION
#### Description
Don't write message OK before bucket is cloned

#### Motivation and Context
Correct the bucket addition message context

#### How Has This Been Tested?
No critical changes, no need to update tests.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
