### PR TITLE
fix(scoop-download): Use correct Args when calling `Get-Manifest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,7 @@
 - **scoop:** Remove temporary code from the scoop executable ([#3898](https://github.com/ScoopInstaller/Scoop/issues/3898))
 - **update:** Update outdated PowerShell 5 warning ([#3986](https://github.com/ScoopInstaller/Scoop/issues/3986))
 - **scoop-info:** Check bucket of installed app ([#3740](https://github.com/ScoopInstaller/Scoop/issues/3740))
+- **scoop-download:** Use correct Args when calling `Get-Manifest` ([#4970](https://github.com/ScoopInstaller/Scoop/issues/4970))
 
 ### Builds
 

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -51,7 +51,7 @@ foreach ($curr_app in $apps) {
     $bucket = $version = $app = $manifest = $url = $null
 
     $app, $bucket, $version = parse_app $curr_app
-    $app, $manifest, $bucket, $url = Get-Manifest "$bucket/$app"
+    $app, $manifest, $bucket, $url = Get-Manifest $curr_app
 
     info "Starting download for $app..."
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

```
❯ scoop download mpv
INFO  Starting download for /mpv...
Loading mpv-0.34.0-x86_64.7z from cache
Checking hash of mpv-0.34.0-x86_64.7z ... ok.
'/mpv' (0.34.0) was downloaded successfully!
```

The appname appended with `/`(slash), when execute `scoop download <app>`

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #XXXX
<!-- or -->
Relates to #XXXX

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

![screenshot_20220607121554](https://user-images.githubusercontent.com/4353480/172376675-e64b80de-db5e-4456-a16e-cb492bd5ceaf.png)


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
