### PR TITLE
feat(getopt): Support option terminator (`--`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- **getopt:** Support option terminator (`--`) ([#5121](https://github.com/ScoopInstaller/Scoop/issues/5121))
 - **scoop-(un)hold:** Support `scoop (un)hold scoop` ([#5089](https://github.com/ScoopInstaller/Scoop/issues/5089))
 - **scoop-config:** Allow 'hold_update_until' be set manually ([#5100](https://github.com/ScoopInstaller/Scoop/issues/5100))
 - **scoop-update:** Stash uncommitted changes before update ([#5091](https://github.com/ScoopInstaller/Scoop/issues/5091))

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -21,7 +21,7 @@ function getopt($argv, $shortopts, $longopts) {
     }
 
     function regex_escape($str) {
-        return [regex]::escape($str)
+        return [Regex]::Escape($str)
     }
 
     # ensure these are arrays
@@ -32,17 +32,17 @@ function getopt($argv, $shortopts, $longopts) {
         $arg = $argv[$i]
         if ($null -eq $arg) { continue }
         # don't try to parse array arguments
-        if ($arg -is [array]) { $rem += , $arg; continue }
-        if ($arg -is [int]) { $rem += $arg; continue }
-        if ($arg -is [decimal]) { $rem += $arg; continue }
+        if ($arg -is [Array]) { $rem += , $arg; continue }
+        if ($arg -is [Int]) { $rem += $arg; continue }
+        if ($arg -is [Decimal]) { $rem += $arg; continue }
 
-        if ($arg.StartsWith('--')) {
-            $name = $arg.Substring(2)
-
-            if ($name.Length -eq 0) {
+        if ($arg -eq '--') {
+            if ($i -lt $argv.Length - 1) {
                 $rem += $argv[($i + 1)..($argv.Length - 1)]
-                return $opts, $rem
             }
+            break
+        } elseif ($arg.StartsWith('--')) {
+            $name = $arg.Substring(2)
 
             $longopt = $longopts | Where-Object { $_ -match "^$name=?$" }
 
@@ -61,10 +61,10 @@ function getopt($argv, $shortopts, $longopts) {
             }
         } elseif ($arg.StartsWith('-') -and $arg -ne '-') {
             for ($j = 1; $j -lt $arg.Length; $j++) {
-                $letter = $arg[$j].tostring()
+                $letter = $arg[$j].ToString()
 
                 if ($shortopts -match "$(regex_escape $letter)`:?") {
-                    $shortopt = $matches[0]
+                    $shortopt = $Matches[0]
                     if ($shortopt[1] -eq ':') {
                         if ($j -ne $arg.Length - 1 -or $i -eq $argv.Length - 1) {
                             return err "Option -$letter requires an argument."

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -8,6 +8,11 @@
 #    array of strings that are long-form options. options that take
 #    a parameter should end with '='
 # returns @(opts hash, remaining_args array, error string)
+# NOTES:
+#    The first "--" in $argv, if any, will terminate all options; any
+# following arguments are treated as non-option arguments, even if
+# they begin with a hyphen. The "--" itself will not be included in
+# the returned $opts. (POSIX-compatible)
 function getopt($argv, $shortopts, $longopts) {
     $opts = @{}; $rem = @()
 
@@ -23,22 +28,28 @@ function getopt($argv, $shortopts, $longopts) {
     $argv = @($argv)
     $longopts = @($longopts)
 
-    for($i = 0; $i -lt $argv.length; $i++) {
+    for ($i = 0; $i -lt $argv.Length; $i++) {
         $arg = $argv[$i]
-        if($null -eq $arg) { continue }
+        if ($null -eq $arg) { continue }
         # don't try to parse array arguments
-        if($arg -is [array]) { $rem += ,$arg; continue }
-        if($arg -is [int]) { $rem += $arg; continue }
-        if($arg -is [decimal]) { $rem += $arg; continue }
+        if ($arg -is [array]) { $rem += , $arg; continue }
+        if ($arg -is [int]) { $rem += $arg; continue }
+        if ($arg -is [decimal]) { $rem += $arg; continue }
 
-        if($arg.startswith('--')) {
-            $name = $arg.substring(2)
+        if ($arg.StartsWith('--')) {
+            $name = $arg.Substring(2)
+
+            if ($name.Length -eq 0) {
+                $rem += $argv[($i + 1)..($argv.Length - 1)]
+                return $opts, $rem
+            }
 
             $longopt = $longopts | Where-Object { $_ -match "^$name=?$" }
 
-            if($longopt) {
-                if($longopt.endswith('=')) { # requires arg
-                    if($i -eq $argv.length - 1) {
+            if ($longopt) {
+                if ($longopt.EndsWith('=')) {
+                    # requires arg
+                    if ($i -eq $argv.Length - 1) {
                         return err "Option --$name requires an argument."
                     }
                     $opts.$name = $argv[++$i]
@@ -48,14 +59,14 @@ function getopt($argv, $shortopts, $longopts) {
             } else {
                 return err "Option --$name not recognized."
             }
-        } elseif($arg.startswith('-') -and $arg -ne '-') {
-            for($j = 1; $j -lt $arg.length; $j++) {
+        } elseif ($arg.StartsWith('-') -and $arg -ne '-') {
+            for ($j = 1; $j -lt $arg.Length; $j++) {
                 $letter = $arg[$j].tostring()
 
-                if($shortopts -match "$(regex_escape $letter)`:?") {
+                if ($shortopts -match "$(regex_escape $letter)`:?") {
                     $shortopt = $matches[0]
-                    if($shortopt[1] -eq ':') {
-                        if($j -ne $arg.length -1 -or $i -eq $argv.length - 1) {
+                    if ($shortopt[1] -eq ':') {
+                        if ($j -ne $arg.Length - 1 -or $i -eq $argv.Length - 1) {
                             return err "Option -$letter requires an argument."
                         }
                         $opts.$letter = $argv[++$i]

--- a/test/Scoop-GetOpts.Tests.ps1
+++ b/test/Scoop-GetOpts.Tests.ps1
@@ -68,4 +68,12 @@ Describe 'getopt' -Tag 'Scoop' {
         $err | Should -BeNullOrEmpty
         $opt.'long-arg' | Should -Be 'test'
     }
+
+    It 'handles the option terminator' {
+        $opt, $rem, $err = getopt '--long-arg', 'test', '--', '-x' 'x' 'long-arg='
+        $err | Should -BeNullOrEmpty
+        $opt.'long-arg' | Should -Be 'test'
+        $opt.'x' | Should -BeNullOrEmpty
+        $rem[0] | Should -Be '-x'
+    }
 }

--- a/test/Scoop-GetOpts.Tests.ps1
+++ b/test/Scoop-GetOpts.Tests.ps1
@@ -70,10 +70,16 @@ Describe 'getopt' -Tag 'Scoop' {
     }
 
     It 'handles the option terminator' {
-        $opt, $rem, $err = getopt '--long-arg', 'test', '--', '-x' 'x' 'long-arg='
+        $opt, $rem, $err = getopt '--long-arg', '--' '' 'long-arg'
         $err | Should -BeNullOrEmpty
-        $opt.'long-arg' | Should -Be 'test'
+        $opt.'long-arg' | Should -BeTrue
+        $rem[0] | Should -BeNullOrEmpty
+        $opt, $rem, $err = getopt '--long-arg', '--', '-x', '-y' 'xy' 'long-arg'
+        $err | Should -BeNullOrEmpty
+        $opt.'long-arg' | Should -BeTrue
         $opt.'x' | Should -BeNullOrEmpty
+        $opt.'y' | Should -BeNullOrEmpty
         $rem[0] | Should -Be '-x'
+        $rem[1] | Should -Be '-y'
     }
 }


### PR DESCRIPTION
#### Description

Support the option terminator `--` in `getopt`, which is compatible with POSIX conventions for command line options (see [reference](https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html) for details).

#### Motivation and Context

This is also a prerequisite for fixing #5094.

#### How Has This Been Tested?

Tested locally with updated [test/Scoop-GetOpts.Tests.ps1](https://github.com/ScoopInstaller/Scoop/blob/876d0ee2d1673c316ea14e84872eece1278fe49d/test/Scoop-GetOpts.Tests.ps1). All passed.

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
