### PR TITLE
Add support for resetting of apps to be imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- **scoop-import:** Add support for resetting of apps to be imported ([#5525](https://github.com/ScoopInstaller/Scoop/issues/5525))
 - **scoop-update:** Add support for parallel syncing buckets in PowerShell 7 and improve output ([#5122](https://github.com/ScoopInstaller/Scoop/issues/5122))
 - **bucket:** Switch nirsoft bucket to ScoopInstaller/Nirsoft ([#5328](https://github.com/ScoopInstaller/Scoop/issues/5328))
 - **config:** Support portable config file ([#5369](https://github.com/ScoopInstaller/Scoop/issues/5369))

--- a/libexec/scoop-import.ps1
+++ b/libexec/scoop-import.ps1
@@ -1,16 +1,18 @@
-# Usage: scoop import <path/url to scoopfile.json>
+# Usage: scoop import <path/url to scoopfile.json> [options]
 # Summary: Imports apps, buckets and configs from a Scoopfile in JSON format
 # Help: To replicate a Scoop installation from a file stored on Desktop, run
 #      scoop import Desktop\scoopfile.json
+#
+# Options:
+#   -r, --reset                     Reset the app after installation
 
-param(
-    [Parameter(Mandatory)]
-    [String]
-    $scoopfile
-)
-
+. "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 
+$opt, $scoopfile, $err = getopt $args 'r' 'reset'
+if ($err) { "scoop import: $err"; exit 1 }
+
+$reset = $opt.r -or $opt.reset
 $import = $null
 $bucket_names = @()
 $def_arch = Get-DefaultArchitecture
@@ -58,6 +60,10 @@ foreach ($item in $import.apps) {
     }
 
     & "$PSScriptRoot\scoop-install.ps1" $app @instArgs
+
+    if ($reset) {
+        & "$PSScriptRoot\scoop-reset.ps1" $app
+    }
 
     if ('Held package' -in $info) {
         & "$PSScriptRoot\scoop-hold.ps1" $item.Name @holdArgs


### PR DESCRIPTION
#### Description
Added a command line option for scoop import:
* -r, --reset: reset each app of imported JSON after installation

#### Motivation and Context
I use the import command quite often to define apps and their versions as dependencies in my projects. The reason for this is of course reproducibility of builds. But when different versions from different buckets of an app are already installed, it might still happen that the wrong apps and/or versions are used.
Closes #5525 

#### How Has This Been Tested?
As there are no unit tests available for the changes file (actually there are no functions in scoop-import.ps1) I tested the changes exploratorily with my local scoopfile.json's.
My changes do affect the scoop import feature only.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
