### PR TITLE
builds(checkhashes): Use correct version number if `UseCache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - **checkver:** Support XML default namespace ([#5191](https://github.com/ScoopInstaller/Scoop/issues/5191))
 - **pssa:** Remove unused 'ExcludeRules' ([#5201](https://github.com/ScoopInstaller/Scoop/issues/5201))
 - **schema:** Add 'installer' and 'shortcuts' to 'autoupdate' ([#5220](https://github.com/ScoopInstaller/Scoop/issues/5220))
+- **checkhashes:** Use correct version number if `UseCache` ([#5240](https://github.com/ScoopInstaller/Scoop/issues/5240))
 
 ### Continuous Integration
 

--- a/bin/checkhashes.ps1
+++ b/bin/checkhashes.ps1
@@ -114,8 +114,11 @@ foreach ($current in $MANIFESTS) {
 
     $current.urls | ForEach-Object {
         $algorithm, $expected = get_hash $current.hashes[$count]
-        $version = 'HASH_CHECK'
-        $tmp = $expected_hash -split ':'
+        if ($UseCache) {
+            $version = $current.manifest.version
+        } else {
+            $version = 'HASH_CHECK'
+        }
 
         Invoke-CachedDownload $current.app $version $_ $null $null -use_cache:$UseCache
 
@@ -145,12 +148,12 @@ foreach ($current in $MANIFESTS) {
         Write-Host 'Mismatch found ' -ForegroundColor Red
         $mismatched | ForEach-Object {
             $file = fullpath (cache_path $current.app $version $current.urls[$_])
-            Write-Host  "`tURL:`t`t$($current.urls[$_])"
+            Write-Host "`tURL:`t`t$($current.urls[$_])"
             if (Test-Path $file) {
-                Write-Host  "`tFirst bytes:`t$((get_magic_bytes_pretty $file ' ').ToUpper())"
+                Write-Host "`tFirst bytes:`t$((get_magic_bytes_pretty $file ' ').ToUpper())"
             }
-            Write-Host  "`tExpected:`t$($current.hashes[$_])" -ForegroundColor Green
-            Write-Host  "`tActual:`t`t$($actuals[$_])" -ForegroundColor Red
+            Write-Host "`tExpected:`t$($current.hashes[$_])" -ForegroundColor Green
+            Write-Host "`tActual:`t`t$($actuals[$_])" -ForegroundColor Red
         }
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

This fix is concerned with GitHubActions, which downloads file twice if there's no autoupdate hash extraction.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When using `checkhashes`, the actual files are downloaded and hash checked, but the version number in cached file is `HASH_CHECK`, and in GHA, `checkhashes` and `checkver` both download files and don't reuse them. So change `checkhashes`'s switch to let reuse.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Before:
![image](https://user-images.githubusercontent.com/5832170/200283605-5f543314-c214-4d2b-a389-10207343a8f9.png)

After:
![image](https://user-images.githubusercontent.com/5832170/200283660-23512968-0e6e-42c6-9a6a-116b7b6fc231.png)


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
