### PR TITLE
feat(core): Improve argument concatenation in `Invoke-ExternalCommand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
 
+### Features
+
+- **core:** Improve argument concatenation in `Invoke-ExternalCommand` ([#5065](https://github.com/ScoopInstaller/Scoop/issues/5065))
+
 ### Bug Fixes
 
 - **install:** Move from cache when `--no-cache` is specified ([#5039](https://github.com/ScoopInstaller/Scoop/issues/5039))

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -526,7 +526,7 @@ function Invoke-ExternalCommand {
         # ArgumentList is supported in PowerShell 6.1 and later (built on .NET Core 2.1+)
         # ref-1: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=net-6.0
         # ref-2: https://docs.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell?view=powershell-7.2#net-framework-vs-net-core
-        $ArgumentList | ForEach-Object -Process { $Process.StartInfo.ArgumentList.Add($_) }
+        $ArgumentList | ForEach-Object { $Process.StartInfo.ArgumentList.Add($_) }
     } else {
         # escape arguments manually in lower versions, refer to https://docs.microsoft.com/en-us/previous-versions/17w5ykft(v=vs.85)
         $escapedArgs = $ArgumentList | ForEach-Object {

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -28,10 +28,10 @@ function Expand-7zipArchive {
         $7zPath = Get-HelperPath -Helper 7zip
     }
     $LogPath = "$(Split-Path $Path)\7zip.log"
-    $ArgList = @('x', "`"$Path`"", "-o`"$DestinationPath`"", '-y')
+    $ArgList = @('x', $Path, "-o$DestinationPath", '-y')
     $IsTar = ((strip_ext $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
     if (!$IsTar -and $ExtractDir) {
-        $ArgList += "-ir!`"$ExtractDir\*`""
+        $ArgList += "-ir!$ExtractDir\*"
     }
     if ($Switches) {
         $ArgList += (-split $Switches)
@@ -53,7 +53,7 @@ function Expand-7zipArchive {
     }
     if ($IsTar) {
         # Check for tar
-        $Status = Invoke-ExternalCommand $7zPath @('l', "`"$Path`"") -LogPath $LogPath
+        $Status = Invoke-ExternalCommand $7zPath @('l', $Path) -LogPath $LogPath
         if ($Status) {
             # get inner tar file name
             $TarFile = (Select-String -Path $LogPath -Pattern '[^ ]*tar$').Matches.Value
@@ -97,7 +97,7 @@ function Expand-ZstdArchive {
     $LogPath = Join-Path (Split-Path $Path) 'zstd.log'
     $DestinationPath = $DestinationPath.TrimEnd('\')
     ensure $DestinationPath | Out-Null
-    $ArgList = @('-d', "`"$Path`"", '--output-dir-flat', "`"$DestinationPath`"", '-f', '-v')
+    $ArgList = @('-d', $Path, '--output-dir-flat', $DestinationPath, '-f', '-v')
 
     if ($Switches) {
         $ArgList += (-split $Switches)
@@ -148,10 +148,10 @@ function Expand-MsiArchive {
     }
     if ((get_config MSIEXTRACT_USE_LESSMSI)) {
         $MsiPath = Get-HelperPath -Helper Lessmsi
-        $ArgList = @('x', "`"$Path`"", "`"$DestinationPath\\`"")
+        $ArgList = @('x', $Path, "$DestinationPath\")
     } else {
         $MsiPath = 'msiexec.exe'
-        $ArgList = @('/a', "`"$Path`"", '/qn', "TARGETDIR=`"$DestinationPath\\SourceDir`"")
+        $ArgList = @('/a', "`"$Path`"", '/qn', "TARGETDIR=`"$DestinationPath\SourceDir`"")
     }
     $LogPath = "$(Split-Path $Path)\msi.log"
     if ($Switches) {
@@ -200,7 +200,7 @@ function Expand-InnoArchive {
         $Removal
     )
     $LogPath = "$(Split-Path $Path)\innounp.log"
-    $ArgList = @('-x', "-d`"$DestinationPath`"", "`"$Path`"", '-y')
+    $ArgList = @('-x', "-d$DestinationPath", $Path, '-y')
     switch -Regex ($ExtractDir) {
         '^[^{].*' { $ArgList += "-c{app}\$ExtractDir" }
         '^{.*' { $ArgList += "-c$ExtractDir" }
@@ -267,7 +267,7 @@ function Expand-DarkArchive {
         $Removal
     )
     $LogPath = "$(Split-Path $Path)\dark.log"
-    $ArgList = @('-nologo', "-x `"$DestinationPath`"", "`"$Path`"")
+    $ArgList = @('-nologo', '-x', $DestinationPath, $Path)
     if ($Switches) {
         $ArgList += (-split $Switches)
     }


### PR DESCRIPTION
### Description

Use `ArgumentList` in PowerShell 6.1 and later (built on .NET Core 2.1+), otherwise escape arguments using [the general MSVC Runtime's rules](https://docs.microsoft.com/en-us/previous-versions/17w5ykft(v=vs.85)) in older versions.

In the past, due to the arbitraryness of arguments, we are not able to handle all cases where arguments may contain spaces, quotes or other special characters for every automatic installer script that uses `Invoke-ExternalCommand`. With this change, we don't have to escape arguments manually for most external commands any more. But for the following exceptions who basically don't follow the general MSVC Runtime's rules of parsing command line, just simply concatenate arguments with spaces to build the argument list string, which means we have to escape arguments manually for them: (case insensitive)

- Well-known executables: `cmd.exe`, `cscript.exe`, `wscript.exe` and `msiexec.exe`.
- Files with these suffixes: `.bat`, `.cmd`, `.js`, `.vbs` and `.wsf`.

Ref: [MS docs](https://docs.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.2#psnativecommandargumentpassing)

### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
