### PR TITLE
builds(checkver): Implement SourceForge checkver functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **scoop-update:** Stash uncommitted changes before update ([#5091](https://github.com/ScoopInstaller/Scoop/issues/5091))
 - **install:** Show the running process ([#5102](https://github.com/ScoopInstaller/Scoop/issues/5102))
 
+### Builds
+
+- **checkver:** Implement SourceForge checkver functionality ([#5113](https://github.com/ScoopInstaller/Scoop/issues/5113))
+
 ## [v0.2.4](https://github.com/ScoopInstaller/Scoop/compare/v0.2.3...v0.2.4) - 2022-08-08
 
 ### Features

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -166,10 +166,10 @@ $Queue | ForEach-Object {
     if ($regex) {
         $sourceforgeRegex = $regex
     } else {
-        $sourceforgeRegex = '(\d[\d.]*\d)'
+        $sourceforgeRegex = '(?!\.)([\d.]+)(?<=\d)'
     }
     if ($json.checkver -eq 'sourceforge') {
-        if ($json.homepage -match '//(sourceforge|sf)\.net/projects/(?<project>[\w-]+)(/files/(?<path>[\w-]+))?|//(?<project>[\w-]+)\.(sourceforge\.(net|io)|sf\.net)') {
+        if ($json.homepage -match '//(sourceforge|sf)\.net/projects/(?<project>[^/]+)(/files/(?<path>[^/]+))?|//(?<project>[^.]+)\.(sourceforge\.(net|io)|sf\.net)') {
             $project = $Matches['project']
             $path = $Matches['path']
         } else {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -177,7 +177,7 @@ $Queue | ForEach-Object {
         $url = $url + '?path=' + $json.checkver.sourceforge.path
     }
 
-    if($json.checkver.re) {
+    if ($json.checkver.re) {
         $regex = $json.checkver.re
     }
     if ($json.checkver.regex) {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -121,8 +121,8 @@ $Queue | ForEach-Object {
     }
     Register-ObjectEvent $wc downloadDataCompleted -ErrorAction Stop | Out-Null
 
-    $githubRegex = '\/releases\/tag\/(?:v|V)?([\d.]+)'
-    $sourceforgeRegex = '(?:.*)?\/(?:v)?([\d.]+)\/'
+    $githubRegex = '/releases/tag/(?:v|V)?([\d.]+)'
+    $sourceforgeRegex = '(?:.*)?/(?:v)?([\d.]+)/'
 
     $url = $json.homepage
     if ($json.checkver.url) {
@@ -150,31 +150,31 @@ $Queue | ForEach-Object {
     }
 
     if ($json.checkver -eq 'sourceforge' -or $json.homepage.Contains('sourceforge.net') -or $json.checkver.sourceforge.path) {
-        if ($json.homepage -match '\/\/sourceforge\.net\/projects\/(?<project>([\w-]+$|[\w-]+))(?:[/]?)' -or $json.homepage -match '\/\/(?<project>[\w-]+)\.sourceforge\.net') {
+        if ($json.homepage -match '//sourceforge\.net/projects/(?<project>([\w-]+$|[\w-]+))(?:[/]?)' -or $json.homepage -match '//(?<project>[\w-]+)\.sourceforge\.net') {
             $url = 'https://sourceforge.net/projects/' + $matches['project'] + '/rss'
-            $regex = '\/\/sourceforge\.net\/projects\/' + $matches['project'] + $sourceforgeRegex
+            $regex = '//sourceforge\.net/projects/' + $matches['project'] + $sourceforgeRegex
             if ($json.checkver -ne 'sourceforge' -and $json.checkver.GetType() -eq [System.String]) {
                 $regex = $json.checkver
             }
         }
         else {
             $url = 'https://sourceforge.net/projects/' + (strip_ext $name) + '/rss'
-            $regex = '\/\/sourceforge\.net\/projects\/' + (strip_ext $name) + $sourceforgeRegex
+            $regex = '//sourceforge\.net/projects/' + (strip_ext $name) + $sourceforgeRegex
         }
     }
 
     if ($json.checkver.sourceforge -and $json.checkver.sourceforge.GetType() -eq [System.String]) {
         $url = 'https://sourceforge.net/projects/' + $json.checkver.sourceforge + '/rss'
-        $regex = '\/\/sourceforge\.net\/projects\/' + $json.checkver.sourceforge + $sourceforgeRegex
+        $regex = '//sourceforge\.net/projects/' + $json.checkver.sourceforge + $sourceforgeRegex
     }
 
     if ($json.checkver.sourceforge.project) {
         $url = 'https://sourceforge.net/projects/' + $json.checkver.sourceforge.project + '/rss'
-        $regex = '\/\/sourceforge\.net\/projects\/' + $json.checkver.sourceforge.project + $sourceforgeRegex
+        $regex = '//sourceforge\.net/projects/' + $json.checkver.sourceforge.project + $sourceforgeRegex
     }
 
     if ($json.checkver.sourceforge.path) {
-        $url = $url + '?path=' + $json.checkver.sourceforge.path
+        $url = $url + '?path=/' + $json.checkver.sourceforge.path.TrimStart('/')
     }
 
     if ($json.checkver.re) {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -182,7 +182,7 @@ $Queue | ForEach-Object {
         $regex = "CDATA\[/$path/.*?$sourceforgeRegex.*?\]".Replace('//', '/')
     }
     if ($json.checkver.sourceforge) {
-        if ($json.checkver.sourceforge.GetType() -eq [System.String] -and $json.checkver.sourceforge -match '(?<project>[\w-]*)(/(?<path>.*))?') {
+        if ($json.checkver.sourceforge -is [System.String] -and $json.checkver.sourceforge -match '(?<project>[\w-]*)(/(?<path>.*))?') {
             $project = $Matches['project']
             $path = $Matches['path']
         } else {
@@ -206,7 +206,7 @@ $Queue | ForEach-Object {
         $xpath = $json.checkver.xpath
     }
 
-    if ($json.checkver.replace -and $json.checkver.replace.GetType() -eq [System.String]) {
+    if ($json.checkver.replace -is [System.String]) { # If `checkver` is [System.String], it has a method called `Replace`
         $replace = $json.checkver.replace
     }
 

--- a/schema.json
+++ b/schema.json
@@ -331,7 +331,8 @@
                                         "path": {
                                             "type": "string"
                                         }
-                                    }
+                                    },
+                                    "type": "object"
                                 }
                             ]
                         }

--- a/schema.json
+++ b/schema.json
@@ -315,6 +315,25 @@
                         "script": {
                             "$ref": "#/definitions/stringOrArrayOfStrings",
                             "description": "Custom PowerShell script to retrieve application version using more complex approach."
+                        },
+                        "sourceforge": {
+                            "anyOf": [
+                                {
+                                    "format": "regex",
+                                    "type": "string"
+                                },
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "project": {
+                                            "type": "string"
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "type": "object"

--- a/schema.json
+++ b/schema.json
@@ -319,7 +319,6 @@
                         "sourceforge": {
                             "anyOf": [
                                 {
-                                    "format": "regex",
                                     "type": "string"
                                 },
                                 {
@@ -334,7 +333,8 @@
                                     },
                                     "type": "object"
                                 }
-                            ]
+                            ],
+                            "type": "object"
                         }
                     },
                     "type": "object"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

SourceForge checkver based on @se35710's previous work.

*The following description is copied from #4560 and updated*

In it's most simple form:

```json
    "checkver": "sourceforge",
```

This will find the project name from homepage, or if that fails, from the manifest name.

A more comples example:

```json
    "checkver": {
        "sourceforge": {
            "project": "pmt",
            "path": "pngcrush-executables"
        }
    },
```

or simplified version (**newly added, just likes github**)

```json
    "checkver": {
        "sourceforge": "pmt/pngcrush-executables"
    },
```

Here we provide the project name, and a path into the files section (to limit number of downloads). `project` is optional and only needed if `homepage` or manifest name is not equal to the SourceForge project name.

The default regex is `(?!\.)([\d.]+)(?<=\d)` and the actually used one is `"CDATA\[/$path/.*?$sourceforgeRegex.*?\]".Replace('//', '/')`. If `regex` or `re` in `checkver` is set, it is used as `$sourceforgeRegex`.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We have a lot of different approaches to SourceForge updates, this will help with maintaining those.

- Relates to #2455
- Relates to #4560

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I've copied some test manifests from #2455 and add more in https://github.com/ScoopInstaller/Tests/pull/5

```console
tests on  test-sf-checkver [?]
❯ .\bin\checkver astyle -f
astyle: 3.1 (scoop version is 3.1)
Forcing autoupdate!
Autoupdating astyle
Found: sha1:5372ca57577f252cb6efdde12f889329786a72a2 using Sourceforge Mode
Writing updated astyle manifest

tests on  test-sf-checkver [?] took 6s
❯ .\bin\checkver binutils -f
binutils: 2.39 (scoop version is 2.39)
Forcing autoupdate!
Autoupdating binutils
Found: sha1:80177c93af07fb1ace1a9e7a6726d47f1430eab3 using Sourceforge Mode
Downloading libgcc-9.2.0-3-mingw32-dll-1.tar.xz to compute hashes!
libgcc-9.2.0-3-mingw32-dll-1.tar.xz (43.8 KB) [===============================================================] 100%
Computed hash: 27f7a72e1aa5d0bb894f84aa62da0200b3a4a334e85457bb1961fc341290f833
Writing updated binutils manifest

tests on  test-sf-checkver [?] took 11s
❯ .\bin\checkver blat -f
blat: 3.2.24 (scoop version is 3.2.24)
Forcing autoupdate!
Autoupdating blat
Found: sha1:a98f048900cea5a70e5ee4f39ad08f6d4f13eccc using Sourceforge Mode
Found: sha1:436c01bfa4dc14a255e63720d0745791bdd9910e using Sourceforge Mode
Writing updated blat manifest

tests on  test-sf-checkver [?] took 8s
❯ .\bin\checkver djvulibre -f
djvulibre: 3.5.28-4.12 (scoop version is 3.5.28-4.12)
Forcing autoupdate!
Autoupdating djvulibre
Found: sha1:acd91e73505f1d00835454ab6314a981cd849541 using Sourceforge Mode
Writing updated djvulibre manifest

tests on  test-sf-checkver [!?] took 8s
❯ .\bin\checkver editorconfig -f
editorconfig: 0.12.1 (scoop version is 0.12.1)
Forcing autoupdate!
Autoupdating editorconfig
Found: sha1:7c44b819690baec3de22edc0c9f7eb21dc0a7850 using Sourceforge Mode
Writing updated editorconfig manifest

tests on  test-sf-checkver [!?] took 6s
❯ .\bin\checkver graphicsmagick -f
graphicsmagick: 1.3.36 (scoop version is 1.3.36)
Forcing autoupdate!
Autoupdating graphicsmagick
Found: sha1:a87e26389d0b3d4ddbb6adde9018c0609376a836 using Sourceforge Mode
Found: sha1:6b6fff1319081890fb85530146c98e63f444d52c using Sourceforge Mode
Writing updated graphicsmagick manifest

tests on  test-sf-checkver [?] took 8s
❯ .\bin\checkver inadyn-mt -f
inadyn-mt: 02.28.10 (scoop version is 02.28.10)
Forcing autoupdate!
Autoupdating inadyn-mt
Found: sha1:176d47ceb2ddf854c3401fd0ae858d38245810a1 using Sourceforge Mode
Writing updated inadyn-mt manifest

tests on  test-sf-checkver [?] took 4s
❯ .\bin\checkver pngcrush -f
pngcrush: 1.8.11 (scoop version is 1.8.11)
Forcing autoupdate!
Autoupdating pngcrush
Found: sha1:ce02f50fa3d82f0d5464f28ac78d3ecee10c5f58 using Sourceforge Mode
Found: sha1:8980ee9b18c0545f61fc8b1156546b24ffa90db8 using Sourceforge Mode
Writing updated pngcrush manifest

tests on  test-sf-checkver [?] took 10s
❯ .\bin\checkver xmlstarlet -f
xmlstarlet: 1.6.1 (scoop version is 1.6.1)
Forcing autoupdate!
Autoupdating xmlstarlet
Found: sha1:cc5f5cd17a1f81740e5185a70408ffd6fa2f862d using Sourceforge Mode
Writing updated xmlstarlet manifest
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
