### PR TITLE
autodetect shim path

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -833,14 +833,13 @@ function shim($path, $global, $name, $arg) {
 
 function get_shim_path() {
     $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\kiennq\shim.exe"
-    $shim_version = get_config SHIM 'default'
+    $shim_version = get_config 'shim' 'kiennq'
     switch ($shim_version) {
-        '71' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\71\shim.exe"; Break }
         'scoopcs' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shimexe\bin\shim.exe"; Break }
-        'kiennq' { Break } # for backward compatibility
         'default' { Break }
-        default { warn "Unknown shim version: '$shim_version'" }
+        default { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\$shim_version\shim.exe"; Break }
     }
+    if(!(Test-Path $shim_path)) { warn "Unknown shim version: '$shim_version'" }
     return $shim_path
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
autodetect shim path

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
change function `get_shim_path()` in core.ps1

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
```
scoop config shim testbad
scoop rest * # should output the warning

scoop config shim 71
scoop rest * # should use '71' version

scoop config shim kiennq
scoop rest * # should use 'kiennq' version

scoop config shim default
scoop rest * # should use 'kiennq' version

scoop config rm shim
scoop rest * # should use 'kiennq' version
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
