### PR TITLE
Another attempt to improve the search performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@
 - **shim:** Use bash executable directly ([#5433](https://github.com/ScoopInstaller/Scoop/issues/5433))
 - **scoop-checkup:** Skip defender check in Windows Sandbox ([#5519](https://github.com/ScoopInstaller/Scoop/issues/5519))
 - **buckets:** Avoid error messages for unexpected dir ([#5549](https://github.com/ScoopInstaller/Scoop/issues/5549))
-- **scoop-virustotal**: Fix `scoop-virustotal` when `--all' has been passed without app ([#5593](https://github.com/ScoopInstaller/Scoop/pull/5593))
+- **scoop-virustotal:** Fix `scoop-virustotal` when `--all` has been passed without app ([#5593](https://github.com/ScoopInstaller/Scoop/pull/5593))
 - **scoop-checkup:** Change the message level of helpers from ERROR to WARN ([#5549](https://github.com/ScoopInstaller/Scoop/issues/5614))
+- **scoop-search:** Improve performance for local search ([#5324](https://github.com/ScoopInstaller/Scoop/issues/5324))
 
 ### Performance Improvements
 

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -11,6 +11,11 @@ param($query)
 
 $list = [System.Collections.Generic.List[PSCustomObject]]::new()
 
+if(!$query -or $query -in @($null, '-h', '--help', '/?')) {
+    my_usage
+    exit 0
+}
+
 try {
     $query = New-Object Regex $query, 'IgnoreCase'
 } catch {

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -53,7 +53,7 @@ function search_bucket($bucket, $query) {
             $bin = bin_match $json $query
             if ($bin) {
                 $list.Add([PSCustomObject]@{
-                    Name = $_
+                    Name = $_.BaseName
                     Version = $json.Version
                     Source = $bucket
                     Binaries = $bin -join ' | '

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -54,7 +54,7 @@ function search_bucket($bucket, $query) {
             $bin = bin_match $json $query
             if ($bin) {
                 $list.Add([PSCustomObject]@{
-                    Name = $_.BaseName
+                    Name = $name
                     Version = $json.Version
                     Source = $bucket
                     Binaries = $bin -join ' | '

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -44,7 +44,7 @@ function search_bucket($bucket, $query) {
 
         if($app.name -match $query) {
             $list.Add([PSCustomObject]@{
-                Name = $_
+                Name = $_.BaseName
                 Version = $json.Version
                 Source = $bucket
                 Binaries = ""

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -40,7 +40,7 @@ function search_bucket($bucket, $query) {
     $apps = Get-ChildItem (Find-BucketDirectory $bucket) -Filter '*.json' -Recurse
 
     $apps | ForEach-Object {
-        $json = [System.IO.File]::ReadAllText("$bucket_dir\$_.json") | ConvertFrom-Json -ErrorAction Continue
+        $json = [System.IO.File]::ReadAllText($_.FullName) | ConvertFrom-Json -ErrorAction Continue
 
         if($app.name -match $query) {
             $list.Add([PSCustomObject]@{

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -78,8 +78,8 @@ function search_bucket($bucket, $query) {
                 Binaries = ""
             })
         } else {
-            $bin = bin_match $manifest $query
-            # $bin = bin_match_json $json $query
+            # $bin = bin_match $manifest $query
+            $bin = bin_match_json $json $query
             if ($bin) {
                 $list.Add([PSCustomObject]@{
                     Name = $name

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -37,8 +37,7 @@ function bin_match($manifest, $query) {
 }
 
 function search_bucket($bucket, $query) {
-    $bucket_dir = Find-BucketDirectory $bucket
-    $apps = apps_in_bucket $bucket_dir
+    $apps = Get-ChildItem (Find-BucketDirectory $bucket) -Filter '*.json' -Recurse
 
     $apps | ForEach-Object {
         $json = [System.IO.File]::ReadAllText("$bucket_dir\$_.json") | ConvertFrom-Json -ErrorAction Continue

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -50,7 +50,7 @@ function bin_match_json($json, $query) {
             } elseif ($subbin.ValueKind -eq [System.Text.Json.JsonValueKind]::Array) {
                 if([System.IO.Path]::GetFileNameWithoutExtension($subbin[0]) -match $query) {
                     $bins += [System.IO.Path]::GetFileName($subbin[0])
-                } elseif ($subbin.GetArrayLength() -gt 2 -and $subbin[1] -match $query) {
+                } elseif ($subbin.GetArrayLength() -ge 2 -and $subbin[1] -match $query) {
                     $bins += $subbin[1]
                 }
             }

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -11,11 +11,6 @@ param($query)
 
 $list = [System.Collections.Generic.List[PSCustomObject]]::new()
 
-if(!$query -or $query -in @($null, '-h', '--help', '/?')) {
-    my_usage
-    exit 0
-}
-
 try {
     $query = New-Object Regex $query, 'IgnoreCase'
 } catch {

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -175,8 +175,10 @@ function search_remotes($query) {
     $remote_list
 }
 
+$jsonTextAvailable = [System.AppDomain]::CurrentDomain.GetAssemblies() | Where-object { [System.IO.Path]::GetFileNameWithoutExtension($_.Location) -eq "System.Text.Json" }
+
 Get-LocalBucket | ForEach-Object {
-    if ($PSVersionTable.PSVersion.Major -ge 7) {
+    if ($jsonTextAvailable) {
         search_bucket $_ $query
     } else {
         search_bucket_legacy $_ $query

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -41,10 +41,11 @@ function search_bucket($bucket, $query) {
 
     $apps | ForEach-Object {
         $json = [System.IO.File]::ReadAllText($_.FullName) | ConvertFrom-Json -ErrorAction Continue
+        $name = $_.BaseName
 
-        if($app.name -match $query) {
+        if ($name -match $query) {
             $list.Add([PSCustomObject]@{
-                Name = $_.BaseName
+                Name = $name
                 Version = $json.Version
                 Source = $bucket
                 Binaries = ""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
This is another attempt to improve the local search performance.
- Not using the `manifest()` function
- Use only one loop over `$apps`
- Push results to `$list` directly
- Use `[System.IO.File]::ReadAllText()` instead of `Get-Content`

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #4239
<!-- or -->
Relates to #4818

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
```pwsh
Measure-Command { scoop search telegram }
Measure-Command { .\bin\scoop.ps1 search telegram }
```

![image](https://user-images.githubusercontent.com/432127/211041968-f5af0a6f-e094-4dfd-846a-2b8d6d6e100d.png)


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
