### PR TITLE
feat(download): Add support for Github Enterprise

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -376,6 +376,9 @@ function Invoke-Download ($url, $to, $cookies, $progress) {
             (ConvertFrom-StringData -StringData $_.Headers).GetEnumerator() | ForEach-Object {
                 $wreq.Headers[$_.Key] = $_.Value
             }
+            if ($null -ne $_.Accept) {
+                $wreq.Accept = $_.Accept
+            }
         }
     }
 


### PR DESCRIPTION
This pull requests is related to #5447 and is aimed at adding support for Github Enterprise. 

It's based on what has been done for private repositories hosted on github.com with #4254. A new attribute has been added to `private hosts` config for `Accept` header since it's not possible to set it like other headers.

I've successfully installed a tool available as a release in a Github Enterprise instance (https://github.company.com/owner/repo/releases/download/tag/XXXXXX_windows_amd64.zip) using the following config.

```
{
    "last_update":  "2023-03-28T15:12:26.6797756+02:00",
    "private_hosts":  [
                          {
                              "match":  "https://github.company.com/*",
                              "headers":  "Authorization=token ghp_XXXXXXXXXXXXXXXXXX",
                              "Accept":  "application/octet-stream"
                          }
                      ],
    "scoop_branch":  "master",
    "scoop_repo":  "https://github.com/ScoopInstaller/Scoop"
}
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
