### PR TITLE
fix(scoop-status): Correct formatting of `Info` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+
+### Bug Fixes
+
+- **scoop-status:** Correct formatting of `Info` output ([#5047](https://github.com/ScoopInstaller/Scoop/issues/5047))
+
 ## [v0.2.3](https://github.com/ScoopInstaller/Scoop/compare/v0.2.2...v0.2.3) - 2022-07-07
 
 ### Features

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -57,7 +57,7 @@ $true, $false | ForEach-Object { # local and global apps
         $item.'Installed Version' = $status.version
         $item.'Latest Version' = if ($status.outdated) { $status.latest_version } else { "" }
         $item.'Missing Dependencies' = $status.missing_deps -Split ' ' -Join ' | '
-        $info = $()
+        $info = @()
         if ($status.failed)  { $info += 'Install failed' }
         if ($status.hold)    { $info += 'Held package' }
         if ($status.removed) { $info += 'Manifest removed' }


### PR DESCRIPTION
### Description

See #5046.

### Motivation and Context

Closes #5046.

### How Has This Been Tested?

Make an app fail to be installed via a separate manifest, and run `scoop status`.

### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
