### PR TITLE
feat(scoop-update): Stash uncommitted changes before update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **install:** Show bucket name while installing an app ([#5075](https://github.com/ScoopInstaller/Scoop/issues/5075))
 - **scoop-status:** Add flag to disable remote checking ([#5073](https://github.com/ScoopInstaller/Scoop/issues/5073))
 - **scoop-update:** Add support for `pre_uninstall` and `post_uninstall` ([#5085](https://github.com/ScoopInstaller/Scoop/issues/5085))
+- **scoop-update:** Stash uncommitted changes before update ([#5091](https://github.com/ScoopInstaller/Scoop/issues/5091))
 
 ### Bug Fixes
 

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -47,6 +47,10 @@
 #       * An empty or unset value for proxy is equivalent to 'default' (with no username or password)
 #       * To bypass the system proxy and connect directly, use 'none' (with no username or password)
 #
+# autostash_on_conflict: $true|$false
+#       When a conflict is detected during updating, Scoop will auto-stash the uncommitted changes.
+#       (Default is $false, which will abort the update)
+#
 # default_architecture: 64bit|32bit
 #       Allow to configure preferred architecture for application installation.
 #       If not specified, architecture is determined be system.

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -99,9 +99,13 @@ function update_scoop() {
         $isBranchChanged = !($currentBranch -match "\*\s+$configBranch")
 
         # Stash uncommitted changes
-        if (git diff HEAD --name-only) {
-            warn "Uncommitted changes detected. Stashing..."
-            git stash push -m "WIP at $([System.DateTime]::Now.ToString('o'))" -u -q
+        if (git -C "$currentdir" diff HEAD --name-only) {
+            if (get_config autostash_on_conflict) {
+                warn "Uncommitted changes detected. Stashing..."
+                git -C "$currentdir" stash push -m "WIP at $([System.DateTime]::Now.ToString('o'))" -u -q
+            } else {
+                abort "Uncommitted changes detected. Updating Aborted."
+            }
         }
 
         # Change remote url if the repo is changed

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -104,7 +104,8 @@ function update_scoop() {
                 warn "Uncommitted changes detected. Stashing..."
                 git -C "$currentdir" stash push -m "WIP at $([System.DateTime]::Now.ToString('o'))" -u -q
             } else {
-                abort "Uncommitted changes detected. Updating Aborted."
+                warn "Uncommitted changes detected. Update aborted."
+                return
             }
         }
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -98,6 +98,12 @@ function update_scoop() {
         $isRepoChanged = !($currentRepo -match $configRepo)
         $isBranchChanged = !($currentBranch -match "\*\s+$configBranch")
 
+        # Stash uncommitted changes
+        if (git diff HEAD --name-only) {
+            warn "Uncommitted changes detected. Stashing..."
+            git stash push -m "WIP at $([System.DateTime]::Now.ToString('o'))" -u -q
+        }
+
         # Change remote url if the repo is changed
         if ($isRepoChanged) {
             git -C "$currentdir" config remote.origin.url "$configRepo"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Auto stash uncommitted changes of scoop before update.

Now the action is done in scoop core, should this be applied to buckets too?

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Relates to https://github.com/ScoopInstaller/Scoop/pull/5089#issuecomment-1207388756

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

![image](https://user-images.githubusercontent.com/5832170/183292198-bd824ad0-0d36-4632-b6ae-f1393ff86971.png)

And this could be tested by checking out this PR, adding some dummy files in scoop dir and running `scoop update`.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
