### PR TITLE
feat(chore): Improve git.exe execution and add parallel bucket updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+
+### Features
+- **scoop-update:** Add support for parallel syncing buckets in PowerShell 7 and improve output ([#5122](https://github.com/ScoopInstaller/Scoop/pull/5122))
+
+### Code Refactoring
+- **git:** Use Invoke-Git() with direct path to git.exe to prevent spawning shim subprocesses ([#5122](https://github.com/ScoopInstaller/Scoop/pull/5122))
+
 ## [v0.3.1](https://github.com/ScoopInstaller/Scoop/compare/v0.3.0...v0.3.1) - 2022-11-15
 
 ### Features

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -20,8 +20,8 @@ switch ($subCommand) {
     }
     ({ $subCommand -in @('-v', '--version') }) {
         Write-Host 'Current Scoop version:'
-        if ((Test-CommandAvailable git) -and (Test-Path "$PSScriptRoot\..\.git") -and (get_config SCOOP_BRANCH 'master') -ne 'master') {
-            git -C "$PSScriptRoot\.." --no-pager log --oneline HEAD -n 1
+        if (Test-GitAvailable -and (Test-Path "$PSScriptRoot\..\.git") -and (get_config SCOOP_BRANCH 'master') -ne 'master') {
+            Invoke-Git -Path "$PSScriptRoot\.." -ArgumentList "--no-pager log --oneline HEAD -n 1"
         } else {
             $version = Select-String -Pattern '^## \[(v[\d.]+)\].*?([\d-]+)$' -Path "$PSScriptRoot\..\CHANGELOG.md"
             Write-Host $version.Matches.Groups[1].Value -ForegroundColor Cyan -NoNewline
@@ -31,9 +31,9 @@ switch ($subCommand) {
 
         Get-LocalBucket | ForEach-Object {
             $bucketLoc = Find-BucketDirectory $_ -Root
-            if ((Test-Path "$bucketLoc\.git") -and (Test-CommandAvailable git)) {
+            if (Test-GitAvailable -and (Test-Path "$bucketLoc\.git")) {
                 Write-Host "'$_' bucket:"
-                git -C "$bucketLoc" --no-pager log --oneline HEAD -n 1
+                Invoke-Git -Path $bucketLoc -ArgumentList "--no-pager log --oneline HEAD -n 1"
                 Write-Host ''
             }
         }

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -21,7 +21,7 @@ switch ($subCommand) {
     ({ $subCommand -in @('-v', '--version') }) {
         Write-Host 'Current Scoop version:'
         if (Test-GitAvailable -and (Test-Path "$PSScriptRoot\..\.git") -and (get_config SCOOP_BRANCH 'master') -ne 'master') {
-            Invoke-Git -Path "$PSScriptRoot\.." -ArgumentList "--no-pager log --oneline HEAD -n 1"
+            Invoke-Git -Path "$PSScriptRoot\.." -ArgumentList @('log', 'HEAD', '-1', '--oneline')
         } else {
             $version = Select-String -Pattern '^## \[(v[\d.]+)\].*?([\d-]+)$' -Path "$PSScriptRoot\..\CHANGELOG.md"
             Write-Host $version.Matches.Groups[1].Value -ForegroundColor Cyan -NoNewline
@@ -33,7 +33,7 @@ switch ($subCommand) {
             $bucketLoc = Find-BucketDirectory $_ -Root
             if (Test-GitAvailable -and (Test-Path "$bucketLoc\.git")) {
                 Write-Host "'$_' bucket:"
-                Invoke-Git -Path $bucketLoc -ArgumentList "--no-pager log --oneline HEAD -n 1"
+                Invoke-Git -Path $bucketLoc -ArgumentList @('log', 'HEAD', '-1', '--oneline')
                 Write-Host ''
             }
         }

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -99,8 +99,8 @@ function list_buckets {
         $bucket = [Ordered]@{ Name = $_ }
         $path = Find-BucketDirectory $_ -Root
         if ((Test-Path (Join-Path $path '.git')) -and (Get-Command git -ErrorAction SilentlyContinue)) {
-            $bucket.Source = git -C $path config remote.origin.url
-            $bucket.Updated = git -C $path log --format='%aD' -n 1 | Get-Date
+            $bucket.Source = Invoke-Git -Path $path -ArgumentList "config remote.origin.url"
+            $bucket.Updated = Invoke-Git -Path $path -ArgumentList "log --format='%aD' -n 1" | Get-Date
         } else {
             $bucket.Source = friendly_path $path
             $bucket.Updated = (Get-Item "$path\bucket").LastWriteTime
@@ -113,7 +113,7 @@ function list_buckets {
 }
 
 function add_bucket($name, $repo) {
-    if (!(Test-CommandAvailable git)) {
+    if (!(Test-GitAvailable)) {
         error "Git is required for buckets. Run 'scoop install git' and try again."
         return 1
     }
@@ -130,7 +130,7 @@ function add_bucket($name, $repo) {
     }
     foreach ($bucket in Get-LocalBucket) {
         if (Test-Path -Path "$bucketsdir\$bucket\.git") {
-            $remote = git -C "$bucketsdir\$bucket" config --get remote.origin.url
+            $remote = Invoke-Git -Path "$bucketsdir\$bucket" -ArgumentList "config --get remote.origin.url"
             if ((Convert-RepositoryUri -Uri $remote) -eq $uni_repo) {
                 warn "Bucket $bucket already exists for $repo"
                 return 2
@@ -139,14 +139,14 @@ function add_bucket($name, $repo) {
     }
 
     Write-Host 'Checking repo... ' -NoNewline
-    $out = git_cmd ls-remote $repo 2>&1
+    $out = Invoke-Git -ArgumentList "ls-remote $repo" 2>&1
     if ($LASTEXITCODE -ne 0) {
         error "'$repo' doesn't look like a valid git repository`n`nError given:`n$out"
         return 1
     }
     ensure $bucketsdir | Out-Null
     $dir = ensure $dir
-    git_cmd clone "$repo" "`"$dir`"" -q
+    Invoke-Git -ArgumentList "clone $repo `"$dir`" -q"
     Write-Host 'OK'
     success "The $name bucket was added successfully."
     return 0
@@ -169,7 +169,7 @@ function new_issue_msg($app, $bucket, $title, $body) {
     $bucket_path = "$bucketsdir\$bucket"
 
     if (Test-Path $bucket_path) {
-        $remote = git -C "$bucket_path" config --get remote.origin.url
+        $remote = Invoke-Git -Path $bucket_path -ArgumentList "config --get remote.origin.url"
         # Support ssh and http syntax
         # git@PROVIDER:USER/REPO.git
         # https://PROVIDER/USER/REPO.git

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -132,7 +132,7 @@ function Invoke-Git {
     [CmdletBinding()]
     [OutputType([String])]
     param(
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory = $false, Position = 0)]
         [Alias('PSPath', 'Path')]
         [ValidateNotNullOrEmpty()]
         [String]

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -182,6 +182,23 @@ function Invoke-Git {
     return Invoke-Command $sb
 }
 
+function Invoke-GitLog {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [String]$Path,
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [String]$CommitHash,
+        [String]$Name = ''
+    )
+    Process {
+        if($Name) {
+            $Name = "%Cgreen$($Name.PadRight(12, ' ').SubString(0, 12))%Creset "
+        }
+        Invoke-Git -Path $Path -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', '--abbrev=12', "--format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s $Name%C(cyan)%cr%Creset'", "$CommitHash..HEAD")
+    }
+}
+
 # helper functions
 function coalesce($a, $b) { if($a) { return $a } $b }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -133,7 +133,7 @@ function Invoke-Git {
     [OutputType([String])]
     param(
         [String] $Path,
-        [PSObject[]] $ArgumentList
+        [String[]] $ArgumentList
     )
 
     $proxy = get_config PROXY

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -192,8 +192,11 @@ function Invoke-GitLog {
         [String]$Name = ''
     )
     Process {
-        if($Name) {
-            $Name = "%Cgreen$($Name.PadRight(12, ' ').SubString(0, 12))%Creset "
+        if ($Name) {
+            if ($Name.Length -gt 12) {
+                $Name = "$($Name.Substring(0, 10)).."
+            }
+            $Name = "%Cgreen$($Name.PadRight(12, ' ').Substring(0, 12))%Creset "
         }
         Invoke-Git -Path $Path -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', '--abbrev=12', "--format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s $Name%C(cyan)%cr%Creset'", "$CommitHash..HEAD")
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -333,7 +333,14 @@ function Get-HelperPath {
     }
     process {
         switch ($Helper) {
-            'Git' { $HelperPath = "$(versiondir 'git' 'current')\mingw64\bin\git.exe" }
+            'Git' {
+                $internalgit = "$(versiondir 'git' 'current')\mingw64\bin\git.exe"
+                if (Test-Path $internalgit) {
+                    $HelperPath = $internalgit
+                } else {
+                    $HelperPath = (Get-Command git -ErrorAction Ignore).Source
+                }
+            }
             '7zip' {
                 $HelperPath = Get-AppFilePath '7zip' '7z.exe'
                 if ([String]::IsNullOrEmpty($HelperPath)) {

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -84,7 +84,7 @@ if ($manifest.depends) {
 
 if (Test-Path $manifest_file) {
     if (Get-Command git -ErrorAction Ignore) {
-        $gitinfo = (Invoke-Git -Path (Split-Path $manifest_file) -ArgumentList "log -1 -s --format='%aD#%an' $manifest_file" 2> $null) -Split '#'
+        $gitinfo = (Invoke-Git -Path (Split-Path $manifest_file) -ArgumentList @('log', '-1', '-s', "--format='%aD#%an'", $manifest_file) 2> $null) -Split '#'
     }
     if ($gitinfo) {
         $item.'Updated at' = $gitinfo[0] | Get-Date

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -84,7 +84,7 @@ if ($manifest.depends) {
 
 if (Test-Path $manifest_file) {
     if (Get-Command git -ErrorAction Ignore) {
-        $gitinfo = (git -C (Split-Path $manifest_file) log -1 -s --format='%aD#%an' $manifest_file 2> $null) -Split '#'
+        $gitinfo = (Invoke-Git -Path (Split-Path $manifest_file) -ArgumentList "log -1 -s --format='%aD#%an' $manifest_file" 2> $null) -Split '#'
     }
     if ($gitinfo) {
         $item.'Updated at' = $gitinfo[0] | Get-Date

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -21,10 +21,10 @@ if (!(Get-FormatData ScoopStatus)) {
 
 function Test-UpdateStatus($repopath) {
     if (Test-Path "$repopath\.git") {
-        Invoke-Git -Path $repopath -ArgumentList "fetch -q origin"
+        Invoke-Git -Path $repopath -ArgumentList @('fetch', '-q', 'origin')
         $script:network_failure = 128 -eq $LASTEXITCODE
-        $branch  = Invoke-Git -Path $repopath -ArgumentList "branch --show-current"
-        $commits = Invoke-Git -Path $repopath -ArgumentList "log 'HEAD..origin/$branch' --oneline"
+        $branch  = Invoke-Git -Path $repopath -ArgumentList @('branch', '--show-current')
+        $commits = Invoke-Git -Path $repopath -ArgumentList @('log', "HEAD..origin/$branch", '--oneline')
         if ($commits) { return $true }
         else { return $false }
     } else {

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -21,10 +21,10 @@ if (!(Get-FormatData ScoopStatus)) {
 
 function Test-UpdateStatus($repopath) {
     if (Test-Path "$repopath\.git") {
-        git_cmd -C "`"$repopath`"" fetch -q origin
+        Invoke-Git -Path $repopath -ArgumentList "fetch -q origin"
         $script:network_failure = 128 -eq $LASTEXITCODE
-        $branch  = git -C $repopath branch --show-current
-        $commits = git -C $repopath log "HEAD..origin/$branch" --oneline
+        $branch  = Invoke-Git -Path $repopath -ArgumentList "branch --show-current"
+        $commits = Invoke-Git -Path $repopath -ArgumentList "log 'HEAD..origin/$branch' --oneline"
         if ($commits) { return $true }
         else { return $false }
     } else {

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -136,7 +136,7 @@ function Sync-Scoop {
 
         $res = $lastexitcode
         if ($Log) {
-            Invoke-Git -Path $currentdir -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', "--format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset'", "$previousCommit..HEAD")
+            Invoke-Git -Path $currentdir -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', '--abbrev=12', "--format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset'", "$previousCommit..HEAD")
         }
 
         if ($res -ne 0) {
@@ -166,7 +166,7 @@ function Sync-Bucket {
         $previousCommit = Invoke-Git -Path $bucketLoc -ArgumentList @('rev-parse', 'HEAD')
         Invoke-Git -Path $bucketLoc @('pull', '-q')
         if ($Log) {
-            Invoke-Git -Path $bucketLoc -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', "--format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %Cgreen$Name%Creset %C(cyan)%cr%Creset'", "$previousCommit..HEAD")
+            Invoke-Git -Path $bucketLoc -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', '--abbrev=12', "--format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %Cgreen$Name%Creset %C(cyan)%cr%Creset'", "$previousCommit..HEAD")
         }
     }
 }
@@ -212,7 +212,7 @@ function Sync-Buckets {
             $previousCommit = Invoke-Git -Path $bucketLoc -ArgumentList @('rev-parse', 'HEAD')
             Invoke-Git -Path $bucketLoc -ArgumentList @('pull', '-q')
             if ($using:Log) {
-                Invoke-Git -Path $bucketLoc -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', "--format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %Cgreen$name%Creset %C(cyan)%cr%Creset'", "$previousCommit..HEAD")
+                Invoke-Git -Path $bucketLoc -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', '--abbrev=12', "--format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %Cgreen$name%Creset %C(cyan)%cr%Creset'", "$previousCommit..HEAD")
             }
         }
     } else {

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -147,7 +147,7 @@ function Sync-Scoop {
     shim "$currentdir\bin\scoop.ps1" $false
 }
 
-function Sync-Buckets {
+function Sync-Bucket {
     Param (
         [Switch]$Log
     )
@@ -342,7 +342,7 @@ if (-not ($apps -or $all)) {
         exit 1
     }
     Sync-Scoop -Log:$show_update_log
-    Sync-Buckets -Log:$show_update_log
+    Sync-Bucket -Log:$show_update_log
     set_config LAST_UPDATE ([System.DateTime]::Now.ToString('o')) | Out-Null
     success 'Scoop was updated successfully!'
 } else {
@@ -357,7 +357,7 @@ if (-not ($apps -or $all)) {
 
     if ($updateScoop) {
         Sync-Scoop -Log:$show_update_log
-        Sync-Buckets -Log:$show_update_log
+        Sync-Bucket -Log:$show_update_log
         set_config LAST_UPDATE ([System.DateTime]::Now.ToString('o')) | Out-Null
         success 'Scoop was updated successfully!'
     }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -168,7 +168,7 @@ function Sync-Bucket {
         $previousCommit = Invoke-Git -Path $bucketLoc -ArgumentList "rev-parse HEAD"
         Invoke-Git -Path $bucketLoc "pull -q"
         if ($Log) {
-            Invoke-Git -Path $bucketLoc -ArgumentList "--no-pager log --no-decorate --grep='^(chore)' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset [$Name]' '$previousCommit..HEAD'"
+            Invoke-Git -Path $bucketLoc -ArgumentList "--no-pager log --no-decorate --grep='^(chore)' --invert-grep --format='tformat: * %C(yellow)%h%Creset [$Name] %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
         }
     }
 }
@@ -214,7 +214,7 @@ function Sync-Buckets {
             $previousCommit = Invoke-Git -Path $bucketLoc -ArgumentList "rev-parse HEAD"
             Invoke-Git -Path $bucketLoc -ArgumentList "pull -q"
             if ($using:Log) {
-                Invoke-Git -Path $bucketLoc -ArgumentList "--no-pager log --no-decorate --grep='^(chore)' --invert-grep --format='tformat: * %C(yellow)%h [$name]%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
+                Invoke-Git -Path $bucketLoc -ArgumentList "--no-pager log --no-decorate --grep='^(chore)' --invert-grep --format='tformat: * %C(yellow)%h%Creset [$name] %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
             }
         }
     } else {

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -59,7 +59,7 @@ $show_update_log = get_config SHOW_UPDATE_LOG $true
 function Sync-Scoop {
     [CmdletBinding()]
     Param (
-        [Boolean]$OutputLog = $true
+        [Switch]$Log
     )
     # Test if Scoop Core is hold
     if(Test-ScoopCoreOnHold) {
@@ -135,7 +135,7 @@ function Sync-Scoop {
         }
 
         $res = $lastexitcode
-        if ($OutputLog) {
+        if ($Log) {
             Invoke-Git -Path $currentdir -ArgumentList "--no-pager log --no-decorate --grep='^(chore)' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
         }
 
@@ -151,8 +151,8 @@ function Sync-Bucket {
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory, ValueFromPipeline)]
-        [PSObject[]]$Name,
-        [Boolean]$OutputLog = $true
+        [String[]]$Name,
+        [Switch]$Log
     )
 
     Process {
@@ -167,7 +167,7 @@ function Sync-Bucket {
 
         $previousCommit = Invoke-Git -Path $bucketLoc -ArgumentList "rev-parse HEAD"
         Invoke-Git -Path $bucketLoc "pull -q"
-        if ($OutputLog) {
+        if ($Log) {
             Invoke-Git -Path $bucketLoc -ArgumentList "--no-pager log --no-decorate --grep='^(chore)' --invert-grep --format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset [$Name]' '$previousCommit..HEAD'"
         }
     }
@@ -175,7 +175,7 @@ function Sync-Bucket {
 
 function Sync-Buckets {
     Param (
-        [Boolean]$OutputLog = $true
+        [Switch]$Log
     )
     Write-Host "Updating Buckets..."
 
@@ -213,12 +213,12 @@ function Sync-Buckets {
 
             $previousCommit = Invoke-Git -Path $bucketLoc -ArgumentList "rev-parse HEAD"
             Invoke-Git -Path $bucketLoc -ArgumentList "pull -q"
-            if ($using:OutputLog) {
+            if ($using:Log) {
                 Invoke-Git -Path $bucketLoc -ArgumentList "--no-pager log --no-decorate --grep='^(chore)' --invert-grep --format='tformat: * %C(yellow)%h [$name]%Creset %<|(72,trunc)%s %C(cyan)%cr%Creset' '$previousCommit..HEAD'"
             }
         }
     } else {
-        $buckets | Where-Object { $_.valid } | ForEach-Object { Sync-Bucket $_.name -OutputLog $OutputLog }
+        $buckets | Where-Object { $_.valid } | ForEach-Object { Sync-Bucket $_.name -Log:$Log }
     }
 }
 
@@ -358,8 +358,8 @@ if (-not ($apps -or $all)) {
         error 'scoop update: --no-cache is invalid when <app> is not specified.'
         exit 1
     }
-    Sync-Scoop -OutputLog $show_update_log
-    Sync-Buckets -OutputLog $show_update_log
+    Sync-Scoop -Log:$show_update_log
+    Sync-Buckets -Log:$show_update_log
     set_config LAST_UPDATE ([System.DateTime]::Now.ToString('o')) | Out-Null
     success 'Scoop was updated successfully!'
 } else {
@@ -373,8 +373,8 @@ if (-not ($apps -or $all)) {
     $apps_param = $apps
 
     if ($updateScoop) {
-        Sync-Scoop -OutputLog $show_update_log
-        Sync-Buckets -OutputLog $show_update_log
+        Sync-Scoop -Log:$show_update_log
+        Sync-Buckets -Log:$show_update_log
         set_config LAST_UPDATE ([System.DateTime]::Now.ToString('o')) | Out-Null
         success 'Scoop was updated successfully!'
     }


### PR DESCRIPTION
#### Description

- By using the direct path to `$appdir\git\current\mingw64\bin\git.exe` this prevents spawning subprocesses and improves execution time
  - This removes calling two shims. `$scoopdir\shims\git.exe` calls `$appdir\git\current\bin\git.exe` which is also a shim.
- Fixes #1615 by replacing `currentuser@` with `:@`
- Spawns cmd.exe only if the `PROXY` config value is set and required by the git command
- Uses PS7 feature `Foreach-Object -Parallel` to run bucket updates in parallel to improve execution time
  - Not sure how to show the changelog right now, so I just added `[extras]` behind the commit hash
- Fallback to sequential updates for PS5
- Improve git log output


Using a fixed `git.exe` could be a problem if someone uses git not installed via scoop because this will not detect it with `Get-Command` anymore.

#### Motivation and Context
1. Improve updating with many buckets
2. Fixes #1615

#### How Has This Been Tested?
- Locally tested

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.


Before:
![image](https://user-images.githubusercontent.com/432127/186285428-a836f039-3eb3-4562-808f-f8f8c5e352d1.png)
![image](https://user-images.githubusercontent.com/432127/186285709-b2591dc9-cc18-428f-920e-b3b869113b7b.png)

After:
![image](https://user-images.githubusercontent.com/432127/186285407-f8979324-df4e-4500-9c4c-80955c4e2816.png)
![image](https://user-images.githubusercontent.com/432127/186285696-103aa607-6ffe-4bf8-8360-cf98e06ebbcc.png)

