### PR TITLE
fix(env): Apply env immediately by `SendMessageTimeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - **core:** Fix `is_in_dir` under Unix ([#5391](https://github.com/ScoopInstaller/Scoop/issues/5391))
 - **core:** Rewrite config file when needed ([#5439](https://github.com/ScoopInstaller/Scoop/issues/5439))
 - **core:** Prevents leaking HTTP(S)_PROXY env vars to current sessions after Invoke-Git in parallel execution ([#5436](https://github.com/ScoopInstaller/Scoop/pull/5436))
-- **env:** Avoid automatic expansion of `%%` in env ([#5395](https://github.com/ScoopInstaller/Scoop/issues/5395))
+- **env:** Avoid automatic expansion of `%%` in env ([#5395](https://github.com/ScoopInstaller/Scoop/issues/5395), [#5452](https://github.com/ScoopInstaller/Scoop/pull/5452))
 - **install:** Fix download from private GitHub repositories ([#5361](https://github.com/ScoopInstaller/Scoop/issues/5361))
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))


### PR DESCRIPTION
Fix the problem caused by the merge of #5395, mentioned in [5424#issuecomment-1479734238](https://github.com/ScoopInstaller/Scoop/pull/5424#issuecomment-1479734238), similar to ScoopInstaller/Install#49.

Use `SendMessageTimeout` in user32 to update the env in explorer.exe, and then the new env will be used in new process of powershell/cmd.

I have tested it in some cases and it works fine. I can't guarantee that all situations will be known to me. For example, a known issue is that if you use Windows Terminal, updating env in one tab does not update env in another tab of the same window, as mentioned in microsoft/terminal#14999.