### PR TITLE
feat(scoop-hold,scoop-unhold): Support `-g`/`--global` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **core:** Add `Get-Encoding` function to fix missing webclient encoding ([#4956](https://github.com/ScoopInstaller/Scoop/issues/4956))
 - **scoop-virustotal:** Migrate to virustotal api v3, improve flows, and ouput powershell objects ([#4983](https://github.com/ScoopInstaller/Scoop/pull/4983))
+- **scoop-hold,scoop-unhold:** Support `-g`/`--global` flag ([#4991](https://github.com/ScoopInstaller/Scoop/issues/4991))
 
 ### Bug Fixes
 

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -1,23 +1,43 @@
 # Usage: scoop unhold <app>
 # Summary: Unhold an app to enable updates
+# Help: To unhold a user-scoped app:
+#      scoop unhold <app>
+#
+# To unhold a global app:
+#      scoop unhold -g <app>
+#
+# Options:
+#   -g, --global  Unhold globally installed apps
 
+. "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\json.ps1" # 'save_install_info' (indirectly)
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'install_info' 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
-$apps = $args
+$opt, $apps, $err = getopt $args 'g' 'global'
+if ($err) { "scoop unhold: $err"; exit 1 }
 
-if(!$apps) {
+$global = $opt.g -or $opt.global
+
+if (!$apps) {
     my_usage
+    exit 1
+}
+
+if ($global -and !(is_admin)) {
+    error 'You need admin rights to unhold a global app.'
     exit 1
 }
 
 $apps | ForEach-Object {
     $app = $_
-    $global = installed $app $true
 
-    if (!(installed $app)) {
-        error "'$app' is not installed."
+    if (!(installed $app $global)) {
+        if ($global) {
+            error "'$app' is not installed globally."
+        } else {
+            error "'$app' is not installed."
+        }
         return
     }
 
@@ -29,7 +49,7 @@ $apps | ForEach-Object {
     $dir = versiondir $app $version $global
     $json = install_info $app $version $global
     $install = @{}
-    $json | Get-Member -MemberType Properties | ForEach-Object { $install.Add($_.Name, $json.($_.Name))}
+    $json | Get-Member -MemberType Properties | ForEach-Object { $install.Add($_.Name, $json.($_.Name)) }
     $install.hold = $null
     save_install_info $install $dir
     success "$app is no longer held and can be updated again."


### PR DESCRIPTION
#### Description

Support a `-g`/`--global` flag for `scoop hold`/`scoop unhold`, which tells Scoop to hold/unhold globally installed apps.

#### Motivation and Context

Closes #4990.

#### How Has This Been Tested?

1. Install an app both user-scoped and globally: `scoop install <app>` and `scoop install -g <app>`.

2. Hold/unhold the user-scoped app: `scoop hold <app>`/`scoop unhold <app>`. This does not require admin privileges.

3. Hold/unhold the global app without admin privileges: `scoop hold -g <app>`/`scoop unhold -g <app>`. It shows an error:

	```
	ERROR You need admin rights to hold a global app.
	ERROR You need admin rights to unhold a global app.
	```

4. Hold/unhold the global app with admin privileges: `sudo scoop hold -g <app>`/`sudo scoop unhold -g <app>`. It works as expected. (Assuming that `sudo` has been installed properly.)

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
