### PR TITLE
fix decompression failed when unzip PostgreSQL11 in PowerShell 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
 
+- **decompress:** postgresql@14.5: decompress error ([3816](https://github.com/ScoopInstaller/Main/issues/3816))
 - **decompress:** Use PS's default 'Expand-Archive()' ([#5185](https://github.com/ScoopInstaller/Scoop/issues/5185))
 - **hash:** Fix SourceForge's hash extraction ([#5189](https://github.com/ScoopInstaller/Scoop/issues/5189))
 - **decompress:** Trim ending '/' ([#5195](https://github.com/ScoopInstaller/Scoop/issues/5195))

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -538,8 +538,8 @@ function Invoke-ExternalCommand {
         $escapedArgs = $ArgumentList | ForEach-Object {
             # escape N consecutive backslash(es), which are followed by a double quote, to 2N consecutive ones
             $s = $_ -replace '(\\+)"', '$1$1"'
-            # escape N consecutive backslash(es), which are at the end of the string, to 2N consecutive ones
-            $s = $s -replace '(\\+)$', '$1$1'
+            # escape N consecutive backslash(es) followed by end-of-string to single occurence.
+            $s = $s -replace '(\\+)$', '$1'
             # escape double quotes
             $s = $s -replace '"', '\"'
             # quote the argument


### PR DESCRIPTION
File decompression failed in PowerShell 5.1.

#### Description
Change lib/core.ps1 L542 from
`$s = $s -replace '(\\+)$', '$1$1'`
to
`$s = $s -replace '(\\+)$', '$1'`

because in current case `scoop install postgresql11`,
lib/decompress.ps1#L9 give an argument $DestinationPath ends with "\\"
and make it failed when decompressing the file with 7zip 22.0.

#### Motivation and Context
Relate to https://github.com/ScoopInstaller/Main/issues/3816
Relate to #4647 

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Take a view of blame https://github.com/YauHsien/Scoop/blame/8aee6f99803d0f0aeab252e1d9d4848777185c51/lib/core.ps1#L544
   that segment is recently put in codebase.
2. Workaround in two of my laptops.
3. Scoop Core CI Tests https://github.com/YauHsien/Scoop/actions/runs/3409371442

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
