### PR TITLE
fix(update): Prevent uninstall when update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **shim:** Remove character replacement in .cmd -> .ps1 shims ([#4914](https://github.com/ScoopInstaller/Scoop/issues/4914))
 - **scoop:** Pass CLI arguments as string objects ([#4931](https://github.com/ScoopInstaller/Scoop/issues/4931))
 - **scoop-info:** Fix error message when manifest is not found ([#4935](https://github.com/ScoopInstaller/Scoop/issues/4935))
+- **update:** Prevent uninstall when update ([#3050](https://github.com/ScoopInstaller/Scoop/issues/3050))
 
 ### Documentation
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
When user update scoop for the first time and meet network changes or folder in use. the program would delete whole scoop folder. 
And I use Rename-Item instead of Remove-Item to prevent this. 
line 77 Test-Path "$newdir\bin\scoop.ps1" is to prevent download using a wrong SCOOP_REPO with no scoop file there. 
#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
In #3050 there might be some small error caused by bucket but result in remove the whole scoop folder. 
So instead of just remove current folder, I rename current folder to old and then delete old folder. 
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- or -->
Relates to #4005
Relates to #3050
#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
remove .git folder in %scoop%\apps\scoop\current
then run scoop update
and if you open a folder in explorer like %scoop%\apps\scoop\current\libexec
folder in use and go into catch sentence
#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
