### PR TITLE
refactor(hash): Use 'Get-FileHash()' directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+
+### Code Refactoring
+
+- **hash:** Use `Get-FileHash()` directly ([#5177](https://github.com/ScoopInstaller/Scoop/issues/5177))
+
 ## [v0.3.0](https://github.com/ScoopInstaller/Scoop/compare/v0.2.4...v0.3.0) - 2022-10-10
 
 ### Features

--- a/bin/checkhashes.ps1
+++ b/bin/checkhashes.ps1
@@ -120,7 +120,7 @@ foreach ($current in $MANIFESTS) {
         Invoke-CachedDownload $current.app $version $_ $null $null -use_cache:$UseCache
 
         $to_check = fullpath (cache_path $current.app $version $_)
-        $actual_hash = compute_hash $to_check $algorithm
+        $actual_hash = (Get-FileHash -Path $to_check -Algorithm $algorithm).Hash.ToLower()
 
         # Append type of algorithm to both expected and actual if it's not sha256
         if ($algorithm -ne 'sha256') {

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -274,7 +274,7 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
         return $null
     }
     $file = fullpath (cache_path $app $version $url)
-    $hash = compute_hash $file 'sha256'
+    $hash = (Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower()
     write-host -f DarkYellow 'Computed hash: ' -NoNewline
     write-host -f Green $hash
     return $hash

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -660,7 +660,7 @@ function hash_for_url($manifest, $url, $arch) {
 function check_hash($file, $hash, $app_name) {
     $file = fullpath $file
     if(!$hash) {
-        warn "Warning: No hash in manifest. SHA256 for '$(fname $file)' is:`n    $(compute_hash $file 'sha256')"
+        warn "Warning: No hash in manifest. SHA256 for '$(fname $file)' is:`n    $((Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower())"
         return $true, $null
     }
 
@@ -672,7 +672,7 @@ function check_hash($file, $hash, $app_name) {
         return $false, "Hash type '$algorithm' isn't supported."
     }
 
-    $actual = compute_hash $file $algorithm
+    $actual = (Get-FileHash -Path $file -Algorithm $algorithm).Hash.ToLower()
     $expected = $expected.ToLower()
 
     if($actual -ne $expected) {
@@ -690,25 +690,6 @@ function check_hash($file, $hash, $app_name) {
     }
     Write-Host "ok." -f Green
     return $true, $null
-}
-
-function compute_hash($file, $algname) {
-    try {
-        if(Test-CommandAvailable Get-FileHash) {
-            return (Get-FileHash -Path $file -Algorithm $algname).Hash.ToLower()
-        } else {
-            $fs = [system.io.file]::openread($file)
-            $alg = [system.security.cryptography.hashalgorithm]::create($algname)
-            $hexbytes = $alg.computehash($fs) | ForEach-Object { $_.tostring('x2') }
-            return [string]::join('', $hexbytes)
-        }
-    } catch {
-        error $_.exception.message
-    } finally {
-        if($fs) { $fs.dispose() }
-        if($alg) { $alg.dispose() }
-    }
-    return ''
 }
 
 # for dealing with installers

--- a/lib/unix.ps1
+++ b/lib/unix.ps1
@@ -19,27 +19,3 @@ function ensure($dir) {
     mkdir -p $dir > $null
     return Convert-Path $dir
 }
-
-# install.ps1
-function compute_hash($file, $algname) {
-    if(is_mac) {
-        switch ($algname)
-        {
-            "md5" { $result = (md5 -q $file) }
-            "sha1" { $result = (shasum -ba 1 $file) }
-            "sha256" { $result = (shasum -ba 256 $file) }
-            "sha512" { $result = (shasum -ba 512 $file) }
-            default { $result = (shasum -ba 256 $file) }
-        }
-    } else {
-        switch ($algname)
-        {
-            "md5" { $result = (md5sum -b $file) }
-            "sha1" { $result = (sha1sum -b $file) }
-            "sha256" { $result = (sha256sum -b $file) }
-            "sha512" { $result = (sha512sum -b $file) }
-            default { $result = (sha256sum -b $file) }
-        }
-    }
-    return $result.split(' ') | Select-Object -first 1
-}

--- a/supporting/shimexe/build.ps1
+++ b/supporting/shimexe/build.ps1
@@ -16,7 +16,7 @@ Write-Output 'Computing checksums ...'
 Remove-Item "$PSScriptRoot\bin\checksum.sha256" -ErrorAction Ignore
 Remove-Item "$PSScriptRoot\bin\checksum.sha512" -ErrorAction Ignore
 Get-ChildItem "$PSScriptRoot\bin\*" -Include *.exe, *.dll | ForEach-Object {
-    "$(compute_hash $_ 'sha256') *$($_.Name)" | Out-File "$PSScriptRoot\bin\checksum.sha256" -Append -Encoding oem
-    "$(compute_hash $_ 'sha512') *$($_.Name)" | Out-File "$PSScriptRoot\bin\checksum.sha512" -Append -Encoding oem
+    "$((Get-FileHash -Path $_ -Algorithm SHA256).Hash.ToLower()) *$($_.Name)" | Out-File "$PSScriptRoot\bin\checksum.sha256" -Append -Encoding oem
+    "$((Get-FileHash -Path $_ -Algorithm SHA512).Hash.ToLower()) *$($_.Name)" | Out-File "$PSScriptRoot\bin\checksum.sha512" -Append -Encoding oem
 }
 Pop-Location

--- a/supporting/validator/build.ps1
+++ b/supporting/validator/build.ps1
@@ -21,7 +21,7 @@ Write-Output 'Computing checksums ...'
 Remove-Item "$PSScriptRoot\bin\checksum.sha256" -ErrorAction Ignore
 Remove-Item "$PSScriptRoot\bin\checksum.sha512" -ErrorAction Ignore
 Get-ChildItem "$PSScriptRoot\bin\*" -Include *.exe, *.dll | ForEach-Object {
-    "$(compute_hash $_ 'sha256') *$($_.Name)" | Out-File "$PSScriptRoot\bin\checksum.sha256" -Append -Encoding oem
-    "$(compute_hash $_ 'sha512') *$($_.Name)" | Out-File "$PSScriptRoot\bin\checksum.sha512" -Append -Encoding oem
+    "$((Get-FileHash -Path $_ -Algorithm SHA256).Hash.ToLower()) *$($_.Name)" | Out-File "$PSScriptRoot\bin\checksum.sha256" -Append -Encoding oem
+    "$((Get-FileHash -Path $_ -Algorithm SHA512).Hash.ToLower()) *$($_.Name)" | Out-File "$PSScriptRoot\bin\checksum.sha512" -Append -Encoding oem
 }
 Pop-Location

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
         It 'Decompression test cases should exist' {
             $testcases = "$working_dir\TestCases.zip"
             $testcases | Should -Exist
-            compute_hash $testcases 'sha256' | Should -Be '791bfce192917a2ff225dcdd87d23ae5f720b20178d85e68e4b1b56139cf8e6a'
+            (Get-FileHash -Path $testcases -Algorithm SHA256).Hash.ToLower() | Should -Be '791bfce192917a2ff225dcdd87d23ae5f720b20178d85e68e4b1b56139cf8e6a'
             if (!$isUnix) {
                 Microsoft.PowerShell.Archive\Expand-Archive $testcases $working_dir
             }

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -121,37 +121,3 @@ Describe 'persist_def' -Tag 'Scoop' {
         $target | Should -Be 'foo'
     }
 }
-
-Describe 'compute_hash' -Tag 'Scoop' {
-    BeforeAll {
-        $working_dir = setup_working 'manifest'
-    }
-
-    It 'computes MD5 correctly' {
-        compute_hash (Join-Path "$working_dir" 'invalid_wget.json') 'md5' | Should -Be 'cf229eecc201063e32b436e73b71deba'
-        compute_hash (Join-Path "$working_dir" 'wget.json') 'md5' | Should -Be '57c397fd5092cbd6a8b4df56be2551ab'
-        compute_hash (Join-Path "$working_dir" 'broken_schema.json') 'md5' | Should -Be '0427c7f4edc33d6d336db98fc160beb0'
-        compute_hash (Join-Path "$working_dir" 'broken_wget.json') 'md5' | Should -Be '30a7d4d3f64cb7a800d96c0f2ccec87f'
-    }
-
-    It 'computes SHA-1 correctly' {
-        compute_hash (Join-Path "$working_dir" 'invalid_wget.json') 'sha1' | Should -Be '33ae44df8feed86cdc8f544234029fb28280c3c5'
-        compute_hash (Join-Path "$working_dir" 'wget.json') 'sha1' | Should -Be '98bfacb887da8cd05d3a1162f89d90173294be55'
-        compute_hash (Join-Path "$working_dir" 'broken_schema.json') 'sha1' | Should -Be '6dcd64f8ce7a3ae6bbc3dc2288b7cb202dbfa3c8'
-        compute_hash (Join-Path "$working_dir" 'broken_wget.json') 'sha1' | Should -Be '60b5b1d5bcb4193d19aeab265eab0bb9b0c46c8f'
-    }
-
-    It 'computes SHA-256 correctly' {
-        compute_hash (Join-Path "$working_dir" 'invalid_wget.json') 'sha256' | Should -Be '1a92ef57c5f3cecba74015ae8e92fc3f2dbe141f9d171c3a06f98645a522d58c'
-        compute_hash (Join-Path "$working_dir" 'wget.json') 'sha256' | Should -Be '31d6d0953d4e95f0a42080acd61a8c2f92bc90cae324c0d6d2301a974c15f62f'
-        compute_hash (Join-Path "$working_dir" 'broken_schema.json') 'sha256' | Should -Be 'f3e5082e366006c317d9426e590623254cb1ce23d4f70165afed340b03ce333b'
-        compute_hash (Join-Path "$working_dir" 'broken_wget.json') 'sha256' | Should -Be 'da658987c3902658c6e754bfa6546dfd084aaa2c3ae25f1fd8aa4645bc9cae24'
-    }
-
-    It 'computes SHA-512 correctly' {
-        compute_hash (Join-Path "$working_dir" 'invalid_wget.json') 'sha512' | Should -Be '7a7b82ec17547f5ec13dc614a8cec919e897e6c344a6ce7d71205d6f1c3aed276c7b15cbc69acac8207f72417993299cef36884e1915d56758ea09efa2259870'
-        compute_hash (Join-Path "$working_dir" 'wget.json') 'sha512' | Should -Be '216ebf07bb77062b51420f0f5eb6b7a94d9623d1d41d36c833436058f41e39898f2aa48d7020711c0d8765d02b87ac2e6810f3f502636a6e6f47dc4b9aa02d17'
-        compute_hash (Join-Path "$working_dir" 'broken_schema.json') 'sha512' | Should -Be '8d3f5617517e61c33275eafea4b166f0a245ec229c40dea436173c354786bad72e4fd9d662f6ac2b9f3dd375c00815a07f10e12975eec1b12da7ba7db10f9c14'
-        compute_hash (Join-Path "$working_dir" 'broken_wget.json') 'sha512' | Should -Be '7b16a714491e91cc6daa5f90e700547fac4d62e1fcec8c4b78f5a2386e04e68a8ed68f27503ece9555904a047df8050b3f12b4f779c05b1e4d0156e6e2d8fdbb'
-    }
-}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

PowerShell 5 and later have `Get-FileHash()` and we could use it directly.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Simplify code base.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`scoop install` and `checkver`

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
