### PR TITLE
fix(core): Avoid error messages when deleting non-existent environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - **install:** Fix download from private GitHub repositories ([#5361](https://github.com/ScoopInstaller/Scoop/issues/5361))
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
-- **core:** Avoid error messages when deleting non-existent environment variable ([#5547]https://github.com/ScoopInstaller/Scoop/issues/5547)
+- **core:** Avoid error messages when deleting non-existent environment variable ([#5547](https://github.com/ScoopInstaller/Scoop/issues/5547))
 - **core:** Use relative path as fallback of `$scoopdir` ([#5544](https://github.com/ScoopInstaller/Scoop/issues/5544))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519](https://github.com/ScoopInstaller/Scoop/issues/5519))
 - **buckets:** Avoid error messages for unexpected dir ([#5549](https://github.com/ScoopInstaller/Scoop/issues/5549))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
-- **fix(core):** Check if the envrionment variable exists before deletion ([#5547]https://github.com/ScoopInstaller/Scoop/issues/5547)
+- **fix(core):** Avoid error messages when deleting non-existent environment variable ([#5547]https://github.com/ScoopInstaller/Scoop/issues/5547)
 
 ### Performance Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
+- **fix(core):** Check if the envrionment variable exists before deletion ([#5547]https://github.com/ScoopInstaller/Scoop/issues/5547)
 
 ### Performance Improvements
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -698,7 +698,7 @@ function env($name, $global, $val = '__get') {
         $RegistryValueOption = [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
         $EnvRegisterKey.GetValue($name, $null, $RegistryValueOption)
     } elseif ($val -eq $null) {
-        $EnvRegisterKey.DeleteValue($name)
+        if ($EnvRegisterKey.GetValue($name)) { $EnvRegisterKey.DeleteValue($name) }
     } else {
         $RegistryValueKind = if ($val.Contains('%')) {
             [Microsoft.Win32.RegistryValueKind]::ExpandString

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -698,7 +698,7 @@ function env($name, $global, $val = '__get') {
         $RegistryValueOption = [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
         $EnvRegisterKey.GetValue($name, $null, $RegistryValueOption)
     } elseif ($val -eq $null) {
-        if ($EnvRegisterKey.GetValue($name)) { $EnvRegisterKey.DeleteValue($name) }
+        try { $EnvRegisterKey.DeleteValue($name) } catch { }
     } else {
         $RegistryValueKind = if ($val.Contains('%')) {
             [Microsoft.Win32.RegistryValueKind]::ExpandString


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Issue:
When delete environment variable during uninstallation, if the environment variable has been deleted before, we will get a error message.
Examples:
1. Same environment variable (name) provide by multiple manifests
2. Delete manually

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Before:
```
PS C:\Users\WDAGUtilityAccount> scoop install openssl1 openssl1-light
Installing 'openssl1' (1.1.1u) [64bit] from versions bucket
Loading Win64OpenSSL-1_1_1u.exe from cache
Checking hash of Win64OpenSSL-1_1_1u.exe ... ok.
Extracting Win64OpenSSL-1_1_1u.exe ... done.
Linking ~\scoop\apps\openssl1\current => ~\scoop\apps\openssl1\1.1.1u
Creating shim for 'openssl'.
'openssl1' (1.1.1u) was installed successfully!
Installing 'openssl1-light' (1.1.1u) [64bit] from versions bucket
Loading Win64OpenSSL_Light-1_1_1u.exe from cache
Checking hash of Win64OpenSSL_Light-1_1_1u.exe ... ok.
Extracting Win64OpenSSL_Light-1_1_1u.exe ... done.
Linking ~\scoop\apps\openssl1-light\current => ~\scoop\apps\openssl1-light\1.1.1u
Creating shim for 'openssl'.
WARN  Overwriting shim ('openssl.exe' -> 'openssl.exe') installed from openssl1
'openssl1-light' (1.1.1u) was installed successfully!
PS C:\Users\WDAGUtilityAccount> scoop uninstall openssl1 openssl1-light
Uninstalling 'openssl1' (1.1.1u).
Removing shim 'openssl.shim.openssl1'.
Unlinking ~\scoop\apps\openssl1\current
'openssl1' was uninstalled.
Uninstalling 'openssl1-light' (1.1.1u).
Removing shim 'openssl.shim'.
Removing shim 'openssl.exe'.
Unlinking ~\scoop\apps\openssl1-light\current
Exception calling "DeleteValue" with "1" argument(s): "No value exists with that name."
At C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\core.ps1:701 char:9
+         $EnvRegisterKey.DeleteValue($name)
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : ArgumentException

'openssl1-light' was uninstalled.
```

After:
```
PS C:\Users\WDAGUtilityAccount> scoop install openssl1 openssl1-light
Installing 'openssl1' (1.1.1u) [64bit] from versions bucket
Loading Win64OpenSSL-1_1_1u.exe from cache
Checking hash of Win64OpenSSL-1_1_1u.exe ... ok.
Extracting Win64OpenSSL-1_1_1u.exe ... done.
Linking ~\scoop\apps\openssl1\current => ~\scoop\apps\openssl1\1.1.1u
Creating shim for 'openssl'.
'openssl1' (1.1.1u) was installed successfully!
Installing 'openssl1-light' (1.1.1u) [64bit] from versions bucket
Loading Win64OpenSSL_Light-1_1_1u.exe from cache
Checking hash of Win64OpenSSL_Light-1_1_1u.exe ... ok.
Extracting Win64OpenSSL_Light-1_1_1u.exe ... done.
Linking ~\scoop\apps\openssl1-light\current => ~\scoop\apps\openssl1-light\1.1.1u
Creating shim for 'openssl'.
WARN  Overwriting shim ('openssl.exe' -> 'openssl.exe') installed from openssl1
'openssl1-light' (1.1.1u) was installed successfully!
PS C:\Users\WDAGUtilityAccount> scoop uninstall openssl1 openssl1-light
Uninstalling 'openssl1' (1.1.1u).
Removing shim 'openssl.shim.openssl1'.
Unlinking ~\scoop\apps\openssl1\current
'openssl1' was uninstalled.
Uninstalling 'openssl1-light' (1.1.1u).
Removing shim 'openssl.shim'.
Removing shim 'openssl.exe'.
Unlinking ~\scoop\apps\openssl1-light\current
'openssl1-light' was uninstalled.
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
