### PR TITLE
refactor(download): Rename `dl()` to `Invoke-Download()`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
     "powershell.codeFormatting.preset": "OTBS",
     "powershell.codeFormatting.alignPropertyValuePairs": true,
     "powershell.codeFormatting.ignoreOneLineBlock": true,
+    "powershell.codeFormatting.useConstantStrings": true,
+    "powershell.codeFormatting.useCorrectCasing": true,
     "files.exclude": {
         "**/.git": true,
         "**/.svn": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Code Refactoring
 
-- **download:** Rename `dl()` to `Invoke-WebDownload()` ([[#5143](https://github.com/ScoopInstaller/Scoop/issues/5143)])
+- **download:** Rename `dl()` to `Invoke-Download()` ([[#5143](https://github.com/ScoopInstaller/Scoop/issues/5143)])
 - **path:** Use 'Convert-Path()' instead of 'Resolve-Path()' ([#5109](https://github.com/ScoopInstaller/Scoop/issues/5109))
 - **scoop-shim:** Use `getopt` to parse arguments ([#5125](https://github.com/ScoopInstaller/Scoop/issues/5125))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- **core:** Use better names for download functions ([[#3830](https://github.com/ScoopInstaller/Scoop/issues/3830)])
+
 ## [v0.2.4](https://github.com/ScoopInstaller/Scoop/compare/v0.2.3...v0.2.4) - 2022-08-08
 
 ### Features

--- a/bin/checkhashes.ps1
+++ b/bin/checkhashes.ps1
@@ -113,7 +113,7 @@ foreach ($current in $MANIFESTS) {
         $version = 'HASH_CHECK'
         $tmp = $expected_hash -split ':'
 
-        dl_with_cache $current.app $version $_ $null $null -use_cache:$UseCache
+        Invoke-CachedDownload $current.app $version $_ $null $null -use_cache:$UseCache
 
         $to_check = fullpath (cache_path $current.app $version $_)
         $actual_hash = compute_hash $to_check $algorithm

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -41,10 +41,10 @@ if (Get-Command -Name 'scoop' -ErrorAction SilentlyContinue) {
 $dir = ensure (versiondir 'scoop' 'current')
 
 # download scoop zip
-$zipurl = 'https://github.com/ScoopInstaller/Scoop/archive/master.zip'
-$zipfile = "$dir\scoop.zip"
+$zipUrl = "https://github.com/ScoopInstaller/Scoop/archive/master.zip"
+$zipFile = "$dir\scoop.zip"
 Write-Output 'Downloading scoop...'
-dl $zipurl $zipfile
+Invoke-WebDownload -Uri $zipUrl -OutFile $zipFile
 
 Write-Output 'Extracting...'
 Add-Type -Assembly "System.IO.Compression.FileSystem"
@@ -57,11 +57,11 @@ shim "$dir\bin\scoop.ps1" $false
 
 # download main bucket
 $dir = "$scoopdir\buckets\main"
-$zipurl = 'https://github.com/ScoopInstaller/Main/archive/master.zip'
-$zipfile = "$dir\main-bucket.zip"
-Write-Output 'Downloading main bucket...'
-New-Item $dir -Type Directory -Force | Out-Null
-dl $zipurl $zipfile
+$zipUrl = "https://github.com/ScoopInstaller/Main/archive/master.zip"
+$zipFile = "$dir\main-bucket.zip"
+Write-Output "Downloading main bucket..."
+New-Item -Path $dir -Type Directory -Force | Out-Null
+Invoke-WebDownload -Uri $zipUrl -OutFile $zipFile
 
 Write-Output 'Extracting...'
 [IO.Compression.ZipFile]::ExtractToDirectory($zipfile, "$dir\_tmp")

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -41,7 +41,7 @@ if (Get-Command -Name 'scoop' -ErrorAction SilentlyContinue) {
 $dir = ensure (versiondir 'scoop' 'current')
 
 # download scoop zip
-$zipUrl = "https://github.com/ScoopInstaller/Scoop/archive/master.zip"
+$zipUrl = 'https://github.com/ScoopInstaller/Scoop/archive/master.zip'
 $zipFile = "$dir\scoop.zip"
 Write-Output 'Downloading scoop...'
 Invoke-WebRequest -Uri $zipUrl -OutFile $zipFile
@@ -57,9 +57,9 @@ shim "$dir\bin\scoop.ps1" $false
 
 # download main bucket
 $dir = "$scoopdir\buckets\main"
-$zipUrl = "https://github.com/ScoopInstaller/Main/archive/master.zip"
+$zipUrl = 'https://github.com/ScoopInstaller/Main/archive/master.zip'
 $zipFile = "$dir\main-bucket.zip"
-Write-Output "Downloading main bucket..."
+Write-Output 'Downloading main bucket...'
 New-Item -Path $dir -Type Directory -Force | Out-Null
 Invoke-WebRequest -Uri $zipUrl -OutFile $zipFile
 

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -44,7 +44,7 @@ $dir = ensure (versiondir 'scoop' 'current')
 $zipUrl = "https://github.com/ScoopInstaller/Scoop/archive/master.zip"
 $zipFile = "$dir\scoop.zip"
 Write-Output 'Downloading scoop...'
-Invoke-WebDownload -Uri $zipUrl -OutFile $zipFile
+Invoke-WebRequest -Uri $zipUrl -OutFile $zipFile
 
 Write-Output 'Extracting...'
 Add-Type -Assembly "System.IO.Compression.FileSystem"
@@ -61,7 +61,7 @@ $zipUrl = "https://github.com/ScoopInstaller/Main/archive/master.zip"
 $zipFile = "$dir\main-bucket.zip"
 Write-Output "Downloading main bucket..."
 New-Item -Path $dir -Type Directory -Force | Out-Null
-Invoke-WebDownload -Uri $zipUrl -OutFile $zipFile
+Invoke-WebRequest -Uri $zipUrl -OutFile $zipFile
 
 Write-Output 'Extracting...'
 [IO.Compression.ZipFile]::ExtractToDirectory($zipfile, "$dir\_tmp")

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -267,7 +267,7 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
     write-host -f Green $basename -NoNewline
     write-host -f DarkYellow ' to compute hashes!'
     try {
-        dl_with_cache $app $version $url $null $null $true
+        Invoke-CachedDownload $app $version $url $null $null $true
     } catch [system.net.webexception] {
         write-host -f darkred $_
         write-host -f darkred "URL $url is not valid"

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -585,11 +585,22 @@ function Invoke-ExternalCommand {
     return $true
 }
 
-function dl($url,$to) {
-    $wc = New-Object Net.Webclient
-    $wc.headers.add('Referer', (strip_filename $url))
-    $wc.Headers.Add('User-Agent', (Get-UserAgent))
-    $wc.downloadFile($url,$to)
+function Invoke-WebDownload {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [Uri]
+        $Uri,
+
+        [Parameter(Mandatory)]
+        [string]
+        $OutFile
+    )
+
+    Invoke-WebRequest -UseBasicParsing -Uri $Uri -OutFile $OutFile -Headers @{
+        Referer      = (strip_filename $Uri);
+        "User-Agent" = Get-UserAgent
+    }
 }
 
 function env($name,$global,$val='__get') {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -588,24 +588,6 @@ function Invoke-ExternalCommand {
     return $true
 }
 
-function Invoke-WebDownload {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [Uri]
-        $Uri,
-
-        [Parameter(Mandatory)]
-        [string]
-        $OutFile
-    )
-
-    Invoke-WebRequest -UseBasicParsing -Uri $Uri -OutFile $OutFile -Headers @{
-        Referer      = (strip_filename $Uri);
-        "User-Agent" = Get-UserAgent
-    }
-}
-
 function env($name,$global,$val='__get') {
     $target = 'User'; if($global) {$target = 'Machine'}
     if($val -eq '__get') { [environment]::getEnvironmentVariable($name,$target) }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -49,7 +49,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     $original_dir = $dir # keep reference to real (not linked) directory
     $persist_dir = persistdir $app $global
 
-    $fname = Import-Url $app $version $manifest $bucket $architecture $dir $use_cache $check_hash
+    $fname = Invoke-ScoopDownload $app $version $manifest $bucket $architecture $dir $use_cache $check_hash
     Invoke-HookScript -HookType 'pre_install' -Manifest $manifest -Arch $architecture
 
     run_installer $fname $manifest $architecture $dir $global
@@ -524,7 +524,7 @@ function Write-DownloadProgress ($read, $total, $url) {
     [console]::SetCursorPosition($left, $top)
 }
 
-function Import-Url ($app, $version, $manifest, $bucket, $architecture, $dir, $use_cache = $true, $check_hash = $true) {
+function Invoke-ScoopDownload ($app, $version, $manifest, $bucket, $architecture, $dir, $use_cache = $true, $check_hash = $true) {
     # we only want to show this warning once
     if(!$use_cache) { warn "Cache is being ignored." }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -85,7 +85,7 @@ function Invoke-CachedDownload ($app, $version, $url, $to, $cookies = $null, $us
 
     if(!(test-path $cached) -or !$use_cache) {
         ensure $cachedir | Out-Null
-        Start-WebDownload $url "$cached.download" $cookies
+        Start-Download $url "$cached.download" $cookies
         Move-Item "$cached.download" $cached -force
     } else { write-host "Loading $(url_remote_filename $url) from cache"}
 
@@ -98,13 +98,13 @@ function Invoke-CachedDownload ($app, $version, $url, $to, $cookies = $null, $us
     }
 }
 
-function Start-WebDownload ($url, $to, $cookies) {
+function Start-Download ($url, $to, $cookies) {
     $progress = [console]::isoutputredirected -eq $false -and
         $host.name -ne 'Windows PowerShell ISE Host'
 
     try {
         $url = handle_special_urls $url
-        Invoke-WebDownload $url $to $cookies $progress
+        Invoke-Download $url $to $cookies $progress
     } catch {
         $e = $_.exception
         if($e.innerexception) { $e = $e.innerexception }
@@ -355,7 +355,7 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
 }
 
 # download with filesize and progress indicator
-function Invoke-WebDownload ($url, $to, $cookies, $progress) {
+function Invoke-Download ($url, $to, $cookies, $progress) {
     $reqUrl = ($url -split '#')[0]
     $wreq = [Net.WebRequest]::Create($reqUrl)
     if ($wreq -is [Net.HttpWebRequest]) {
@@ -409,7 +409,7 @@ function Invoke-WebDownload ($url, $to, $cookies, $progress) {
             $newUrl = "$newUrl#/$postfix"
         }
 
-        Invoke-WebDownload $newUrl $to $cookies $progress
+        Invoke-Download $newUrl $to $cookies $progress
         return
     }
 

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -95,11 +95,11 @@ foreach ($curr_app in $apps) {
     }
 
     if(Test-Aria2Enabled) {
-        dl_with_cache_aria2 $app $version $manifest $architecture $cachedir $manifest.cookie $use_cache $curr_check_hash
+        Invoke-CachedAria2Download $app $version $manifest $architecture $cachedir $manifest.cookie $use_cache $curr_check_hash
     } else {
         foreach($url in script:url $manifest $architecture) {
             try {
-                dl_with_cache $app $version $url $null $manifest.cookie $use_cache
+                Invoke-CachedDownload $app $version $url $null $manifest.cookie $use_cache
             } catch {
                 write-host -f darkred $_
                 error "URL $url is not valid"

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -210,12 +210,12 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     # Remove and replace whole region after proper fix
     Write-Host "Downloading new version"
     if (Test-Aria2Enabled) {
-        dl_with_cache_aria2 $app $version $manifest $architecture $cachedir $manifest.cookie $true $check_hash
+        Invoke-CachedAria2Download $app $version $manifest $architecture $cachedir $manifest.cookie $true $check_hash
     } else {
         $urls = script:url $manifest $architecture
 
         foreach ($url in $urls) {
-            dl_with_cache $app $version $url $null $manifest.cookie $true
+            Invoke-CachedDownload $app $version $url $null $manifest.cookie $true
 
             if ($check_hash) {
                 $manifest_hash = hash_for_url $manifest $url $architecture


### PR DESCRIPTION
#### Description

This PR renames the `dl` and related functions to use more descriptive names that better adhere to PowerShell conventions.

#### Motivation and Context

Resolves #3830

#### How Has This Been Tested?

Test suite run on local machine and in [CI](https://github.com/examosa/Scoop/actions/runs/3040324142/jobs/4896244634); all remain passing.

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
