### PR TITLE
fix(scoop-(un)hold): Correct output the messages when manifest not found, (already|not) held

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
-- **scoop-(un)hold:** Correct output the messages when manifest not found, (already|not) held ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
+- **scoop-(un)hold:** Correct output the messages when manifest not found, (already|not) held ([#5519](https://github.com/ScoopInstaller/Scoop/issues/5519))
 
 ### Performance Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **scoop-info:** Fix errors in file size collection when `--verbose` ([#5352](https://github.com/ScoopInstaller/Scoop/pull/5352))
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
+- **scoop-(un)hold:** Correct output the messages when manifest not found, (already|not) held ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
 
 ### Performance Improvements
 

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -54,6 +54,7 @@ $apps | ForEach-Object {
     }
     $dir = versiondir $app $version $global
     $json = install_info $app $version $global
+    if (!$json) { abort "Failed to hold '$app'." }
     $install = @{}
     $json | Get-Member -MemberType Properties | ForEach-Object { $install.Add($_.Name, $json.($_.Name)) }
     $install.hold = $true

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -54,11 +54,15 @@ $apps | ForEach-Object {
     }
     $dir = versiondir $app $version $global
     $json = install_info $app $version $global
-    if (!$json) { abort "Failed to hold '$app'." }
+    if (!$json) {
+        error "Failed to hold '$app'."
+        continue
+    }
     $install = @{}
     $json | Get-Member -MemberType Properties | ForEach-Object { $install.Add($_.Name, $json.($_.Name)) }
     if ($install.hold) {
-        abort "'$app' is already held."
+        info "'$app' is already held."
+        continue
     }
     $install.hold = $true
     save_install_info $install $dir

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -47,7 +47,7 @@ $apps | ForEach-Object {
         return
     }
 
-    if (get_config NO_JUNCTION){
+    if (get_config NO_JUNCTION) {
         $version = Select-CurrentVersion -App $app -Global:$global
     } else {
         $version = 'current'
@@ -57,6 +57,9 @@ $apps | ForEach-Object {
     if (!$json) { abort "Failed to hold '$app'." }
     $install = @{}
     $json | Get-Member -MemberType Properties | ForEach-Object { $install.Add($_.Name, $json.($_.Name)) }
+    if ($install.hold) {
+        abort "'$app' is already held."
+    }
     $install.hold = $true
     save_install_info $install $dir
     success "$app is now held and can not be updated anymore."

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -53,6 +53,7 @@ $apps | ForEach-Object {
     }
     $dir = versiondir $app $version $global
     $json = install_info $app $version $global
+    if (!$json) { abort "Failed to unhold '$app'" }
     $install = @{}
     $json | Get-Member -MemberType Properties | ForEach-Object { $install.Add($_.Name, $json.($_.Name)) }
     $install.hold = $null

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -53,11 +53,15 @@ $apps | ForEach-Object {
     }
     $dir = versiondir $app $version $global
     $json = install_info $app $version $global
-    if (!$json) { abort "Failed to unhold '$app'" }
+    if (!$json) {
+        error "Failed to unhold '$app'"
+        continue
+    }
     $install = @{}
     $json | Get-Member -MemberType Properties | ForEach-Object { $install.Add($_.Name, $json.($_.Name)) }
     if (!$install.hold) {
-        abort "'$app' is not held."
+        info "'$app' is not held."
+        continue
     }
     $install.hold = $null
     save_install_info $install $dir

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -56,6 +56,9 @@ $apps | ForEach-Object {
     if (!$json) { abort "Failed to unhold '$app'" }
     $install = @{}
     $json | Get-Member -MemberType Properties | ForEach-Object { $install.Add($_.Name, $json.($_.Name)) }
+    if (!$install.hold) {
+        abort "'$app' is not held."
+    }
     $install.hold = $null
     save_install_info $install $dir
     success "$app is no longer held and can be updated again."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

- Abort hold when manifest not found
- Abort hold when app already held
- Abort unhold when app not held

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #5485 #5273

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Before:
#5485

After:
```
PS C:\Users\WDAGUtilityAccount> scoop hold mysql-workbench
Failed to hold 'mysql-workbench'.
PS C:\Users\WDAGUtilityAccount> scoop unhold mysql-workbench
Failed to unhold 'mysql-workbench'
PS C:\Users\WDAGUtilityAccount> scoop reset mysql-workbench
Resetting mysql-workbench (8.0.31).
Linking ~\scoop\apps\mysql-workbench\current => ~\scoop\apps\mysql-workbench\8.0.31
Creating shim for 'MySQLWorkbench'.
Creating shim for 'mysql'.
Creating shim for 'mysqldump'.
Creating shortcut for MySQLWorkbench (MySQLWorkbench.exe)
PS C:\Users\WDAGUtilityAccount> scoop hold mysql-workbench
mysql-workbench is now held and can not be updated anymore.
PS C:\Users\WDAGUtilityAccount> scoop unhold mysql-workbench
mysql-workbench is no longer held and can be updated again.

PS C:\Users\WDAGUtilityAccount> scoop hold mysql-workbench
mysql-workbench is now held and can not be updated anymore.
PS C:\Users\WDAGUtilityAccount> scoop hold mysql-workbench
'mysql-workbench' is already held.
PS C:\Users\WDAGUtilityAccount> scoop unhold mysql-workbench
mysql-workbench is no longer held and can be updated again.
PS C:\Users\WDAGUtilityAccount> scoop unhold mysql-workbench
'mysql-workbench' is not held.
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
