### PR TITLE
refactor(scoop-download): Output more detailed manifest information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Code Refactoring
 
 - **git:** Use Invoke-Git() with direct path to git.exe to prevent spawning shim subprocesses ([#5122](https://github.com/ScoopInstaller/Scoop/issues/5122))
+- **scoop-download:** Output more detailed manifest information ([#5277](https://github.com/ScoopInstaller/Scoop/issues/5277))
 
 ### Tests
 

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -57,7 +57,7 @@ foreach ($curr_app in $apps) {
     $app, $bucket, $version = parse_app $curr_app
     $app, $manifest, $bucket, $url = Get-Manifest "$bucket/$app"
 
-    info "Starting download for $app..."
+    info "Downloading '$app'$(if ($version) { " ($version)" }) [$architecture]$(if ($bucket) { " from $bucket bucket" })"
 
     # Generate manifest if there is different version in manifest
     if (($null -ne $version) -and ($manifest.version -ne $version)) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
Show bucket, version, architecture information when downloading app.

#### Motivation and Context
- Clearly prompt the user which manifest(app) is downloading
- Consistent with `scoop-install`

#### How Has This Been Tested?
![screenshot_20221206230513](https://user-images.githubusercontent.com/4353480/206044915-d248c9dd-9f82-4cb4-8bcc-11ed2de660f8.png)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
