### PR TITLE
fix(scoop-config): Output [DateTime] as [String]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **decompress:** Trim ending '/' ([#5195](https://github.com/ScoopInstaller/Scoop/issues/5195))
 - **shim:** Exit if shim creating failed 'cause no git ([#5225](https://github.com/ScoopInstaller/Scoop/issues/5225))
 - **scoop-import:** Add correct architecture argument ([#5210](https://github.com/ScoopInstaller/Scoop/issues/5210))
+- **scoop-config:** Output `[DateTime]` as `[String]` ([#5232](https://github.com/ScoopInstaller/Scoop/issues/5232))
 
 ### Code Refactoring
 

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -179,7 +179,11 @@ if (!$name) {
     if($null -eq $value) {
         Write-Host "'$name' is not set"
     } else {
-        $value
+        if ($value -is [System.DateTime]) {
+            $value.ToString('o')
+        } else {
+            $value
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

> Beginning in PowerShell 6, ConvertTo-Json attempts to convert strings formatted as timestamps to DateTime values.

https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7.2#notes

So this fix coerce [DataTime] output to [String] to make uniform output in PS5 and PS7.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Closes #5229

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

PS5:

```shell
❯ scoop config last_update
2022-10-30T17:14:47.9357171+08:00
```

PS7 (before):

```shell
❯ scoop config last_update

2022年10月30日 17:14:47
```

PS7 (after):

```shell
❯ scoop config last_update
2022-10-30T17:14:47.9357171+08:00
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
