### PR TITLE
fix(scoop-checkup): Skip defender check in Windows Sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **install:** Fix download from private GitHub repositories ([#5361](https://github.com/ScoopInstaller/Scoop/issues/5361))
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
+- **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
 
 ### Performance Improvements
 

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -10,7 +10,7 @@ $defenderIssues = 0
 
 $adminPrivileges = ([System.Security.Principal.WindowsPrincipal] [System.Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
 
-if ($adminPrivileges) {
+if ($adminPrivileges -and $env:USERNAME -ne 'WDAGUtilityAccount') {
     $defenderIssues += !(check_windows_defender $false)
     $defenderIssues += !(check_windows_defender $true)
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Get-MpPreference : Provider load failure

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Defender is OFF in Sandbox.(default

Closes #XXXX
<!-- or -->
Relates to https://github.com/ScoopInstaller/Install/commit/c99c2f1d53cf699d1a02af1d5ad0ec897c9b6120

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Before:
```
PS C:\Users\WDAGUtilityAccount> scoop checkup
Get-MpPreference : Provider load failure
At C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\diagnostic.ps1:9 char:14
+         if ((Get-MpPreference).DisableRealtimeMonitoring) { return $t ...
+              ~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (MSFT_MpPreference:root\Microsoft\...FT_MpPreference) [Get-MpPreference],
   CimException
    + FullyQualifiedErrorId : HRESULT 0x80041013,Get-MpPreference

Get-MpPreference : Provider load failure
At C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\diagnostic.ps1:9 char:14
+         if ((Get-MpPreference).DisableRealtimeMonitoring) { return $t ...
+              ~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (MSFT_MpPreference:root\Microsoft\...FT_MpPreference) [Get-MpPreference],
   CimException
    + FullyQualifiedErrorId : HRESULT 0x80041013,Get-MpPreference

WARN  Windows Developer Mode is not enabled. Operations relevant to symlinks may fail without proper rights.
  You may read more about the symlinks support here:
  https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
ERROR '7-Zip' is not installed! It's required for unpacking most programs. Please Run 'scoop install 7zip' or 'scoop install 7zip-zstd'.
ERROR 'Inno Setup Unpacker' is not installed! It's required for unpacking InnoSetup files. Please run 'scoop install innounp'.
ERROR 'dark' is not installed! It's required for unpacking installers created with the WiX Toolset. Please run 'scoop install dark' or 'scoop install wixtoolset'.
WARN  Found 4 potential problems.
```

After:
```
PS C:\Users\WDAGUtilityAccount> scoop checkup
WARN  Windows Developer Mode is not enabled. Operations relevant to symlinks may fail without proper rights.
  You may read more about the symlinks support here:
  https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
ERROR '7-Zip' is not installed! It's required for unpacking most programs. Please Run 'scoop install 7zip' or 'scoop install 7zip-zstd'.
ERROR 'Inno Setup Unpacker' is not installed! It's required for unpacking InnoSetup files. Please run 'scoop install innounp'.
ERROR 'dark' is not installed! It's required for unpacking installers created with the WiX Toolset. Please run 'scoop install dark' or 'scoop install wixtoolset'.
WARN  Found 4 potential problems.
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
