### PR TITLE
fix(chore): Handle spaces in git command arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Code Refactoring
 
-- **git:** Use Invoke-Git() with direct path to git.exe to prevent spawning shim subprocesses ([#5122](https://github.com/ScoopInstaller/Scoop/issues/5122))
+- **git:** Use Invoke-Git() with direct path to git.exe to prevent spawning shim subprocesses ([#5122](https://github.com/ScoopInstaller/Scoop/issues/5122), [#5375](https://github.com/ScoopInstaller/Scoop/issues/5375))
 - **scoop-download:** Output more detailed manifest information ([#5277](https://github.com/ScoopInstaller/Scoop/issues/5277))
 
 ### Tests

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -100,7 +100,7 @@ function list_buckets {
         $path = Find-BucketDirectory $_ -Root
         if ((Test-Path (Join-Path $path '.git')) -and (Get-Command git -ErrorAction SilentlyContinue)) {
             $bucket.Source = Invoke-Git -Path $path -ArgumentList @('config', 'remote.origin.url')
-            $bucket.Updated = Invoke-Git -Path $path -ArgumentList @('log', "--format='%aD'", '-n', '1')
+            $bucket.Updated = Invoke-Git -Path $path -ArgumentList @('log', '--format=%aD', '-n', '1') | Get-Date
         } else {
             $bucket.Source = friendly_path $path
             $bucket.Updated = (Get-Item "$path\bucket").LastWriteTime

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -145,19 +145,16 @@ function Invoke-Git {
 
     $proxy = get_config PROXY
     $git = Get-HelperPath -Helper Git
-    $arguments = $ArgumentList -join ' '
-    $cmd = "`"$git`" $arguments"
 
     if ($WorkingDirectory) {
-        $cmd = "`"$git`" -C `"$WorkingDirectory`" $arguments"
+        $ArgumentList = @('-C', $WorkingDirectory) + $ArgumentList
     }
-    $sb = [scriptblock]::Create("& $cmd")
 
     if([String]::IsNullOrEmpty($proxy) -or $proxy -eq 'none')  {
-        return Invoke-Command $sb
+        return & $git $ArgumentList
     }
 
-    if($arguments -Match '\b(clone|checkout|pull|fetch|ls-remote)\b') {
+    if($ArgumentList -Match '\b(clone|checkout|pull|fetch|ls-remote)\b') {
         $old_https = $env:HTTPS_PROXY
         $old_http = $env:HTTP_PROXY
         try {
@@ -167,7 +164,7 @@ function Invoke-Git {
             }
             $env:HTTPS_PROXY = $proxy
             $env:HTTP_PROXY = $proxy
-            return Invoke-Command $sb
+            return & $git $ArgumentList
         }
         catch {
             error $_
@@ -179,7 +176,7 @@ function Invoke-Git {
         }
     }
 
-    return Invoke-Command $sb
+    return & $git $ArgumentList
 }
 
 function Invoke-GitLog {
@@ -198,7 +195,7 @@ function Invoke-GitLog {
             }
             $Name = "%Cgreen$($Name.PadRight(12, ' ').Substring(0, 12))%Creset "
         }
-        Invoke-Git -Path $Path -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', '--abbrev=12', "--format='tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s $Name%C(cyan)%cr%Creset'", "$CommitHash..HEAD")
+        Invoke-Git -Path $Path -ArgumentList @('--no-pager', 'log', '--color', '--no-decorate', "--grep='^(chore)'", '--invert-grep', '--abbrev=12', "--format=tformat: * %C(yellow)%h%Creset %<|(72,trunc)%s $Name%C(cyan)%cr%Creset", "$CommitHash..HEAD")
     }
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -151,7 +151,7 @@ function Invoke-Git {
     }
 
     if([String]::IsNullOrEmpty($proxy) -or $proxy -eq 'none')  {
-        return & $git $ArgumentList
+        return & $git @ArgumentList
     }
 
     if($ArgumentList -Match '\b(clone|checkout|pull|fetch|ls-remote)\b') {
@@ -164,7 +164,7 @@ function Invoke-Git {
             }
             $env:HTTPS_PROXY = $proxy
             $env:HTTP_PROXY = $proxy
-            return & $git $ArgumentList
+            return & $git @ArgumentList
         }
         catch {
             error $_
@@ -176,7 +176,7 @@ function Invoke-Git {
         }
     }
 
-    return & $git $ArgumentList
+    return & $git @ArgumentList
 }
 
 function Invoke-GitLog {

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -84,7 +84,7 @@ if ($manifest.depends) {
 
 if (Test-Path $manifest_file) {
     if (Get-Command git -ErrorAction Ignore) {
-        $gitinfo = (Invoke-Git -Path (Split-Path $manifest_file) -ArgumentList @('log', '-1', '-s', "--format='%aD#%an'", $manifest_file) 2> $null) -Split '#'
+        $gitinfo = (Invoke-Git -Path (Split-Path $manifest_file) -ArgumentList @('log', '-1', '-s', '--format=%aD#%an', $manifest_file) 2> $null) -Split '#'
     }
     if ($gitinfo) {
         $item.'Updated at' = $gitinfo[0] | Get-Date


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
Fix regression introduced in #5122, i.e. handling of Scoop home paths which have spaces in them.

<!-- or -->


#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Run commands like `scoop bucket ...` or `scoop info ...` which use Git internally.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
