### PR TITLE
refactor(manifest): Rename 'Find-Manifest()' to 'Get-Manifest()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - **scoop-search:** Require files in 'bucket' dir for remote known buckets ([#4943](https://github.com/ScoopInstaller/Scoop/issues/4943))
 - **update:** Prevent uninstall when update ([#4949](https://github.com/ScoopInstaller/Scoop/issues/4949))
 
+### Code Refactoring
+
+- **manifest:** Rename 'Find-Manifest()' to 'Get-Manifest() ([#4966](https://github.com/ScoopInstaller/Scoop/issues/4966))
+
 ### Documentation
 
 - **readme:** Update license badge ([#4929](https://github.com/ScoopInstaller/Scoop/issues/4929))

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -72,39 +72,6 @@ function buckets {
     return Get-LocalBucket
 }
 
-function Find-Manifest($app, $bucket) {
-    $manifest, $url = $null, $null
-
-    # check if app is a URL or UNC path
-    if ($app -match '^(ht|f)tps?://|\\\\') {
-        $url = $app
-        $app = appname_from_url $url
-        $manifest = url_manifest $url
-    } else {
-        if ($bucket) {
-            $manifest = manifest $app $bucket
-        } else {
-            foreach ($bucket in Get-LocalBucket) {
-                $manifest = manifest $app $bucket
-                if ($manifest) { break }
-            }
-        }
-
-        if (!$manifest) {
-            # couldn't find app in buckets: check if it's a local path
-            $path = $app
-            if (!$path.endswith('.json')) { $path += '.json' }
-            if (Test-Path $path) {
-                $url = "$(Resolve-Path $path)"
-                $app = appname_from_url $url
-                $manifest, $bucket = url_manifest $url
-            }
-        }
-    }
-
-    return $app, $manifest, $bucket, $url
-}
-
 function Convert-RepositoryUri {
     [CmdletBinding()]
     param (
@@ -197,7 +164,7 @@ function rm_bucket($name) {
 }
 
 function new_issue_msg($app, $bucket, $title, $body) {
-    $app, $manifest, $bucket, $url = Find-Manifest $app $bucket
+    $app, $manifest, $bucket, $url = Get-Manifest "$bucket/$app"
     $url = known_bucket_repo $bucket
     $bucket_path = "$bucketsdir\$bucket"
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -941,11 +941,12 @@ function applist($apps, $global) {
     return ,@($apps | ForEach-Object { ,@($_, $global) })
 }
 
-function parse_app([string] $app) {
-    if($app -match '(?:(?<bucket>[a-zA-Z0-9-_.]+)\/)?(?<app>.*\.json$|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?') {
-        return $matches['app'], $matches['bucket'], $matches['version']
+function parse_app([string]$app) {
+    if ($app -match '^(?:(?<bucket>[a-zA-Z0-9-_.]+)/)?(?<app>.*\.json$|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?$') {
+        return $Matches['app'], $Matches['bucket'], $Matches['version']
+    } else {
+        return $app, $null, $null
     }
-    return $app, $null, $null
 }
 
 function show_app($app, $bucket, $version) {

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -32,9 +32,8 @@ function Get-Dependency {
         $Unresolved = @()
     )
     process {
-        $AppName, $bucket, $null = parse_app $AppName
+        $AppName, $manifest, $bucket, $null = Get-Manifest $AppName
         $Unresolved += $AppName
-        $null, $manifest, $null, $null = Find-Manifest $AppName $bucket
 
         if (!$manifest) {
             if (((Get-LocalBucket) -notcontains $bucket) -and $bucket) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -7,8 +7,7 @@ function nightly_version($date, $quiet = $false) {
 }
 
 function install_app($app, $architecture, $global, $suggested, $use_cache = $true, $check_hash = $true) {
-    $app, $bucket, $null = parse_app $app
-    $app, $manifest, $bucket, $url = Find-Manifest $app $bucket
+    $app, $manifest, $bucket, $url = Get-Manifest $app
 
     if(!$manifest) {
         abort "Couldn't find manifest for '$app'$(if($url) { " at the URL $url" })."

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -22,13 +22,47 @@ function url_manifest($url) {
     $str | convertfrom-json
 }
 
+function Get-Manifest($app) {
+    $bucket, $manifest, $url = $null
+    # check if app is a URL or UNC path
+    if ($app -match '^(ht|f)tps?://|\\\\') {
+        $url = $app
+        $app = appname_from_url $url
+        $manifest = url_manifest $url
+    } else {
+        $app, $bucket, $version = parse_app $app
+        if ($bucket) {
+            $manifest = manifest $app $bucket
+        } else {
+            foreach ($bucket in Get-LocalBucket) {
+                $manifest = manifest $app $bucket
+                if ($manifest) {
+                    break
+                }
+            }
+        }
+        if (!$manifest) {
+            # couldn't find app in buckets: check if it's a local path
+            if (!$app.EndsWith('.json')) {
+                $app += '.json'
+            }
+            if (Test-Path $app) {
+                $url = Convert-Path $app
+                $app = appname_from_url $url
+                $manifest = url_manifest $url
+            }
+        }
+    }
+    return $app, $manifest, $bucket, $url
+}
+
 function manifest($app, $bucket, $url) {
-    if($url) { return url_manifest $url }
+    if ($url) { return url_manifest $url }
     parse_json (manifest_path $app $bucket)
 }
 
 function save_installed_manifest($app, $bucket, $dir, $url) {
-    if($url) {
+    if ($url) {
         $wc = New-Object Net.Webclient
         $wc.Headers.Add('User-Agent', (Get-UserAgent))
         $wc.downloadstring($url) > "$dir\manifest.json"
@@ -51,7 +85,7 @@ function save_install_info($info, $dir) {
 
 function install_info($app, $version, $global) {
     $path = "$(versiondir $app $version $global)\install.json"
-    if(!(test-path $path)) { return $null }
+    if (!(Test-Path $path)) { return $null }
     parse_json $path
 }
 
@@ -73,20 +107,21 @@ function default_architecture {
 }
 
 function arch_specific($prop, $manifest, $architecture) {
-    if($manifest.architecture) {
+    if ($manifest.architecture) {
         $val = $manifest.architecture.$architecture.$prop
-        if($val) { return $val } # else fallback to generic prop
+        if ($val) { return $val } # else fallback to generic prop
     }
 
-    if($manifest.$prop) { return $manifest.$prop }
+    if ($manifest.$prop) { return $manifest.$prop }
 }
 
 function supports_architecture($manifest, $architecture) {
     return -not [String]::IsNullOrEmpty((arch_specific 'url' $manifest $architecture))
 }
 
-function generate_user_manifest($app, $bucket, $version) { # 'autoupdate.ps1' 'buckets.ps1' 'manifest.ps1'
-    $null, $manifest, $bucket, $null = Find-Manifest $app $bucket
+function generate_user_manifest($app, $bucket, $version) {
+    # 'autoupdate.ps1' 'buckets.ps1' 'manifest.ps1'
+    $app, $manifest, $bucket, $null = Get-Manifest "$bucket/$app"
     if ("$($manifest.version)" -eq "$version") {
         return manifest_path $app $bucket
     }

--- a/libexec/scoop-cat.ps1
+++ b/libexec/scoop-cat.ps1
@@ -4,12 +4,11 @@
 param($app)
 
 . "$PSScriptRoot\..\lib\json.ps1" # 'ConvertToPrettyJson'
-. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
 
 if (!$app) { error '<app> missing'; my_usage; exit 1 }
 
-$app, $bucket, $null = parse_app $app
-$app, $manifest, $bucket, $url = Find-Manifest $app $bucket
+$null, $manifest, $bucket, $url = Get-Manifest $app
 
 if ($manifest) {
         $style = get_config cat_style

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -18,7 +18,7 @@
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' (indirectly)
 . "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
-. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'generate_user_manifest' 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'generate_user_manifest' 'Get-Manifest'
 . "$PSScriptRoot\..\lib\install.ps1"
 
 $opt, $apps, $err = getopt $args 'fhua:' 'force', 'no-hash-check', 'no-update-scoop', 'arch='
@@ -51,7 +51,7 @@ foreach ($curr_app in $apps) {
     $bucket = $version = $app = $manifest = $url = $null
 
     $app, $bucket, $version = parse_app $curr_app
-    $app, $manifest, $bucket, $url = Find-Manifest $app $bucket
+    $app, $manifest, $bucket, $url = Get-Manifest "$bucket/$app"
 
     info "Starting download for $app..."
 

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -2,10 +2,10 @@
 # Summary: Opens the app homepage
 param($app)
 
-. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
 
 if ($app) {
-    $null, $manifest, $bucket, $null = Find-Manifest $app
+    $null, $manifest, $bucket, $null = Get-Manifest $app
     if ($manifest) {
         if ($manifest.homepage) {
             Start-Process $manifest.homepage

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -4,7 +4,7 @@
 #   -v, --verbose       Show full paths and URLs
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1" # 'Find-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Get-InstalledVersion'
 
 $opt, $app, $err = getopt $args 'v' 'verbose'
@@ -13,31 +13,21 @@ $verbose = $opt.v -or $opt.verbose
 
 if (!$app) { my_usage; exit 1 }
 
-if ($app -match '^(ht|f)tps?://|\\\\') {
-    # check if $app is a URL or UNC path
-    $url = $app
-    $app = appname_from_url $url
-    $global = installed $app $true
-    $status = app_status $app $global
-    $manifest = url_manifest $url
-    $manifest_file = $url
-} else {
-    # else $app is a normal app name
-    $global = installed $app $true
-    $app, $bucket, $null = parse_app $app
-    $status = app_status $app $global
-    $app, $manifest, $bucket, $url = Find-Manifest $app $bucket
-}
+$app, $manifest, $bucket, $url = Get-Manifest $app
 
 if (!$manifest) {
     abort "Could not find manifest for '$(show_app $app)' in local buckets."
 }
 
+$global = installed $app $true
+$status = app_status $app $global
 $install = install_info $app $status.version $global
 $status.installed = $bucket -and $install.bucket -eq $bucket
 $version_output = $manifest.version
-if (!$manifest_file) {
-    $manifest_file = if ($bucket) { manifest_path $app $bucket } else { $url }
+$manifest_file = if ($bucket) {
+    manifest_path $app $bucket
+} else {
+    $url
 }
 
 if ($verbose) {

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -20,7 +20,7 @@
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' 'manifest.ps1' (indirectly)
 . "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
-. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'generate_user_manifest' 'Select-CurrentVersion' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'default_architecture' 'generate_user_manifest' 'Get-Manifest' 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\decompress.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -7,7 +7,7 @@
 #   -p, --purge    Remove all persistent data
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\manifest.ps1" # 'Select-CurrentVersion' (indirectly)
+. "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest' 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\install.ps1"
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"

--- a/test/Scoop-Depends.Tests.ps1
+++ b/test/Scoop-Depends.Tests.ps1
@@ -69,30 +69,30 @@ Describe 'Package Dependencies' -Tag 'Scoop' {
         BeforeAll {
             Mock Test-HelperInstalled { $false }
             Mock get_config { $true } -ParameterFilter { $name -eq 'MSIEXTRACT_USE_LESSMSI' }
-            Mock Find-Manifest { $null, @{}, $null, $null } -ParameterFilter { $AppName -eq 'lessmsi' }
-            Mock Find-Manifest { $null, @{ url = 'test.msi' }, $null, $null } -ParameterFilter { $AppName -eq '7zip' }
-            Mock Find-Manifest { $null, @{}, $null, $null } -ParameterFilter { $AppName -eq 'innounp' }
+            Mock Get-Manifest { 'lessmsi', @{}, $null, $null } -ParameterFilter { $app -eq 'lessmsi' }
+            Mock Get-Manifest { '7zip', @{ url = 'test.msi' }, $null, $null } -ParameterFilter { $app -eq '7zip' }
+            Mock Get-Manifest { 'innounp', @{}, $null, $null } -ParameterFilter { $app -eq 'innounp' }
         }
 
         It 'Resolve install dependencies' {
-            Mock Find-Manifest { $null, @{ url = 'test.7z' }, $null, $null }
+            Mock Get-Manifest { 'test', @{ url = 'test.7z' }, $null, $null }
             Get-Dependency -AppName 'test' -Architecture '32bit' | Should -Be @('lessmsi', '7zip', 'test')
-            Mock Find-Manifest { $null, @{ innosetup = $true }, $null, $null }
+            Mock Get-Manifest { 'test', @{ innosetup = $true }, $null, $null }
             Get-Dependency -AppName 'test' -Architecture '32bit' | Should -Be @('innounp', 'test')
         }
         It 'Resolve script dependencies' {
-            Mock Find-Manifest { $null, @{ pre_install = 'Expand-7zipArchive ' }, $null, $null }
+            Mock Get-Manifest { 'test', @{ pre_install = 'Expand-7zipArchive ' }, $null, $null }
             Get-Dependency -AppName 'test' -Architecture '32bit' | Should -Be @('lessmsi', '7zip', 'test')
         }
         It 'Resolve runtime dependencies' {
-            Mock Find-Manifest { $null, @{}, $null, $null } -ParameterFilter { $AppName -eq 'depends' }
-            Mock Find-Manifest { $null, @{ depends = 'depends' }, $null, $null }
+            Mock Get-Manifest { 'depends', @{}, $null, $null } -ParameterFilter { $app -eq 'depends' }
+            Mock Get-Manifest { 'test', @{ depends = 'depends' }, $null, $null }
             Get-Dependency -AppName 'test' -Architecture '32bit' | Should -Be @('depends', 'test')
         }
         It 'Keep bucket name of app' {
-            Mock Find-Manifest { $null, @{}, $null, $null } -ParameterFilter { $AppName -eq 'bucket/depends' }
-            Mock Find-Manifest { $null, @{ depends = 'bucket/depends' }, $null, $null }
-            Get-Dependency -AppName 'anotherbucket/test' -Architecture '32bit' | Should -Be @('bucket/depends', 'anotherbucket/test')
+            Mock Get-Manifest { 'depends', @{}, 'anotherbucket', $null } -ParameterFilter { $app -eq 'anotherbucket/depends' }
+            Mock Get-Manifest { 'test', @{ depends = 'anotherbucket/depends' }, 'bucket', $null }
+            Get-Dependency -AppName 'bucket/test' -Architecture '32bit' | Should -Be @('anotherbucket/depends', 'bucket/test')
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

- Move `bucket.ps1/Find-Manifest()` to `manifest.ps1/Get-Manifest()`
- Embed `parse_app()` into `Get-Manifest()`
- Enclose `parse_app()`'s RegEx with `^` and `$`

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Closes #4910
<!-- or -->
- Relates to https://github.com/ScoopInstaller/Scoop/pull/4914#issuecomment-1128677389

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- `scoop cat`
- `scoop info`
- `scoop home`
- `scoop install`
- `test.ps1`

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
