### PR TITLE
fix: fixed shim add bug related to #5492

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - **shim:** Exit if shim creating failed 'cause no git ([#5225](https://github.com/ScoopInstaller/Scoop/issues/5225))
 - **scoop-import:** Add correct architecture argument ([#5210](https://github.com/ScoopInstaller/Scoop/issues/5210))
 - **scoop-config:** Output `[DateTime]` as `[String]` ([#5232](https://github.com/ScoopInstaller/Scoop/issues/5232))
+- **shim:** fixed shim add bug related to Resolve-Path ([#5492](https://github.com/ScoopInstaller/Scoop/issues/5492))
 
 ### Code Refactoring
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -825,10 +825,10 @@ function shim($path, $global, $name, $arg) {
     $shim = "$abs_shimdir\$($name.tolower())"
 
     # convert to relative path
-    Push-Location $abs_shimdir
-    $relative_path = Resolve-Path -Relative $path
-    Pop-Location
     $resolved_path = Convert-Path $path
+    Push-Location $abs_shimdir
+    $relative_path = Resolve-Path -Relative $resolved_path
+    Pop-Location
 
     if ($path -match '\.(exe|com)$') {
         # for programs with no awareness of any shell


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
Changed a bit of order of operations. What was happening before didn't make any sense with the kinds of input and outputs Resolve-Path uses. Without any documentation to go off, it seems the original creator wanted a relative path ***from*** the shims dir ***to*** the file you are trying to create a shim for because of weird pathname bugs that occur when that file is on a separate drive from your scoop install. The code now reflects that line of logic and produces no error output.

#### Motivation and Context
I like to use scoop shims as a centralized way to add programs to my path (Ex: `scoop shim add ols .\ols.exe` where ols was built from source), but that had error output generated by Resolve-Path. It wasn't preventing the creation of my shims in this case, but it was a bug none-the-less.
Closes #5492

#### How Has This Been Tested?
I've created and removed shims via:
1. Installing programs via scoop normally (`scoop install <blah>`)
2. Added a shim to a file on the same drive as my scoop install.
3. Added a shim to a file on a different drive from my scoop install.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
