### PR TITLE
fix(checkver) use Start-Job for manifest script to not to exit on break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
 
+- **checkver:** use Start-Job for manifest script to not to exit on break ([#32](https://github.com/ScoopInstaller/GithubActions/issues/32))
 - **decompress:** Exclude '*.nsis' that may cause error ([#5294](https://github.com/ScoopInstaller/Scoop/issues/5294))
 - **autoupdate:** Fix file hash extraction ([#5295](https://github.com/ScoopInstaller/Scoop/issues/5295))
 - **getopt:** Stop split arguments in `getopt()` and ensure array by explicit arguments type ([#5326](https://github.com/ScoopInstaller/Scoop/issues/5326))

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -288,8 +288,12 @@ while ($in_progress -gt 0) {
             $page = (Get-Encoding($wc)).GetString($ev.SourceEventArgs.Result)
         }
         if ($script) {
-            $page = Start-Job ([scriptblock]::Create($script -join "`r`n"))
-            Wait-Job $page | Out-Null
+            $scriptJob = Start-Job -ScriptBlock ([scriptblock]::Create($script -join "`r`n"))
+            $page = Receive-Job -Job $scriptJob -Wait
+            if (!$page) {
+				next "'checkver.script' is not valid"
+				continue
+            }
         }
 
         if ($jsonpath) {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -288,7 +288,8 @@ while ($in_progress -gt 0) {
             $page = (Get-Encoding($wc)).GetString($ev.SourceEventArgs.Result)
         }
         if ($script) {
-            $page = Invoke-Command ([scriptblock]::Create($script -join "`r`n"))
+            $page = Start-Job ([scriptblock]::Create($script -join "`r`n"))
+            Wait-Job $page | Out-Null
         }
 
         if ($jsonpath) {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -291,8 +291,8 @@ while ($in_progress -gt 0) {
             $scriptJob = Start-Job -ScriptBlock ([scriptblock]::Create($script -join "`r`n"))
             $page = Receive-Job -Job $scriptJob -Wait
             if (!$page) {
-				next "'checkver.script' is not valid"
-				continue
+                next "'checkver.script' is not valid"
+                continue
             }
         }
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Change the method `checkver` runs manifest scripts to use `Start-Job` instead of `Invoke-Command`.  When using `Invoke-Command`  if the script calls a `break` the parent process will exit.

See: [Do not use break outside of a loop, switch, or trap](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_break?view=powershell-5.1#do-not-use-break-outside-of-a-loop-switch-or-trap)

> Using break inside a pipeline break, such as a ForEach-Object script block, not only exits the pipeline, it potentially terminates the entire runspace.


#### Motivation and Context

Currently autoupdating is broken on all Scoop buckets that have a manifest that runs a `break` in the autoupdate script portion.  Once one manifest is run that has issued a break the Github action will exit and the rest of the bucket will fail to update.

This change starts the manifest script as a separate job allowing the parent process to continue after the manifest script exits, and letting the github action to finish updating the buckets.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Closes https://github.com/ScoopInstaller/GithubActions/issues/32
- Closes https://github.com/ScoopInstaller/Extras/issues/10596
- Closes https://github.com/ScoopInstaller/Extras/issues/10591
- Closes https://github.com/ScoopInstaller/Extras/issues/10592
- Closes https://github.com/ScoopInstaller/Extras/issues/10567
- Closes https://github.com/ScoopInstaller/Extras/issues/10594
- Closes https://github.com/ScoopInstaller/Extras/issues/10613
- Closes https://github.com/ScoopInstaller/Extras/issues/10622

<!-- or -->

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I ran the change on my copy of the current (3579b11f99c692f6b68c1ce5119b8e5d6db9f2bb) Extras repo.  I have attached the output of the update [here](https://github.com/ScoopInstaller/Scoop/files/10837817/scoop-checkver-script-use_start-job-extras-bucket-update-after.txt).  Compare with the current log of Excavator ran during the same period:
- https://github.com/ScoopInstaller/Extras/actions/runs/4280369231/jobs/7452054609#step:3:642

See where it fails on `librewolf`.  [That manifest](https://github.com/ScoopInstaller/Extras/blob/14adf6326703ed8c1ed32e5844bf1bfd8995b086/bucket/librewolf.json#L47) issues a `break` command.  My local bucket updated 84 manifests.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
