### PR TITLE
fix(core): Use relative path as fallback of `$scoopdir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
+- **core:** Use relative path as fallback of `$scoopdir` ([#5544]https://github.com/ScoopInstaller/Scoop/issues/5544)
 
 ### Performance Improvements
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1382,7 +1382,7 @@ if ($scoopConfig -and $scoopConfig.PSObject.Properties.Name -contains 'lastUpdat
 # END NOTE
 
 # Scoop root directory
-$scoopdir = $env:SCOOP, (get_config ROOT_PATH), "$([System.Environment]::GetFolderPath('UserProfile'))\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$scoopdir = $env:SCOOP, (get_config ROOT_PATH), (Resolve-Path "$PSScriptRoot\..\..\..\..)") | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
 
 # Scoop global apps directory
 $globaldir = $env:SCOOP_GLOBAL, (get_config GLOBAL_PATH), "$([System.Environment]::GetFolderPath('CommonApplicationData'))\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1382,7 +1382,7 @@ if ($scoopConfig -and $scoopConfig.PSObject.Properties.Name -contains 'lastUpdat
 # END NOTE
 
 # Scoop root directory
-$scoopdir = $env:SCOOP, (get_config ROOT_PATH), (Resolve-Path "$PSScriptRoot\..\..\..\..)") | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$scoopdir = $env:SCOOP, (get_config ROOT_PATH), (Resolve-Path "$PSScriptRoot\..\..\..\..") | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
 
 # Scoop global apps directory
 $globaldir = $env:SCOOP_GLOBAL, (get_config GLOBAL_PATH), "$([System.Environment]::GetFolderPath('CommonApplicationData'))\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1382,7 +1382,7 @@ if ($scoopConfig -and $scoopConfig.PSObject.Properties.Name -contains 'lastUpdat
 # END NOTE
 
 # Scoop root directory
-$scoopdir = $env:SCOOP, (get_config ROOT_PATH), (Resolve-Path "$PSScriptRoot\..\..\..\..") | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$scoopdir = $env:SCOOP, (get_config ROOT_PATH), (Resolve-Path "$PSScriptRoot\..\..\..\.."), "$([System.Environment]::GetFolderPath('UserProfile'))\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
 
 # Scoop global apps directory
 $globaldir = $env:SCOOP_GLOBAL, (get_config GLOBAL_PATH), "$([System.Environment]::GetFolderPath('CommonApplicationData'))\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description

Use relative path as fallback of Scoop root directory.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fallback to `~\scoop` cause non-standard installations of Scoop to not be recognized properly.

Relates to #5543 https://github.com/ScoopInstaller/Scoop/discussions/5542#discussioncomment-6199111

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Before:
```
PS C:\Users\WDAGUtilityAccount> scoop bucket list
Get-ChildItem : Cannot find path 'C:\Users\WDAGUtilityAccount\scoop\buckets' because it does not exist.
At C:\Users\WDAGUtilityAccount\中文\s p a c e\scoop\apps\scoop\current\lib\buckets.ps1:61 char:62
+ ... eneric.List[String]](Get-ChildItem -Path $bucketsdir -Directory).Name
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\WDAGUt...t\scoop\buckets:String) [Get-ChildItem], ItemNotFound
   Exception
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetChildItemCommand

WARN  No bucket found. Please run 'scoop bucket add main' to add the default 'main' bucket.
```

After:
```
PS C:\Users\WDAGUtilityAccount> scoop bucket list

Name     Source                                Updated               Manifests
----     ------                                -------               ---------
main     ~\中文\s p a c e\scoop\buckets\main     6/18/2023 11:29:54 AM      1207
extras   ~\中文\s p a c e\scoop\buckets\extras   6/18/2023 11:29:54 AM      1880
versions ~\中文\s p a c e\scoop\buckets\versions 6/18/2023 11:29:56 AM       425
java     ~\中文\s p a c e\scoop\buckets\java     6/18/2023 11:29:55 AM       253
nuke     ~\中文\s p a c e\scoop\buckets\nuke     6/18/2023 11:29:54 AM       134


PS C:\Users\WDAGUtilityAccount> $env:SCOOP
PS C:\Users\WDAGUtilityAccount> scoop config
PS C:\Users\WDAGUtilityAccount>
```



#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
