### PR TITLE
fix(install): Move from cache when `--no-cache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- **install:** Move from cache when `--no-cache` is specified ([#5039](https://github.com/ScoopInstaller/Scoop/issues/5039))
 - **scoop-status:** Correct formatting of `Info` output ([#5047](https://github.com/ScoopInstaller/Scoop/issues/5047))
 
 ## [v0.2.3](https://github.com/ScoopInstaller/Scoop/compare/v0.2.2...v0.2.3) - 2022-07-07

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -90,7 +90,11 @@ function dl_with_cache($app, $version, $url, $to, $cookies = $null, $use_cache =
     } else { write-host "Loading $(url_remote_filename $url) from cache"}
 
     if (!($null -eq $to)) {
-        Copy-Item $cached $to
+        if ($use_cache) {
+            Copy-Item $cached $to
+        } else {
+            Move-Item $cached $to -Force
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
When the `--no-cache` flag is specified, the downloaded file should be moved from the cache folder, instead of copying it. 

This was being done in `dl_with_cache_aria2` function, but not in `dl_with_cache` function. 

This PR fixes it.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #5038
<!-- or -->

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
