### PR TITLE
feat: Allow global install of PowerShell modules 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **config:** Support portable config file ([#5369](https://github.com/ScoopInstaller/Scoop/issues/5369))
 - **bucket:** Make official buckets higher priority ([#5398](https://github.com/ScoopInstaller/Scoop/issues/5398))
 - **core:** Add `-Quiet` switch for `Invoke-ExternalCommand` ([#5346](https://github.com/ScoopInstaller/Scoop/issues/5346))
+- **core:** Allow global install of PowerShell modules ([#5611](https://github.com/ScoopInstaller/Scoop/issues/5611))
 
 ### Bug Fixes
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -264,6 +264,7 @@ function filesize($length) {
 function basedir($global) { if($global) { return $globaldir } $scoopdir }
 function appsdir($global) { "$(basedir $global)\apps" }
 function shimdir($global) { "$(basedir $global)\shims" }
+function modulesdir($global) { "$(basedir $global)\modules" }
 function appdir($app, $global) { "$(appsdir $global)\$app" }
 function versiondir($app, $version, $global) { "$(appdir $app $global)\$version" }
 

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -1,22 +1,23 @@
 $modulesdir = "$scoopdir\modules"
+$globalmodulesdir = "$env:ProgramFiles\WindowsPowerShell\Modules" # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_psmodulepath
 
 function install_psmodule($manifest, $dir, $global) {
     $psmodule = $manifest.psmodule
     if (!$psmodule) { return }
 
     if ($global) {
-        abort 'Installing PowerShell modules globally is not implemented!'
-    }
-
-    $modulesdir = ensure $modulesdir
-    ensure_in_psmodulepath $modulesdir $global
+		$targetdir = ensure $globalmodulesdir
+    } else {
+		$targetdir = ensure $modulesdir;
+		ensure_in_psmodulepath $modulesdir $global
+	}
 
     $module_name = $psmodule.name
     if (!$module_name) {
         abort "Invalid manifest: The 'name' property is missing from 'psmodule'."
     }
 
-    $linkfrom = "$modulesdir\$module_name"
+    $linkfrom = "$targetdir\$module_name"
     Write-Host "Installing PowerShell module '$module_name'"
 
     Write-Host "Linking $(friendly_path $linkfrom) => $(friendly_path $dir)"
@@ -36,7 +37,13 @@ function uninstall_psmodule($manifest, $dir, $global) {
     $module_name = $psmodule.name
     Write-Host "Uninstalling PowerShell module '$module_name'."
 
-    $linkfrom = "$modulesdir\$module_name"
+    if ($global) { 
+		$targetdir = ensure $globalmodulesdir
+    } else {
+		$targetdir = ensure $modulesdir;
+	}
+
+    $linkfrom = "$targetdir\$module_name"
     if (Test-Path $linkfrom) {
         Write-Host "Removing $(friendly_path $linkfrom)"
         $linkfrom = Convert-Path $linkfrom

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -1,16 +1,10 @@
-$modulesdir = "$scoopdir\modules"
-$globalmodulesdir = "$env:ProgramFiles\WindowsPowerShell\Modules" # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_psmodulepath
-
 function install_psmodule($manifest, $dir, $global) {
     $psmodule = $manifest.psmodule
     if (!$psmodule) { return }
 
-    if ($global) {
-        $targetdir = ensure $globalmodulesdir
-    } else {
-        $targetdir = ensure $modulesdir;
-        ensure_in_psmodulepath $modulesdir $global
-    }
+    $targetdir = ensure (modulesdir $global)
+
+    ensure_in_psmodulepath $targetdir $global
 
     $module_name = $psmodule.name
     if (!$module_name) {
@@ -37,11 +31,7 @@ function uninstall_psmodule($manifest, $dir, $global) {
     $module_name = $psmodule.name
     Write-Host "Uninstalling PowerShell module '$module_name'."
 
-    if ($global) {
-        $targetdir = ensure $globalmodulesdir
-    } else {
-        $targetdir = ensure $modulesdir;
-    }
+    $targetdir = modulesdir $global
 
     $linkfrom = "$targetdir\$module_name"
     if (Test-Path $linkfrom) {

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -6,11 +6,11 @@ function install_psmodule($manifest, $dir, $global) {
     if (!$psmodule) { return }
 
     if ($global) {
-		$targetdir = ensure $globalmodulesdir
+        $targetdir = ensure $globalmodulesdir
     } else {
-		$targetdir = ensure $modulesdir;
-		ensure_in_psmodulepath $modulesdir $global
-	}
+        $targetdir = ensure $modulesdir;
+        ensure_in_psmodulepath $modulesdir $global
+    }
 
     $module_name = $psmodule.name
     if (!$module_name) {
@@ -37,11 +37,11 @@ function uninstall_psmodule($manifest, $dir, $global) {
     $module_name = $psmodule.name
     Write-Host "Uninstalling PowerShell module '$module_name'."
 
-    if ($global) { 
-		$targetdir = ensure $globalmodulesdir
+    if ($global) {
+        $targetdir = ensure $globalmodulesdir
     } else {
-		$targetdir = ensure $modulesdir;
-	}
+        $targetdir = ensure $modulesdir;
+    }
 
     $linkfrom = "$targetdir\$module_name"
     if (Test-Path $linkfrom) {


### PR DESCRIPTION
Allow global install of PowerShell modules
 - ~~By installing them to $env:ProgramFiles\WindowsPowerShell\Modules which is the folder where both Windows PowerShell and PowerShell core use. (See https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_psmodulepath )~~
 - By installing them to `basedir\modules` (c:\ProgramData\scoop\modules) 
 - And adding that path to system (all users) PSModulePath env var.
 
#### Description
<!-- Describe your changes in detail -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #5601 #5597

#### How Has This Been Tested?
By installing, updating, uninstalling gsudo.
```
scoop install gsudo -g
scoop uninstall gsudo -g

scoop install gsudo@2.1.0 -g
scoop install gsudo@2.3.0 -g
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
