### PR TITLE
fix(scoop-virustotal): fix url used by Get-VirusTotalResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **scoop-info:** Fix error message when manifest is not found ([#4935](https://github.com/ScoopInstaller/Scoop/issues/4935))
 - **scoop-search:** Require files in 'bucket' dir for remote known buckets ([#4943](https://github.com/ScoopInstaller/Scoop/issues/4943))
 - **update:** Prevent uninstall when update ([#4949](https://github.com/ScoopInstaller/Scoop/issues/4949))
+- **scoop-virustotal:** Fix url used by Get-VirusTotalResult ([#4965](https://github.com/ScoopInstaller/Scoop/issues/4965))
 
 ### Documentation
 

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -82,7 +82,7 @@ $requests = 0
 
 Function Get-VirusTotalResult($hash, $app) {
     $hash = $hash.ToLower()
-    $url = "https://www.virustotal.com/ui/files/$hash"
+    $url = "https://www.virustotal.com/gui/files/$hash"
     $wc = New-Object Net.Webclient
     $wc.Headers.Add('User-Agent', (Get-UserAgent))
     $result = $wc.downloadstring($url)


### PR DESCRIPTION
#### Description

Fix url used by Get-VirusTotalResult

#### Motivation and Context

Close #4965

#### How Has This Been Tested?

Test it by modify (scoop prefix scoop)/libexec/scoop-virustotal.ps1

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
