### PR TITLE
fix(env): Avoid automatic expansion of `%%` in env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **shim:** Exit if shim creating failed 'cause no git ([#5225](https://github.com/ScoopInstaller/Scoop/issues/5225))
 - **scoop-import:** Add correct architecture argument ([#5210](https://github.com/ScoopInstaller/Scoop/issues/5210))
 - **scoop-config:** Output `[DateTime]` as `[String]` ([#5232](https://github.com/ScoopInstaller/Scoop/issues/5232))
+- **env:** Avoid automatic expansion of `%%` in env ([#5394](https://github.com/ScoopInstaller/Scoop/issues/5394))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **autoupdate:** Fix file hash extraction ([#5295](https://github.com/ScoopInstaller/Scoop/issues/5295))
 - **shortcuts:** Output correctly formatted path ([#5333](https://github.com/ScoopInstaller/Scoop/issues/5333))
 - **core:** Fix `is_in_dir` under Unix ([#5391](https://github.com/ScoopInstaller/Scoop/issues/5391))
+- **env:** Avoid automatic expansion of `%%` in env ([#5394](https://github.com/ScoopInstaller/Scoop/issues/5394))
 
 ### Code Refactoring
 
@@ -44,7 +45,6 @@
 - **shim:** Exit if shim creating failed 'cause no git ([#5225](https://github.com/ScoopInstaller/Scoop/issues/5225))
 - **scoop-import:** Add correct architecture argument ([#5210](https://github.com/ScoopInstaller/Scoop/issues/5210))
 - **scoop-config:** Output `[DateTime]` as `[String]` ([#5232](https://github.com/ScoopInstaller/Scoop/issues/5232))
-- **env:** Avoid automatic expansion of `%%` in env ([#5394](https://github.com/ScoopInstaller/Scoop/issues/5394))
 
 ### Code Refactoring
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -594,12 +594,17 @@ function env($name, $global, $val='__get') {
         $RegisterKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager'
     }
     $RegisterKey = Get-Item -Path $RegisterKeyPath
+    $EnvRegisterKey = $RegisterKey.OpenSubKey('Environment')
     if ($val -eq '__get') {
-        $RegisterKey.OpenSubKey('Environment').GetValue($name, $null,
+        $EnvRegisterKey.GetValue($name, $null,
             [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
     } else {
-        $RegisterKey.OpenSubKey('Environment', $true).SetValue($name, $val,
-            [Microsoft.Win32.RegistryValueKind]::ExpandString)
+        $EnvRegisterKey = $RegisterKey.OpenSubKey('Environment', $true)
+        $RegistryValueKind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+        if ($EnvRegisterKey.GetValue($name)) {
+            $RegistryValueKind = $EnvRegisterKey.GetValueKind($name)
+        }
+        $EnvRegisterKey.SetValue($name, $val, $RegistryValueKind)
     }
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -589,15 +589,17 @@ function Invoke-ExternalCommand {
 }
 
 function env($name, $global, $val='__get') {
-    $EnvironmentRegisterKey = 'HKCU:\Environment'
+    $RegisterKeyPath = 'HKCU:'
     if ($global) {
-        $EnvironmentRegisterKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+        $RegisterKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager'
     }
+    $RegisterKey = Get-Item -Path $RegisterKeyPath
     if ($val -eq '__get') {
-        (Get-Item -Path $EnvironmentRegisterKey).
-            GetValue($name, '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        $RegisterKey.OpenSubKey('Environment').GetValue($name, $null,
+            [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
     } else {
-        Set-ItemProperty -Path $EnvironmentRegisterKey -Name $name -Value $val -Type 'ExpandString'
+        $RegisterKey.OpenSubKey('Environment', $true).SetValue($name, $val,
+            [Microsoft.Win32.RegistryValueKind]::ExpandString)
     }
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -589,9 +589,18 @@ function Invoke-ExternalCommand {
 }
 
 function env($name,$global,$val='__get') {
-    $target = 'User'; if($global) {$target = 'Machine'}
-    if($val -eq '__get') { [environment]::getEnvironmentVariable($name,$target) }
-    else { [environment]::setEnvironmentVariable($name,$val,$target) }
+    $target = 'User'
+    $EnvironmentRegisterKey = 'HKCU:\Environment'
+    if ($global) {
+        $target = 'Machine'
+        $EnvironmentRegisterKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+    }
+    if ($val -eq '__get') {
+        (Get-Item -Path $EnvironmentRegisterKey).
+            GetValue($name, '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+    } else {
+        [environment]::setEnvironmentVariable($name,$val,$target)
+    }
 }
 
 function isFileLocked([string]$path) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -668,17 +668,20 @@ function env($name, $global, $val = '__get') {
     } else {
         Get-Item -Path 'HKCU:'
     }
+    $EnvRegisterKey = $RegisterKey.OpenSubKey('Environment', $val -ne '__get')
 
     if ($val -eq '__get') {
-        $EnvRegisterKey = $RegisterKey.OpenSubKey('Environment')
         $RegistryValueOption = [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
         $EnvRegisterKey.GetValue($name, $null, $RegistryValueOption)
+    } elseif ($val -eq $null) {
+        $EnvRegisterKey.DeleteValue($name)
     } else {
-        $EnvRegisterKey = $RegisterKey.OpenSubKey('Environment', $true)
-        $RegistryValueKind = if ($EnvRegisterKey.GetValue($name)) {
+        $RegistryValueKind = if ($val.Contains('%')) {
+            [Microsoft.Win32.RegistryValueKind]::ExpandString
+        } elseif ($EnvRegisterKey.GetValue($name)) {
             $EnvRegisterKey.GetValueKind($name)
         } else {
-            [Microsoft.Win32.RegistryValueKind]::ExpandString
+            [Microsoft.Win32.RegistryValueKind]::String
         }
         $EnvRegisterKey.SetValue($name, $val, $RegistryValueKind)
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -588,7 +588,7 @@ function Invoke-ExternalCommand {
     return $true
 }
 
-function env($name,$global,$val='__get') {
+function env($name, $global, $val='__get') {
     $target = 'User'
     $EnvironmentRegisterKey = 'HKCU:\Environment'
     if ($global) {
@@ -599,7 +599,7 @@ function env($name,$global,$val='__get') {
         (Get-Item -Path $EnvironmentRegisterKey).
             GetValue($name, '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
     } else {
-        [environment]::setEnvironmentVariable($name,$val,$target)
+        Set-ItemProperty -Path $EnvironmentRegisterKey -Name $name -Value $val -Type 'ExpandString'
     }
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -589,10 +589,8 @@ function Invoke-ExternalCommand {
 }
 
 function env($name, $global, $val='__get') {
-    $target = 'User'
     $EnvironmentRegisterKey = 'HKCU:\Environment'
     if ($global) {
-        $target = 'Machine'
         $EnvironmentRegisterKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
     }
     if ($val -eq '__get') {


### PR DESCRIPTION
#### Description

For example, the following command is used to obtain system environment variables.

```ps1
(Get-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment").GetValue(
    "Path",
    "",
    [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
```

The string obtained by it will not replace the `%%`.

#### Motivation and Context

Use the Registry to get the unexpanded environment variable string inspired by PowerShell/PowerShell#17518. 
Fixes #5394
Related to #1813

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
