### PR TITLE
fix(scoop-uninstall): run pre_uninstall before testing running processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- **core:** Add pre_uninstall and post_uninstall hooks ([#4957](https://github.com/ScoopInstaller/Scoop/issues/4957))
+- **core:** Add pre_uninstall and post_uninstall hooks ([#4957](https://github.com/ScoopInstaller/Scoop/issues/4957) [#4962](https://github.com/ScoopInstaller/Scoop/issues/4962))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- **core:** Add pre_uninstall and post_uninstall hooks ([#4957](https://github.com/ScoopInstaller/Scoop/issues/4957)， [#4962](https://github.com/ScoopInstaller/Scoop/issues/4962))
+- **core:** Add pre_uninstall and post_uninstall hooks ([#4957](https://github.com/ScoopInstaller/Scoop/issues/4957), [#4962](https://github.com/ScoopInstaller/Scoop/issues/4962))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- **core:** Add pre_uninstall and post_uninstall hooks ([#4957](https://github.com/ScoopInstaller/Scoop/issues/4957) [#4962](https://github.com/ScoopInstaller/Scoop/issues/4962))
+- **core:** Add pre_uninstall and post_uninstall hooks ([#4957](https://github.com/ScoopInstaller/Scoop/issues/4957)， [#4962](https://github.com/ScoopInstaller/Scoop/issues/4962))
 
 ### Bug Fixes
 

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -54,6 +54,8 @@ if (!$apps) { exit 0 }
         $dir = versiondir $app $version $global
         $persist_dir = persistdir $app $global
 
+        Invoke-HookScript -HookType 'pre_uninstall' -Manifest $manifest -Arch $architecture
+
         #region Workaround for #2952
         if (test_running_process $app $global) {
             continue
@@ -70,8 +72,6 @@ if (!$apps) { exit 0 }
         $manifest = installed_manifest $app $version $global
         $install = install_info $app $version $global
         $architecture = $install.architecture
-
-        Invoke-HookScript -HookType 'pre_uninstall' -Manifest $manifest -Arch $architecture
 
         run_uninstaller $manifest $architecture $dir
         rm_shims $app $manifest $global $architecture

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -54,6 +54,10 @@ if (!$apps) { exit 0 }
         $dir = versiondir $app $version $global
         $persist_dir = persistdir $app $global
 
+        $manifest = installed_manifest $app $version $global
+        $install = install_info $app $version $global
+        $architecture = $install.architecture
+
         Invoke-HookScript -HookType 'pre_uninstall' -Manifest $manifest -Arch $architecture
 
         #region Workaround for #2952
@@ -68,10 +72,6 @@ if (!$apps) { exit 0 }
             error "Access denied: $dir. You might need to restart."
             continue
         }
-
-        $manifest = installed_manifest $app $version $global
-        $install = install_info $app $version $global
-        $architecture = $install.architecture
 
         run_uninstaller $manifest $architecture $dir
         rm_shims $app $manifest $global $architecture


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
Execute the `pre_uninstall` hook before other uninstallation preparation work, namely `test_running_process`

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #4961
<!-- or -->
Motivations
- `pre_uninstall` script should handle teardown work such as stopping services, so that the uninstallation process isn't blocked by running processes.
- Matches symmetry with `post_uninstall`, which is run at the very end of the uninstallation process.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
