### PR TITLE
fix(core): Fix detection of Git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
+- **core:** Fix detection of Git ([#5545]https://github.com/ScoopInstaller/Scoop/issues/5545)
 
 ### Performance Improvements
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -367,7 +367,7 @@ function Get-HelperPath {
     process {
         switch ($Helper) {
             'Git' {
-                $internalgit = "$(versiondir 'git' 'current')\mingw64\bin\git.exe"
+                $internalgit = (Get-AppFilePath 'git' 'mingw64\bin\git.exe'), (Get-AppFilePath 'git' 'mingw32\bin\git.exe') | Where-Object { $_ -ne $null }
                 if (Test-Path $internalgit) {
                     $HelperPath = $internalgit
                 } else {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -368,7 +368,7 @@ function Get-HelperPath {
         switch ($Helper) {
             'Git' {
                 $internalgit = (Get-AppFilePath 'git' 'mingw64\bin\git.exe'), (Get-AppFilePath 'git' 'mingw32\bin\git.exe') | Where-Object { $_ -ne $null }
-                if ($internalgit -and (Test-Path $internalgit)) {
+                if ($internalgit) {
                     $HelperPath = $internalgit
                 } else {
                     $HelperPath = (Get-Command git -ErrorAction Ignore).Source

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -368,7 +368,7 @@ function Get-HelperPath {
         switch ($Helper) {
             'Git' {
                 $internalgit = (Get-AppFilePath 'git' 'mingw64\bin\git.exe'), (Get-AppFilePath 'git' 'mingw32\bin\git.exe') | Where-Object { $_ -ne $null }
-                if (Test-Path $internalgit) {
+                if ($internalgit -and (Test-Path $internalgit)) {
                     $HelperPath = $internalgit
                 } else {
                     $HelperPath = (Get-Command git -ErrorAction Ignore).Source

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -349,7 +349,7 @@ Function Test-CommandAvailable {
 }
 
 Function Test-GitAvailable {
-    Return [Boolean](Test-Path (Get-HelperPath -Helper Git) -ErrorAction Ignore)
+    return [Boolean](Get-HelperPath -Helper Git)
 }
 
 function Get-HelperPath {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

1. Fix function `Test-GitAvailable`: avoid outputs additional error in powershell 5.x

CAUSE: git's path are `Test-Path` twice.
https://github.com/ScoopInstaller/Scoop/blob/1d140585a4895c533a39b08e17ab615cdbfe323f/lib/core.ps1#L352
https://github.com/ScoopInstaller/Scoop/blob/1d140585a4895c533a39b08e17ab615cdbfe323f/lib/core.ps1#L371-L375

2. Fix function `Get-HelperPath`: fallback git(32bit).

CAUSE: git(32bit) is not expected before.
https://github.com/ScoopInstaller/Scoop/blob/1d140585a4895c533a39b08e17ab615cdbfe323f/lib/core.ps1#L370

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Relates to #5122

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. `Test-GitAvailable`

Before:
```
PS C:\Users\WDAGUtilityAccount> $PSVersionTable.PSVersion.Major
5
PS C:\Users\WDAGUtilityAccount> scoop update
Test-Path : Cannot bind argument to parameter 'Path' because it is null.
At C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\core.ps1:352 char:32
+     Return [Boolean](Test-Path (Get-HelperPath -Helper Git) -ErrorAct ...
+                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.TestPathCom
   mand

Scoop uses Git to update itself. Run 'scoop install git' and try again.
PS C:\Users\WDAGUtilityAccount> pwsh
PowerShell 7.3.4
PS C:\Users\WDAGUtilityAccount> scoop update
Scoop uses Git to update itself. Run 'scoop install git' and try again.
```

After:
```
PS C:\Users\WDAGUtilityAccount> $PSVersionTable.PSVersion.Major
5
PS C:\Users\WDAGUtilityAccount> scoop update
Scoop uses Git to update itself. Run 'scoop install git' and try again.
PS C:\Users\WDAGUtilityAccount> pwsh
PowerShell 7.3.4
PS C:\Users\WDAGUtilityAccount> scoop update
Scoop uses Git to update itself. Run 'scoop install git' and try again.
```

2. `Get-HelperPath`

Before:
```
PS C:\Users\WDAGUtilityAccount> . C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\core.ps1
PS C:\Users\WDAGUtilityAccount> Get-HelperPath -Helper Git
PS C:\Users\WDAGUtilityAccount> scoop install git -a 32bit -u
...
PS C:\Users\WDAGUtilityAccount> Get-HelperPath -Helper Git
C:\Users\WDAGUtilityAccount\scoop\shims\git.exe
PS C:\Users\WDAGUtilityAccount> scoop uninstall git; scoop install git -a 64bit -u
...
PS C:\Users\WDAGUtilityAccount> Get-HelperPath -Helper Git
C:\Users\WDAGUtilityAccount\scoop\apps\git\current\mingw64\bin\git.exe
```

After:
```
PS C:\Users\WDAGUtilityAccount> . C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\core.ps1
PS C:\Users\WDAGUtilityAccount> Get-HelperPath -Helper Git
PS C:\Users\WDAGUtilityAccount> scoop install git -a 32bit -u
...
PS C:\Users\WDAGUtilityAccount> Get-HelperPath -Helper Git
C:\Users\WDAGUtilityAccount\scoop\apps\git\current\mingw32\bin\git.exe
PS C:\Users\WDAGUtilityAccount> scoop uninstall git; scoop install git -a 64bit -u
...
PS C:\Users\WDAGUtilityAccount> Get-HelperPath -Helper Git
C:\Users\WDAGUtilityAccount\scoop\apps\git\current\mingw64\bin\git.exe
```



#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
