### PR TITLE
feat(core): Create no window by default in `Invoke-ExternalCommand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- **core:** Create no window by default in `Invoke-ExternalCommand` ([#5066](https://github.com/ScoopInstaller/Scoop/issues/5066))
 - **core:** Improve argument concatenation in `Invoke-ExternalCommand` ([#5065](https://github.com/ScoopInstaller/Scoop/issues/5065))
 
 ### Bug Fixes

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -520,6 +520,8 @@ function Invoke-ExternalCommand {
     if ($RunAs) {
         $Process.StartInfo.UseShellExecute = $true
         $Process.StartInfo.Verb = 'RunAs'
+    } else {
+        $Process.StartInfo.CreateNoWindow = $true
     }
     if ($FilePath -match '^((cmd|cscript|wscript|msiexec)(\.exe)?|.*\.(bat|cmd|js|vbs|wsf))$') {
         $Process.StartInfo.Arguments = $ArgumentList -join ' '


### PR DESCRIPTION
### Description

Support a new `-NoWindow` switch which indicates the process should be started without creating a new window to contain it. **This switch cannot go with `-RunAs`.**

### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
