### PR TITLE
fix(getopt): Stop split arguments in `getopt()` and ensure array by explicit arguments type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - **decompress:** Exclude '*.nsis' that may cause error ([#5294](https://github.com/ScoopInstaller/Scoop/issues/5294))
 - **autoupdate:** Fix file hash extraction ([#5295](https://github.com/ScoopInstaller/Scoop/issues/5295))
+- **shims parse:** Improve getops to split with quote and space ([#5313](Can't add a shim to an exe with spaces in it's filepath))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - **decompress:** Exclude '*.nsis' that may cause error ([#5294](https://github.com/ScoopInstaller/Scoop/issues/5294))
 - **autoupdate:** Fix file hash extraction ([#5295](https://github.com/ScoopInstaller/Scoop/issues/5295))
-- **shims parse:** Improve getops to split with quote and space ([#5313](Can't add a shim to an exe with spaces in it's filepath))
+- **getopt:** Stop split arguments in `getopt()` and ensure array by explicit arguments type ([#5326](https://github.com/ScoopInstaller/Scoop/issues/5326))
 - **shortcuts:** Output correctly formatted path ([#5333](https://github.com/ScoopInstaller/Scoop/issues/5333))
 
 ### Code Refactoring

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -25,7 +25,7 @@ function getopt($argv, $shortopts, $longopts) {
     }
 
     # ensure these are arrays
-    $argv = @($argv -split ' \\(?=(?:[^"]|"[^"]*")*$)')
+    $argv = @($argv)
     $longopts = @($longopts)
     for ($i = 0; $i -lt $argv.Length; $i++) {
         $arg = $argv[$i]

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -25,7 +25,7 @@ function getopt($argv, $shortopts, $longopts) {
     }
 
     # ensure these are arrays
-    $argv = @($argv -split ' ')
+    $argv = @($argv -split ' (?=(?:[^"]|"[^"]*")*$)')
     $longopts = @($longopts)
 
     for ($i = 0; $i -lt $argv.Length; $i++) {

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -13,7 +13,7 @@
 # following arguments are treated as non-option arguments, even if
 # they begin with a hyphen. The "--" itself will not be included in
 # the returned $opts. (POSIX-compatible)
-function getopt($argv, $shortopts, $longopts) {
+function getopt([String[]]$argv, [String]$shortopts, [String[]]$longopts) {
     $opts = @{}; $rem = @()
 
     function err($msg) {
@@ -24,9 +24,6 @@ function getopt($argv, $shortopts, $longopts) {
         return [Regex]::Escape($str)
     }
 
-    # ensure these are arrays
-    $argv = @($argv)
-    $longopts = @($longopts)
     for ($i = 0; $i -lt $argv.Length; $i++) {
         $arg = $argv[$i]
         if ($null -eq $arg) { continue }

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -25,9 +25,8 @@ function getopt($argv, $shortopts, $longopts) {
     }
 
     # ensure these are arrays
-    $argv = @($argv -split ' (?=(?:[^"]|"[^"]*")*$)')
+    $argv = @($argv -split ' \\(?=(?:[^"]|"[^"]*")*$)')
     $longopts = @($longopts)
-
     for ($i = 0; $i -lt $argv.Length; $i++) {
         $arg = $argv[$i]
         if ($null -eq $arg) { continue }
@@ -81,6 +80,5 @@ function getopt($argv, $shortopts, $longopts) {
             $rem += $arg
         }
     }
-
     $opts, $rem
 }

--- a/test/Scoop-GetOpts.Tests.ps1
+++ b/test/Scoop-GetOpts.Tests.ps1
@@ -17,6 +17,12 @@ Describe 'getopt' -Tag 'Scoop' {
         $err | Should -Be 'Option --arb requires an argument.'
     }
 
+    It 'handle space in quote' {
+        $opt, $rem, $err = getopt '"c:\Program File (86)\test"'
+        $err | Should -BeNullOrEmpty
+        $rem.length | Should -Be 1
+    }
+
     It 'handle unrecognized short option' {
         $null, $null, $err = getopt '-az' 'a' ''
         $err | Should -Be 'Option -z not recognized.'

--- a/test/Scoop-GetOpts.Tests.ps1
+++ b/test/Scoop-GetOpts.Tests.ps1
@@ -18,9 +18,9 @@ Describe 'getopt' -Tag 'Scoop' {
     }
 
     It 'handle space in quote' {
-        $opt, $rem, $err = getopt '"c:\Program File (86)\test"'
+        $opt, $rem, $err = getopt '-x', 'space arg' 'x:' ''
         $err | Should -BeNullOrEmpty
-        $rem.length | Should -Be 1
+        $opt.x | Should -Be 'space arg'
     }
 
     It 'handle unrecognized short option' {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### getops handle space with quote
<!-- Describe your changes in detail -->

#### Correct #5313 
<!-- Why is this change required? What problem does it solve? -->
Currently, getops parse with split space. With this correction, getops is more resilient and can parse in a more robust way with quote. Previously, 'parse this "sort of text"' => parse/this/sort/of/text
Now, 'parse this "sort of text"' => parse/this/sort of text
This correction can now handle parsing path with space (ex: c:\Program Files).
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #5313 
<!-- or -->

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Use bug description, test on some other cases

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
