### PR TITLE
fix(scoop-search): Require files in 'bucket' dir for remote known buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **shim:** Remove character replacement in .cmd -> .ps1 shims ([#4914](https://github.com/ScoopInstaller/Scoop/issues/4914))
 - **scoop:** Pass CLI arguments as string objects ([#4931](https://github.com/ScoopInstaller/Scoop/issues/4931))
 - **scoop-info:** Fix error message when manifest is not found ([#4935](https://github.com/ScoopInstaller/Scoop/issues/4935))
+- **scoop-search:** Require files in 'bucket' dir for remote known buckets ([#4943](https://github.com/ScoopInstaller/Scoop/issues/4943))
 
 ### Documentation
 

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -63,7 +63,7 @@ function search_remote($bucket, $query) {
         $repo_name = $Matches[2]
         $api_link = "https://api.github.com/repos/$user/$repo_name/git/trees/HEAD?recursive=1"
         $result = download_json $api_link | Select-Object -ExpandProperty tree |
-            Where-Object -Value "^(?:bucket/)?(.*$query.*)\.json$" -Property Path -Match |
+            Where-Object -Value "^bucket/(.*$query.*)\.json$" -Property Path -Match |
             ForEach-Object { $Matches[1] }
     }
 


### PR DESCRIPTION
Change regex in function [`search_remote`](https://github.com/ScoopInstaller/Scoop/blob/aaa726c09f786d2af902d827ae8d0caee964ca1e/libexec/scoop-search.ps1#L59-L71): only matches json files inside 'bucket' directory.

<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
All [known buckets](https://github.com/ScoopInstaller/Scoop/blob/aaa726c09f786d2af902d827ae8d0caee964ca1e/buckets.json) store manifest json files in 'bucket' directory. Current `scoop-search.ps1` use a regex that may match json files in the root directory, which is unnecessary for them. This small change let the 'bucket' directory be required.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #4943
<!-- or -->

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Run regression and all tests passed:
```
Tests completed in 38.78s
Tests Passed: 125, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
```

2. Try the command in issue #4943 and got output as expected:
```
scoop.ps1 search markdownlint
No matches found.
```

3. Run with an exist app to make sure it's not broken:
```
scoop.ps1 search minecraft
Results from other known buckets...
(add them using 'scoop bucket add <name>')

'games' bucket (install using 'scoop install games/<app>'):
    minecraft
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
