### PR TITLE
fix(shim): Check literal path in `Get-ShimPath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - **scoop-checkup:** Change the message level of helpers from ERROR to WARN ([#5549](https://github.com/ScoopInstaller/Scoop/issues/5614))
 - **scoop-(un)hold:** Correct output the messages when manifest not found, (already|not) held ([#5519](https://github.com/ScoopInstaller/Scoop/issues/5519))
 - **scoop-update:** Change error message to a better instruction ([#5677](https://github.com/ScoopInstaller/Scoop/issues/5677))
+- **shim:** Check literal path in `Get-ShimPath` ([#5680](https://github.com/ScoopInstaller/Scoop/issues/5680))
 
 ### Performance Improvements
 

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -82,7 +82,7 @@ function Get-ShimInfo($ShimPath) {
 function Get-ShimPath($ShimName, $Global) {
     '.shim', '.ps1' | ForEach-Object {
         $shimPath = Join-Path (shimdir $Global) "$ShimName$_"
-        if (Test-Path $shimPath) {
+        if (Test-Path -LiteralPath $shimPath) {
             return $shimPath
         }
     }


### PR DESCRIPTION
### Description

A run of `scoop shim info scoo*` shows this:

```
Name     : scoo*
Path     : <SCOOP_ROOT>\shims\scoo*.ps1
Source   : scoop
Type     : ExternalScript
IsGlobal : False
IsHidden : True
```

Related code:

https://github.com/ScoopInstaller/Scoop/blob/f93028001fbe5c78cc41f59e3814d2ac8e595724/libexec/scoop-shim.ps1#L82-L89

A name containing wildcard characters (e.g., `*`) is directly passed to `Get-ShimPath` here and the returned path still contains wildcard characters.

This is not expected according to the usage of `scoop shim info <shim_name>`. No characters should be interpreted as wildcard characters here.

### Motivation and Context

Fix the bug.

### How Has This Been Tested?

Run:

```powershell
scoop shim info scoo*
scoop shim info scoo* -g
```

Output:

```
ERROR: Local shim not found: scoo*
ERROR: Global shim not found: scoo*
```

### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
