### PR TITLE
fix(#1606): Remove console window for GUI apps, without changing the manifests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug Fixes
 
-- **gui-shim:** remove console window for GUI applications ([#1606](https://github.com/ScoopInstaller/Scoop/issues/1606))
+- **shim:** Remove console window for GUI applications ([#5559](https://github.com/ScoopInstaller/Scoop/issues/5559))
 - **decompress:** Exclude '*.nsis' that may cause error ([#5294](https://github.com/ScoopInstaller/Scoop/issues/5294))
 - **autoupdate:** Fix file hash extraction ([#5295](https://github.com/ScoopInstaller/Scoop/issues/5295))
 - **getopt:** Stop split arguments in `getopt()` and ensure array by explicit arguments type ([#5326](https://github.com/ScoopInstaller/Scoop/issues/5326))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+- **gui-shim:** remove console window for GUI applications ([#1606](https://github.com/ScoopInstaller/Scoop/issues/1606))
 - **decompress:** Exclude '*.nsis' that may cause error ([#5294](https://github.com/ScoopInstaller/Scoop/issues/5294))
 - **autoupdate:** Fix file hash extraction ([#5295](https://github.com/ScoopInstaller/Scoop/issues/5295))
 - **getopt:** Stop split arguments in `getopt()` and ensure array by explicit arguments type ([#5326](https://github.com/ScoopInstaller/Scoop/issues/5326))

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1,9 +1,8 @@
 # Returns the subsystem of the EXE
 function Get-Subsystem($filePath) {
     try {
-        $fileStream = [System.IO.FileStream]::new($filePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite)
+        $fileStream = [System.IO.FileStream]::new($filePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
         $binaryReader = [System.IO.BinaryReader]::new($fileStream)
-        $binaryWriter = [System.IO.BinaryWriter]::new($fileStream)
     } catch {
         return -1  # leave the subsystem part silently
     }
@@ -896,7 +895,7 @@ function shim($path, $global, $name, $arg) {
         $target_subsystem = Get-Subsystem $resolved_path
 
         if (($target_subsystem -ne 3) -and ($target_subsystem -ge 0)) { # Subsystem -eq 3 means `Console`, -ge 0 to ignore
-            Write-Output "Changing Subsystem 3[current] to $target_subsystem[new] for $shim.exe"
+            Write-Output "Making $shim.exe a GUI binary."
             Change-Subsystem "$shim.exe" $target_subsystem
         }
     } elseif ($path -match '\.(bat|cmd)$') {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -777,7 +777,6 @@ function shim($path, $global, $name, $arg) {
             Write-Output "args = $arg" | Out-UTF8File "$shim.shim" -Append
         }
 
-        echo "Resolved path: $resolved_path | $path"
         $target_subsystem = Get-Subsystem $resolved_path
 
         if ($target_subsystem -ne 3) { # Subsystem 3 means `Console`

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1,3 +1,59 @@
+# Returns the subsystem of the EXE
+function Get-Subsystem($filePath) {
+    try {
+        $fileStream = [System.IO.FileStream]::new($filePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite)
+        $binaryReader = [System.IO.BinaryReader]::new($fileStream)
+        $binaryWriter = [System.IO.BinaryWriter]::new($fileStream)
+    } catch {
+        return -1
+    }
+
+    try {
+        $fileStream.Seek(0x3C, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $peOffset = $binaryReader.ReadInt32()
+
+        $fileStream.Seek($peOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $fileHeaderOffset = $fileStream.Position
+
+        $fileStream.Seek(18, [System.IO.SeekOrigin]::Current) | Out-Null
+        $fileStream.Seek($fileHeaderOffset + 0x5C, [System.IO.SeekOrigin]::Begin) | Out-Null
+
+        return $binaryReader.ReadInt16()
+    } finally {
+        $binaryReader.Close()
+        $fileStream.Close()
+    }
+}
+
+function Change-Subsystem($filePath, $targetSubsystem) {
+    try {
+        $fileStream = [System.IO.FileStream]::new($filePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite)
+        $binaryReader = [System.IO.BinaryReader]::new($fileStream)
+        $binaryWriter = [System.IO.BinaryWriter]::new($fileStream)
+    } catch {
+        Write-Output "Error opening File:'$filePath'"
+        return
+    }
+
+    try {
+        $fileStream.Seek(0x3C, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $peOffset = $binaryReader.ReadInt32()
+
+        $fileStream.Seek($peOffset, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $fileHeaderOffset = $fileStream.Position
+
+        $fileStream.Seek(18, [System.IO.SeekOrigin]::Current) | Out-Null
+        $fileStream.Seek($fileHeaderOffset + 0x5C, [System.IO.SeekOrigin]::Begin) | Out-Null
+
+        $binaryWriter.Write([System.Int16] $targetSubsystem)
+
+        Write-Output "Subsystem 3[current] -> $targetSubsystem[new]"
+    } finally {
+        $binaryReader.Close()
+        $fileStream.Close()
+    }
+}
+
 function Optimize-SecurityProtocol {
     # .NET Framework 4.7+ has a default security protocol called 'SystemDefault',
     # which allows the operating system to choose the best protocol to use.
@@ -719,6 +775,13 @@ function shim($path, $global, $name, $arg) {
         Write-Output "path = `"$resolved_path`"" | Out-UTF8File "$shim.shim"
         if ($arg) {
             Write-Output "args = $arg" | Out-UTF8File "$shim.shim" -Append
+        }
+
+        echo "Resolved path: $resolved_path | $path"
+        $target_subsystem = Get-Subsystem $resolved_path
+
+        if ($target_subsystem -ne 3) { # Subsystem 3 means `Console`
+            Change-Subsystem "$shim.exe" $target_subsystem
         }
     } elseif ($path -match '\.(bat|cmd)$') {
         # shim .bat, .cmd so they can be used by programs with no awareness of PSH

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -5,7 +5,7 @@ function Get-Subsystem($filePath) {
         $binaryReader = [System.IO.BinaryReader]::new($fileStream)
         $binaryWriter = [System.IO.BinaryWriter]::new($fileStream)
     } catch {
-        return -1
+        return -1  # leave the subsystem part silently
     }
 
     try {
@@ -46,8 +46,6 @@ function Change-Subsystem($filePath, $targetSubsystem) {
         $fileStream.Seek($fileHeaderOffset + 0x5C, [System.IO.SeekOrigin]::Begin) | Out-Null
 
         $binaryWriter.Write([System.Int16] $targetSubsystem)
-
-        Write-Output "Subsystem 3[current] -> $targetSubsystem[new]"
     } finally {
         $binaryReader.Close()
         $fileStream.Close()
@@ -779,7 +777,8 @@ function shim($path, $global, $name, $arg) {
 
         $target_subsystem = Get-Subsystem $resolved_path
 
-        if ($target_subsystem -ne 3) { # Subsystem 3 means `Console`
+        if (($target_subsystem -ne 3) -and ($target_subsystem -ge 0)) { # Subsystem -eq 3 means `Console`, -ge 0 to ignore
+            Write-Output "Changing Subsystem 3[current] to $target_subsystem[new] for $shim.exe"
             Change-Subsystem "$shim.exe" $target_subsystem
         }
     } elseif ($path -match '\.(bat|cmd)$') {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
Added 2 functions to get the subsystem of the shimmed PE binaries and change the subsystem of the shim executable while installing.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #1606 as it is annoying to deal with the Console Window.
<!-- or -->

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've checked my code changes by installing packages: nvim, vim, wireshark, firefox.
Every GUI app from the above packages (nvim-qt, gvim, gvimdiff, wireshark, firefox) doesn't pop-up a console window and works fine.
The changed code only affects the `subsystem` value in the PE `Optional Headers` of the shim exe.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
