### PR TITLE
fix(jsonpath): Prevent converting date string to DateTime in JSONPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - **config:** Change config option to snake_case in file and SCREAMING_CASE in code ([#5116](https://github.com/ScoopInstaller/Scoop/issues/5116))
+- **jsonpath:** Prevent converting date string to DateTime in JSONPath ([#5130](https://github.com/ScoopInstaller/Scoop/issues/5130))
 - **psmodule:** Remove folder recursively when unlinking previous module path ([#5127](https://github.com/ScoopInstaller/Scoop/issues/5127))
 
 ### Code Refactoring

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -98,7 +98,9 @@ function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitution
         $jsonpath = substitute $jsonpath $substitutions ($jsonpath -like "*=~*")
     }
     try {
-        $obj = [Newtonsoft.Json.Linq.JValue]::Parse($json)
+		$settings = New-Object -Type Newtonsoft.Json.JsonSerializerSettings
+		$settings.DateParseHandling = [Newtonsoft.Json.DateParseHandling]::None
+        $obj = [Newtonsoft.Json.JsonConvert]::DeserializeObject($json, $settings)
     } catch [Newtonsoft.Json.JsonReaderException] {
         return $null
     }

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -98,8 +98,8 @@ function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitution
         $jsonpath = substitute $jsonpath $substitutions ($jsonpath -like "*=~*")
     }
     try {
-		$settings = New-Object -Type Newtonsoft.Json.JsonSerializerSettings
-		$settings.DateParseHandling = [Newtonsoft.Json.DateParseHandling]::None
+        $settings = New-Object -Type Newtonsoft.Json.JsonSerializerSettings
+        $settings.DateParseHandling = [Newtonsoft.Json.DateParseHandling]::None
         $obj = [Newtonsoft.Json.JsonConvert]::DeserializeObject($json, $settings)
     } catch [Newtonsoft.Json.JsonReaderException] {
         return $null


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
If you extract the date and time string with `checkver/jsonpath` in the manifest file, it will be converted to `M/d/yyyy h:m:s tt` format instead of the original string. This is due to Json.net converting to DateTime type, so it suppresses the conversion.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #5129 
<!-- or -->


#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. `scoop bucket add version`
2. modify `goneovim-nightly.json` with https://github.com/ScoopInstaller/Versions/pull/618
3. modify `lib/json.ps1` with this PR
4. `checkver.ps1 goneovim-nightly ~/scoop/bucket/versions/bucket -f`
5. update successful

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
