### PR TITLE
fix(core): Allow to use '_' and '.' in bucket name

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -895,7 +895,7 @@ function applist($apps, $global) {
 }
 
 function parse_app([string] $app) {
-    if($app -match '(?:(?<bucket>[a-zA-Z0-9-]+)\/)?(?<app>.*\.json$|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?') {
+    if($app -match '(?:(?<bucket>[a-zA-Z0-9-_.]+)\/)?(?<app>.*\.json$|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?') {
         return $matches['app'], $matches['bucket'], $matches['version']
     }
     return $app, $null, $null


### PR DESCRIPTION
#### Description

Updating a bucket is always failed when bucket name contains '_' or '.'.

(Scoop v0.2.0 - Released at 2022-05-10)

#### Motivation and Context (How to reproduce the error)

```powershell
> scoop bucket add aaa_bbb SOME-REPO-URL
Checking repo... OK
The aaa_bbb bucket was added successfully.
> scoop update SOME-MANIFEST-IN-REPO-AAA_BBB
Couldn't find manifest for 'aaa_bbb'.
```

#### How Has This Been Tested?
Sorry for no tests, no docs. I'm not good at PowerShell, just found out where to fix.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
