### PR TITLE
ChromeHtmltoPdf: Add version 2.6.5

### DIFF
--- a/chrome-html-to-pdf
+++ b/chrome-html-to-pdf
@@ -1,0 +1,12 @@
+{
+    "version":  "2.6.5",
+    "license":  "MIT",
+    "extract_dir":  "ChromeHtmltoPdf_265",
+    "url":  "https://github.com/Sicos1977/ChromeHtmlToPdf/releases/download/2.6.5/ChromeHtmltoPdf_265.zip",
+    "depends":  ["dotnet-sdk", "googlechrome"],
+    "homepage":  "https://github.com/Sicos1977/ChromeHtmlToPdf",
+    "bin":  "ChromeHtmlToPdfConsole.exe",
+    "autoupdate": {
+        "url": "https://github.com/Sicos1977/ChromeHtmlToPdf/releases/download/$version/ChromeHtmltoPdf_265.zip"
+    }
+}


### PR DESCRIPTION
This is a tool written in .NET that captures exactly the way chrome renders your HTML, and turns it into a PDF file.

I succcessfully [made it work on my machine](https://github.com/Sicos1977/ChromeHtmlToPdf/issues/92) as you require.

Hope this can be added to a bucket soon enough ! 🚀

#### Description
No changes to the original package, I just created a manifest for people to get it through scoop

#### Motivation and Context
This package is very useful to me and I was surprised it wasn't available through scoop !

#### How Has This Been Tested?

The following powershell one-liner works on my machine:

```powershell
scoop install https://gist.githubusercontent.com/arnos-stuff/4f9b2d92d812b25d0ee8335c543cba78/raw/cfa861ab3078a20c69157ab45daf33f26005fd63/chrome-html-to-pdf.json
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
