### PR TITLE
builds(pssa): Remove unused 'ExcludeRules'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - **auto-pr:** Add `CommitMessageFormat` option ([#5171](https://github.com/ScoopInstaller/Scoop/issues/5171))
 - **checkver:** Support XML default namespace ([#5191](https://github.com/ScoopInstaller/Scoop/issues/5191))
+- **pssa:** Remove unused 'ExcludeRules' ([#5201](https://github.com/ScoopInstaller/Scoop/issues/5201))
 
 ### Tests
 

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -26,12 +26,6 @@
     # will be excluded.
     ExcludeRules = @(
         # Currently Scoop widely uses Write-Host to output colored text.
-        'PSAvoidUsingWriteHost',
-        # Temporarily allow uses of Invoke-Expression,
-        # this command is used by some core functions and hard to be removed.
-        'PSAvoidUsingInvokeExpression',
-        # PSUseDeclaredVarsMoreThanAssignments doesn't currently work due to:
-        # https://github.com/PowerShell/PSScriptAnalyzer/issues/636
-        'PSUseDeclaredVarsMoreThanAssignments'
+        'PSAvoidUsingWriteHost'
     )
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

`Invoke-Expression()` has been remove in #4941, and `PSUseDeclaredVarsMoreThanAssignments` seems to work fine now.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Just clean up codes.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

PS7:

![image](https://user-images.githubusercontent.com/5832170/196174346-1bebba77-7a9b-4f7e-b1f6-775d43a09ef0.png)

PS5:

![image](https://user-images.githubusercontent.com/5832170/196174384-db002815-50b5-4d4e-afc1-b9e6c7ab899d.png)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
