### PR TITLE
refactor(iec): Rename 'Invoke-ExternalCommand()' to 'Start-ExternalProcess()' and support EnvVars/WorkingDirectory

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -27,7 +27,7 @@ function Expand-7zipArchive {
     } else {
         $7zPath = Get-HelperPath -Helper 7zip
     }
-    $LogPath = "$(Split-Path $Path)\7zip.log"
+    $LogName = "$(Split-Path $Path)\7zip.log"
     $DestinationPath = $DestinationPath.TrimEnd('\')
     $ArgList = @('x', $Path, "-o$DestinationPath", '-xr!*.nsis', '-y')
     $IsTar = ((strip_ext $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
@@ -42,22 +42,22 @@ function Expand-7zipArchive {
         'Skip' { $ArgList += '-aos' }
         'Rename' { $ArgList += '-aou' }
     }
-    $Status = Invoke-ExternalCommand $7zPath $ArgList -LogPath $LogPath
+    $Status = Start-ExternalProcess $7zPath $ArgList -LogName $LogName
     if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogName)`n$(new_issue_msg $app $bucket 'decompress error')"
     }
     if (!$IsTar -and $ExtractDir) {
         movedir "$DestinationPath\$ExtractDir" $DestinationPath | Out-Null
     }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
+    if (Test-Path $LogName) {
+        Remove-Item $LogName -Force
     }
     if ($IsTar) {
         # Check for tar
-        $Status = Invoke-ExternalCommand $7zPath @('l', $Path) -LogPath $LogPath
+        $Status = Start-ExternalProcess $7zPath @('l', $Path) -LogName $LogName
         if ($Status) {
             # get inner tar file name
-            $TarFile = (Select-String -Path $LogPath -Pattern '[^ ]*tar$').Matches.Value
+            $TarFile = (Select-String -Path $LogName -Pattern '[^ ]*tar$').Matches.Value
             Expand-7zipArchive -Path "$DestinationPath\$TarFile" -DestinationPath $DestinationPath -ExtractDir $ExtractDir -Removal
         } else {
             abort "Failed to list files in $Path.`nNot a 7-Zip supported archive file."
@@ -95,7 +95,7 @@ function Expand-ZstdArchive {
         $Removal
     )
     $ZstdPath = Get-HelperPath -Helper Zstd
-    $LogPath = Join-Path (Split-Path $Path) 'zstd.log'
+    $LogName = Join-Path (Split-Path $Path) 'zstd.log'
     $DestinationPath = $DestinationPath.TrimEnd('\')
     ensure $DestinationPath | Out-Null
     $ArgList = @('-d', $Path, '--output-dir-flat', $DestinationPath, '-f', '-v')
@@ -107,16 +107,16 @@ function Expand-ZstdArchive {
         # Remove original archive file
         $ArgList += '--rm'
     }
-    $Status = Invoke-ExternalCommand $ZstdPath $ArgList -LogPath $LogPath
+    $Status = Start-ExternalProcess $ZstdPath $ArgList -LogName $LogName
     if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogName)`n$(new_issue_msg $app $bucket 'decompress error')"
     }
     $IsTar = (strip_ext $Path) -match '\.tar$'
     if (!$IsTar -and $ExtractDir) {
         movedir (Join-Path $DestinationPath $ExtractDir) $DestinationPath | Out-Null
     }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
+    if (Test-Path $LogName) {
+        Remove-Item $LogName -Force
     }
     if ($IsTar) {
         # Check for tar
@@ -154,13 +154,13 @@ function Expand-MsiArchive {
         $MsiPath = 'msiexec.exe'
         $ArgList = @('/a', "`"$Path`"", '/qn', "TARGETDIR=`"$DestinationPath\SourceDir`"")
     }
-    $LogPath = "$(Split-Path $Path)\msi.log"
+    $LogName = "$(Split-Path $Path)\msi.log"
     if ($Switches) {
         $ArgList += (-split $Switches)
     }
-    $Status = Invoke-ExternalCommand $MsiPath $ArgList -LogPath $LogPath
+    $Status = Start-ExternalProcess $MsiPath $ArgList -LogName $LogName
     if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogName)`n$(new_issue_msg $app $bucket 'decompress error')"
     }
     if ($ExtractDir -and (Test-Path "$DestinationPath\SourceDir")) {
         movedir "$DestinationPath\SourceDir\$ExtractDir" $OriDestinationPath | Out-Null
@@ -174,8 +174,8 @@ function Expand-MsiArchive {
     if (($DestinationPath -ne (Split-Path $Path)) -and (Test-Path "$DestinationPath\$(fname $Path)")) {
         Remove-Item "$DestinationPath\$(fname $Path)" -Force
     }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
+    if (Test-Path $LogName) {
+        Remove-Item $LogName -Force
     }
     if ($Removal) {
         # Remove original archive file
@@ -200,7 +200,7 @@ function Expand-InnoArchive {
         [Switch]
         $Removal
     )
-    $LogPath = "$(Split-Path $Path)\innounp.log"
+    $LogName = "$(Split-Path $Path)\innounp.log"
     $ArgList = @('-x', "-d$DestinationPath", $Path, '-y')
     switch -Regex ($ExtractDir) {
         '^[^{].*' { $ArgList += "-c{app}\$ExtractDir" }
@@ -210,12 +210,12 @@ function Expand-InnoArchive {
     if ($Switches) {
         $ArgList += (-split $Switches)
     }
-    $Status = Invoke-ExternalCommand (Get-HelperPath -Helper Innounp) $ArgList -LogPath $LogPath
+    $Status = Start-ExternalProcess (Get-HelperPath -Helper Innounp) $ArgList -LogName $LogName
     if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogName)`n$(new_issue_msg $app $bucket 'decompress error')"
     }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
+    if (Test-Path $LogName) {
+        Remove-Item $LogName -Force
     }
     if ($Removal) {
         # Remove original archive file
@@ -274,17 +274,17 @@ function Expand-DarkArchive {
         [Switch]
         $Removal
     )
-    $LogPath = "$(Split-Path $Path)\dark.log"
+    $LogName = "$(Split-Path $Path)\dark.log"
     $ArgList = @('-nologo', '-x', $DestinationPath, $Path)
     if ($Switches) {
         $ArgList += (-split $Switches)
     }
-    $Status = Invoke-ExternalCommand (Get-HelperPath -Helper Dark) $ArgList -LogPath $LogPath
+    $Status = Start-ExternalProcess (Get-HelperPath -Helper Dark) $ArgList -LogName $LogName
     if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogName)`n$(new_issue_msg $app $bucket 'decompress error')"
     }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
+    if (Test-Path $LogName) {
+        Remove-Item $LogName -Force
     }
     if ($Removal) {
         # Remove original archive file

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -734,7 +734,7 @@ function install_msi($fname, $dir, $msi) {
 
     $continue_exit_codes = @{ 3010 = "a restart is required to complete installation" }
 
-    $installed = Invoke-ExternalCommand 'msiexec' $arg -Activity "Running installer..." -ContinueExitCodes $continue_exit_codes
+    $installed = Start-ExternalProcess 'msiexec' $arg -Prompt 'Running installer...' -ContinueExitCodes $continue_exit_codes
     if(!$installed) {
         abort "Installation aborted. You might need to run 'scoop uninstall $app' before trying again."
     }
@@ -766,7 +766,7 @@ function install_prog($fname, $dir, $installer, $global) {
     if($prog.endswith('.ps1')) {
         & $prog @arg
     } else {
-        $installed = Invoke-ExternalCommand $prog $arg -Activity "Running installer..."
+        $installed = Start-ExternalProcess $prog $arg -Prompt 'Running installer...'
         if(!$installed) {
             abort "Installation aborted. You might need to run 'scoop uninstall $app' before trying again."
         }
@@ -819,7 +819,7 @@ function run_uninstaller($manifest, $architecture, $dir) {
             if($exe.endswith('.ps1')) {
                 & $exe @arg
             } else {
-                $uninstalled = Invoke-ExternalCommand $exe $arg -Activity "Running uninstaller..." -ContinueExitCodes $continue_exit_codes
+                $uninstalled = Start-ExternalProcess $exe $arg -Prompt 'Running uninstaller...' -ContinueExitCodes $continue_exit_codes
                 if(!$uninstalled) { abort "Uninstallation aborted." }
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

- Rename `Invoke-ExternalCommand()` to `Start-ExternalProcess()`
- Add environment variables and working directory suport

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Rename `Activity` to `Prompt`
- Rename `LogPath` to `LogName`
- Always redirect standard output and error, otherwise the function will not print its output to screen even if `LogName` is not set (related to #5066)
- Allow environment variables be set (related to #5122)
- Allow working directory be set (related to #5122)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

![image](https://user-images.githubusercontent.com/5832170/186659131-1a65efc7-efc4-4a5d-bfd4-9652b5e63233.png)

With proxy server on and off.

For the strange `git ls-remotes` output: `git` print `From https://github.com/ScoopInstaller/Tests` via the error output 🤣 

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
