### PR TITLE
fix(manifest): Correct source of manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519]https://github.com/ScoopInstaller/Scoop/issues/5519)
 - **buckets:** Avoid error messages for unexpected dir ([#5549]https://github.com/ScoopInstaller/Scoop/issues/5549)
+- **manifest:** Correct source of manifest ([#5575](https://github.com/ScoopInstaller/Scoop/issues/5575))
 
 ### Performance Improvements
 

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -37,9 +37,9 @@ function Get-Dependency {
 
         if (!$manifest) {
             if (((Get-LocalBucket) -notcontains $bucket) -and $bucket) {
-                warn "Bucket '$bucket' not installed. Add it with 'scoop bucket add $bucket' or 'scoop bucket add $bucket <repo>'."
+                warn "Bucket '$bucket' not Added. Add it with 'scoop bucket add $bucket' or 'scoop bucket add $bucket <repo>'."
             }
-            abort "Couldn't find manifest for '$AppName'$(if(!$bucket) { '.' } else { " from '$bucket' bucket." })"
+            abort "Couldn't find manifest for '$AppName'$(if($bucket) { " from '$bucket' bucket" } elseif($url) { " at '$url'" })."
         }
 
         $deps = @(Get-InstallationHelper $manifest $Architecture) + @($manifest.depends) | Select-Object -Unique

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -37,7 +37,7 @@ function Get-Dependency {
 
         if (!$manifest) {
             if (((Get-LocalBucket) -notcontains $bucket) -and $bucket) {
-                warn "Bucket '$bucket' not Added. Add it with 'scoop bucket add $bucket' or 'scoop bucket add $bucket <repo>'."
+                warn "Bucket '$bucket' not Added. Add it with $(if($bucket -in (known_buckets)) { "'scoop bucket add $bucket' or " })'scoop bucket add $bucket <repo>'."
             }
             abort "Couldn't find manifest for '$AppName'$(if($bucket) { " from '$bucket' bucket" } elseif($url) { " at '$url'" })."
         }

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -37,7 +37,7 @@ function Get-Dependency {
 
         if (!$manifest) {
             if (((Get-LocalBucket) -notcontains $bucket) -and $bucket) {
-                warn "Bucket '$bucket' not Added. Add it with $(if($bucket -in (known_buckets)) { "'scoop bucket add $bucket' or " })'scoop bucket add $bucket <repo>'."
+                warn "Bucket '$bucket' not added. Add it with $(if($bucket -in (known_buckets)) { "'scoop bucket add $bucket' or " })'scoop bucket add $bucket <repo>'."
             }
             abort "Couldn't find manifest for '$AppName'$(if($bucket) { " from '$bucket' bucket" } elseif($url) { " at '$url'" })."
         }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -9,7 +9,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     $app, $manifest, $bucket, $url = Get-Manifest $app
 
     if(!$manifest) {
-        abort "Couldn't find manifest for '$app'$(if($url) { " at the URL $url" })."
+        abort "Couldn't find manifest for '$app'$(if($bucket) { " from '$bucket' bucket" } elseif($url) { " at '$url'" })."
     }
 
     $version = $manifest.version

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -43,7 +43,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
             return
         }
     }
-    Write-Output "Installing '$app' ($version) [$architecture]$(if ($bucket) { " from $bucket bucket" })"
+    Write-Output "Installing '$app' ($version) [$architecture]$(if ($bucket) { " from $bucket bucket" } else { " from '$url'" })"
 
     $dir = ensure (versiondir $app $version $global)
     $original_dir = $dir # keep reference to real (not linked) directory

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -43,7 +43,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
             return
         }
     }
-    Write-Output "Installing '$app' ($version) [$architecture]$(if ($bucket) { " from $bucket bucket" } else { " from '$url'" })"
+    Write-Output "Installing '$app' ($version) [$architecture]$(if ($bucket) { " from '$bucket' bucket" } else { " from '$url'" })"
 
     $dir = ensure (versiondir $app $version $global)
     $original_dir = $dir # keep reference to real (not linked) directory

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -7,7 +7,7 @@ function parse_json($path) {
     try {
         Get-Content $path -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
     } catch {
-        warn "Error parsing JSON at $path."
+        warn "Error parsing JSON at '$path'."
     }
 }
 
@@ -27,7 +27,7 @@ function url_manifest($url) {
     try {
         $str | ConvertFrom-Json -ErrorAction Stop
     } catch {
-        warn "Error parsing JSON at $url."
+        warn "Error parsing JSON at '$url'."
     }
 }
 
@@ -44,24 +44,23 @@ function Get-Manifest($app) {
         if ($bucket) {
             $manifest = manifest $app $bucket
         } else {
-            foreach ($bucket in Get-LocalBucket) {
-                $manifest = manifest $app $bucket
+            foreach ($tekcub in Get-LocalBucket) {
+                $manifest = manifest $app $tekcub
                 if ($manifest) {
+                    $bucket = $tekcub
                     break
                 }
             }
         }
         if (!$manifest) {
             # couldn't find app in buckets: check if it's a local path
-            $appPath = $app
-            $bucket = $null
-            if (!$appPath.EndsWith('.json')) {
-                $appPath += '.json'
-            }
-            if (Test-Path $appPath) {
-                $url = Convert-Path $appPath
+            if (Test-Path $app) {
+                $url = Convert-Path $app
                 $app = appname_from_url $url
                 $manifest = url_manifest $url
+            } else {
+                if (($app -match '\\/') -or $app.EndsWith('.json')) { $url = $app }
+                $app = appname_from_url $app
             }
         }
     }

--- a/libexec/scoop-cat.ps1
+++ b/libexec/scoop-cat.ps1
@@ -14,14 +14,14 @@ if (!$app) { error '<app> missing'; my_usage; exit 1 }
 $null, $manifest, $bucket, $url = Get-Manifest $app
 
 if ($manifest) {
-        $style = get_config CAT_STYLE
-        if ($style) {
-                $manifest | ConvertToPrettyJson | bat --no-paging --style $style --language json
-        } else {
-                $manifest | ConvertToPrettyJson
-        }
+    $style = get_config CAT_STYLE
+    if ($style) {
+        $manifest | ConvertToPrettyJson | bat --no-paging --style $style --language json
+    } else {
+        $manifest | ConvertToPrettyJson
+    }
 } else {
-        abort "Couldn't find manifest for '$app'$(if($url) { " at the URL $url" })."
+    abort "Couldn't find manifest for '$app'$(if($bucket) { " from '$bucket' bucket" } elseif($url) { " at '$url'" })."
 }
 
 exit $exitCode

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -70,7 +70,7 @@ foreach ($curr_app in $apps) {
     }
 
     if(!$manifest) {
-        error "Couldn't find manifest for '$app'$(if($url) { " at the URL $url" })."
+        error "Couldn't find manifest for '$app'$(if($bucket) { " from '$bucket' bucket" } elseif($url) { " at '$url'" })."
         continue
     }
     $version = $manifest.version


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Correct prompt about source of manifest when not found.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Close #5546

This is the original functionality that was broken when merging new features/refactoring. After the changes, user must explicitly input full filename for local manifests:
```
$manifest = '{
    "version": "1",
    "url": "http://example.org/#/App.exe"
}'

$manifest | out-file localmanifest.json -Encoding ascii
$manifest | out-file manifest_without_suffix -Encoding ascii

scoop install localmanifest × # This was allowed before.
scoop install localmanifest.json √
scoop install .\localmanifest.json √
scoop install manifest_without_suffix √
```

Example for actual usage:
```
~\Desktop\manifests
❯ ls -name
git
git.json
~\Desktop\manifests
❯ scoop info git

Name        : git
Description : Distributed version control system
Version     : 2.42.0.2
Bucket      : main
Website     : https://gitforwindows.org
License     : GPL-2.0-only
Updated at  : 8/30/2023 12:30:31 PM
Updated by  : github-actions[bot]
Installed   : 2.42.0.2
Binaries    : bin\sh.exe | bin\bash.exe | cmd\git.exe | cmd\gitk.exe | cmd\git-gui.exe | cmd\scalar.exe | usr\bin\tig.exe |
              git-bash.exe
Shortcuts   : Git Bash | Git GUI
Environment : GIT_INSTALL_ROOT = <root>
Notes       : Set Git Credential Manager Core by running: "git config --global credential.helper manager"

              To add context menu entries, run '<root>\install-context.reg'

              To create file-associations for .git* and .sh files, run '<root>\install-file-associations.reg'


~\Desktop\manifests

# install git from main bucket
❯ scoop install git

# install git from ~\Desktop\manifests\git file
❯ scoop install .\git

# install git from ~\Desktop\manifests\git.json file, unless a manifest with filename `git.json.json` in added buckets
❯ scoop install git.json

# install git from ~\Desktop\manifests\git.json file
❯ scoop install .\git.json
```




#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

test.ps1: https://gist.github.com/HUMORCE/4e215c95bdcbb9d17a6b0cda777b6331/raw/790ee7b5b050dfb511ce59e6c83efdd4404292f0/test.ps1

screenshot: left=before, right=after
![Screenshot_230711021447](https://github.com/ScoopInstaller/Scoop/assets/4353480/2b631f40-4e17-4ec7-8134-02bd9ebe1794)

show source for remote or local manifest when installing:
![Screenshot_231008140545](https://github.com/ScoopInstaller/Scoop/assets/4353480/5d2d4eca-10ea-4279-8590-282bdc5536ad)



#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
