### PR TITLE
fix(core): Handle scoop aliases and broken(edited,copied) shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
-- **core:** Handle scoop aliases and broken(edited,copied) shim ([#5551]https://github.com/ScoopInstaller/Scoop/issues/5551)
+- **core:** Handle scoop aliases and broken(edited,copied) shim ([#5551](https://github.com/ScoopInstaller/Scoop/issues/5551))
 
 ### Performance Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
+- **core:** Handle scoop aliases and broken(edited,copied) shim ([#5551]https://github.com/ScoopInstaller/Scoop/issues/5551)
 
 ### Performance Improvements
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -416,7 +416,10 @@ function Get-CommandPath {
         } catch {
             return $null
         }
-        $commandPath = if ($comm.Path -like "$userShims*" -or $comm.Path -like "$globalShims*") {
+        $commandPath = if ($comm.Path -like "$userShims\scoop-*.ps1") {
+            # Scoop aliases
+            $comm.Source
+        } elseif ($comm.Path -like "$userShims*" -or $comm.Path -like "$globalShims*") {
             Get-ShimTarget ($comm.Path -replace '\.exe$', '.shim')
         } elseif ($comm.CommandType -eq 'Application') {
             $comm.Source
@@ -793,7 +796,7 @@ function Get-ShimTarget($ShimPath) {
         if (!$shimTarget) {
             $shimTarget = ((Select-String -Path $ShimPath -Pattern '[''"]([^@&]*?)[''"]' -AllMatches).Matches.Groups | Select-Object -Last 1).Value
         }
-        $shimTarget | Convert-Path
+        $shimTarget | Convert-Path -ErrorAction SilentlyContinue
     }
 }
 

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -4,7 +4,7 @@
 param($command)
 
 if (!$command) {
-    'ERROR: <command> missing'
+    error '<command> missing'
     my_usage
     exit 1
 }
@@ -12,7 +12,7 @@ if (!$command) {
 $path = Get-CommandPath $command
 
 if ($null -eq $path) {
-    Write-Host "'$command' not found / not a scoop shim."
+    warn "'$command' not found, not a scoop shim, or a broken shim."
     exit 2
 } else {
     friendly_path $path


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`scoop-which` cannot get path when these case:
- `scoop which <manually creaetd/edited shim missing shimTarget>`
- `scoop which <copied shim>` e.g. moving Scoop root directory from other locations
- `scoop which scoop-<scoop_alias>`

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

![Screenshot_230620033720](https://github.com/ScoopInstaller/Scoop/assets/4353480/7ab68598-02af-4163-adb6-f5c4dd68d117)


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
