### PR TITLE
fix(scoop-info): Fix error message when manifest is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **depends:** Avoid digits in archive file extension (except for .7z and .001) ([#4915](https://github.com/ScoopInstaller/Scoop/issues/4915))
 - **bucket:** Don't check remote URL of non-git buckets ([#4923](https://github.com/ScoopInstaller/Scoop/issues/4923))
 - **bucket:** Don't write message OK before bucket is cloned ([#4925](https://github.com/ScoopInstaller/Scoop/issues/4925))
+- **scoop-info:** Fix error message when manifest is not found  ([#4928](https://github.com/ScoopInstaller/Scoop/issues/4928))
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - **depends:** Avoid digits in archive file extension (except for .7z and .001) ([#4915](https://github.com/ScoopInstaller/Scoop/issues/4915))
 - **bucket:** Don't check remote URL of non-git buckets ([#4923](https://github.com/ScoopInstaller/Scoop/issues/4923))
 - **bucket:** Don't write message OK before bucket is cloned ([#4925](https://github.com/ScoopInstaller/Scoop/issues/4925))
-- **scoop-info:** Fix error message when manifest is not found  ([#4928](https://github.com/ScoopInstaller/Scoop/issues/4928))
+- **scoop-info:** Fix error message when manifest is not found  ([#4935](https://github.com/ScoopInstaller/Scoop/issues/4935))
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - **depends:** Avoid digits in archive file extension (except for .7z and .001) ([#4915](https://github.com/ScoopInstaller/Scoop/issues/4915))
 - **bucket:** Don't check remote URL of non-git buckets ([#4923](https://github.com/ScoopInstaller/Scoop/issues/4923))
 - **bucket:** Don't write message OK before bucket is cloned ([#4925](https://github.com/ScoopInstaller/Scoop/issues/4925))
-- **scoop-info:** Fix error message when manifest is not found  ([#4935](https://github.com/ScoopInstaller/Scoop/issues/4935))
+- **scoop-info:** Fix error message when manifest is not found ([#4935](https://github.com/ScoopInstaller/Scoop/issues/4935))
 
 ### Documentation
 

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -30,7 +30,7 @@ if ($app -match '^(ht|f)tps?://|\\\\') {
 }
 
 if (!$manifest) {
-    abort "Could not find manifest for '$(show_app $app)' in any buckets."
+    abort "Could not find manifest for '$(show_app $app)' in local buckets."
 }
 
 $install = install_info $app $status.version $global

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -30,7 +30,7 @@ if ($app -match '^(ht|f)tps?://|\\\\') {
 }
 
 if (!$manifest) {
-    abort "Could not find manifest for '$(show_app $app $bucket)'."
+    abort "Could not find manifest for '$(show_app $app)' in any buckets."
 }
 
 $install = install_info $app $status.version $global


### PR DESCRIPTION
#### Description

Fixes https://github.com/ScoopInstaller/Scoop/issues/4928.

Abort message no longer references the last bucket searched via `Find-Manifest`

#### Motivation and Context

Fixes #4928


#### How Has This Been Tested?

This is an edge case abort message, and there appear to be no tests that use the string literal `Could not find manifest` which suggests the text is never explicitly matched against during test execution. 

```
$ find . -name "*.ps1" -exec grep -iH "could not find manifest" {} \;
./libexec/scoop-home.ps1:        abort "Could not find manifest for '$app'."
./libexec/scoop-info.ps1:    abort "Could not find manifest for '$(show_app $app)' in any known buckets."
```

My assumption here is that the tests should pass, sadly I don't actually have a powershell build environment, and I wouldn't really know how to start building one to include `BuildHelpers` and other PS modules referenced in _test/bin/test.ps1_


#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] ~I have updated the documentation accordingly.~ Documentation change not required.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
