### PR TITLE
builds(checkver): Read the private_host config variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@
 - **decompress:** Exclude '*.nsis' that may cause error ([#5294](https://github.com/ScoopInstaller/Scoop/issues/5294))
 - **autoupdate:** Fix file hash extraction ([#5295](https://github.com/ScoopInstaller/Scoop/issues/5295))
 - **shortcuts:** Output correctly formatted path ([#5333](https://github.com/ScoopInstaller/Scoop/issues/5333))
-- **core:** Checkver can now read the private_host config variable
 
 ### Code Refactoring
 
 - **git:** Use Invoke-Git() with direct path to git.exe to prevent spawning shim subprocesses ([#5122](https://github.com/ScoopInstaller/Scoop/issues/5122), [#5375](https://github.com/ScoopInstaller/Scoop/issues/5375))
 - **scoop-download:** Output more detailed manifest information ([#5277](https://github.com/ScoopInstaller/Scoop/issues/5277))
+
+### Builds
+
+- **checkver:** Read the private_host config variable ([#5381](https://github.com/ScoopInstaller/Scoop/issues/5381))
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **decompress:** Exclude '*.nsis' that may cause error ([#5294](https://github.com/ScoopInstaller/Scoop/issues/5294))
 - **autoupdate:** Fix file hash extraction ([#5295](https://github.com/ScoopInstaller/Scoop/issues/5295))
 - **shortcuts:** Output correctly formatted path ([#5333](https://github.com/ScoopInstaller/Scoop/issues/5333))
+- **core:** Checkver can now read the private_host config variable
 
 ### Code Refactoring
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -223,24 +223,24 @@ $Queue | ForEach-Object {
         $wc.Headers.Add('Authorization', "token $GitHubToken")
     }
 
+    $url = substitute $url $substitutions
+
+    $state = New-Object psobject @{
+        app      = $name
+        file     = $file
+        url      = $url
+        regex    = $regex
+        json     = $json
+        jsonpath = $jsonpath
+        xpath    = $xpath
+        reverse  = $reverse
+        replace  = $replace
+    }
+
     get_config PRIVATE_HOSTS | Where-Object { $_ -ne $null -and $url -match $_.match } | ForEach-Object {
         (ConvertFrom-StringData -StringData $_.Headers).GetEnumerator() | ForEach-Object {
             $wc.Headers[$_.Key] = $_.Value
         }
-    }
-
-    $url = substitute $url $substitutions
-
-    $state = New-Object psobject @{
-        app      = $name;
-        file     = $file;
-        url      = $url;
-        regex    = $regex;
-        json     = $json;
-        jsonpath = $jsonpath;
-        xpath    = $xpath;
-        reverse  = $reverse;
-        replace  = $replace;
     }
 
     $wc.Headers.Add('Referer', (strip_filename $url))

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -223,6 +223,12 @@ $Queue | ForEach-Object {
         $wc.Headers.Add('Authorization', "token $GitHubToken")
     }
 
+    get_config PRIVATE_HOSTS | Where-Object { $_ -ne $null -and $url -match $_.match } | ForEach-Object {
+        (ConvertFrom-StringData -StringData $_.Headers).GetEnumerator() | ForEach-Object {
+            $wc.Headers[$_.Key] = $_.Value
+        }
+    }
+
     $url = substitute $url $substitutions
 
     $state = New-Object psobject @{


### PR DESCRIPTION
#### Description
Checkver does not read the private_hosts config variable. That's mean it is not possible to add a url endpoint which points for example to a text file in a private repository, wherein you can query the current version of your app. 

Relates to https://github.com/ScoopInstaller/Scoop/discussions/5380

#### How Has This Been Tested?
Just run the CI Tests.

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
