### PR TITLE
refactor(shim, scoop-cache) use -join instead of '+' to concatenate strings

### DIFF
--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -7,7 +7,6 @@
 #     scoop cache show
 # to see what's in the cache, and
 #     scoop cache rm <app> to remove downloads for a specific app.
-#
 # To clear everything in your cache, use:
 #     scoop cache rm *
 # You can also use the `-a/--all` switch in place of `*` here
@@ -23,7 +22,7 @@ function cacheshow($app) {
     if (!$app -or $app -eq '*') {
         $app = '.*?'
     } else {
-        $app = '(' + ($app -join '|') + ')'
+        $app = -join @('(', $app, '|', ')')
     }
     $files = @(Get-ChildItem $cachedir | Where-Object -Property Name -Value "^$app#" -Match)
     $totalLength = ($files | Measure-Object -Property Length -Sum).Sum
@@ -41,7 +40,7 @@ function cacheremove($app) {
     } elseif ($app -eq '*' -or $app -eq '-a' -or $app -eq '--all') {
         $files = @(Get-ChildItem $cachedir)
     } else {
-        $app = '(' + ($app -join '|') + ')'
+        $app = -join @('(', $app, '|', ')')
         $files = @(Get-ChildItem $cachedir | Where-Object -Property Name -Value "^$app#" -Match)
     }
     $totalLength = ($files | Measure-Object -Property Length -Sum).Sum

--- a/supporting/shimexe/shim.cs
+++ b/supporting/shimexe/shim.cs
@@ -70,7 +70,7 @@ namespace Scoop {
 
             var configPath = Path.Combine(dir, name + ".shim");
             if(!File.Exists(configPath)) {
-                Console.Error.WriteLine("Couldn't find " + Path.GetFileName(configPath) + " in " + dir);
+                Console.Error.WriteLine(-join @("Couldn't find ", Path.GetFileName(configPath), " in ", dir));
                 return 1;
             }
 
@@ -89,7 +89,7 @@ namespace Scoop {
                 cmd_args += pass_args;
             }
             if(!string.IsNullOrEmpty(cmd_args)) cmd_args = " " + cmd_args;
-            var cmd = "\"" + path + "\"" + cmd_args;
+            var cmd = -join @("\"", path, "\"", cmd_args);
 
             if(!CreateProcess(null, cmd, IntPtr.Zero, IntPtr.Zero,
                 bInheritHandles: true,
@@ -133,7 +133,7 @@ namespace Scoop {
 
         // now uses GetArgs instead
         static string Serialize(string[] args) {
-            return string.Join(" ", args.Select(a => a.Contains(' ') ? '"' + a + '"' : a));
+            return string.Join(" ", args.Select(a => a.Contains(' ') ? (-join @('"', a, '"')) : a));
         }
 
         // strips the program name from the command line, returns just the arguments


### PR DESCRIPTION
use "-join" to improve performance

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
