### PR TITLE
fix(shim): Avoid unexpected output of `list` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - **scoop-checkup:** Change the message level of helpers from ERROR to WARN ([#5549](https://github.com/ScoopInstaller/Scoop/issues/5614))
 - **scoop-(un)hold:** Correct output the messages when manifest not found, (already|not) held ([#5519](https://github.com/ScoopInstaller/Scoop/issues/5519))
 - **scoop-update:** Change error message to a better instruction ([#5677](https://github.com/ScoopInstaller/Scoop/issues/5677))
+- **shim:** Avoid unexpected output of `list` subcommand ([#5681](https://github.com/ScoopInstaller/Scoop/issues/5681))
 
 ### Performance Improvements
 

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -12,7 +12,7 @@
 #
 # To list all shims or matching shims, use the 'list' subcommand:
 #
-#     scoop shim list [<shim_name>/<regex_pattern>...]
+#     scoop shim list [<regex_pattern>...]
 #
 # To show a shim's information, use the 'info' subcommand:
 #

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -12,7 +12,7 @@
 #
 # To list all shims or matching shims, use the 'list' subcommand:
 #
-#     scoop shim list [<shim_name>/<pattern>...]
+#     scoop shim list [<shim_name>/<regex_pattern>...]
 #
 # To show a shim's information, use the 'info' subcommand:
 #
@@ -144,7 +144,7 @@ switch ($SubCommand) {
         $other | ForEach-Object {
             try {
                 $pattern = $_
-                [Regex]::New($pattern)
+                [void][Regex]::New($pattern)
             } catch {
                 Write-Host "ERROR: Invalid pattern: " -ForegroundColor Red -NoNewline
                 Write-Host $pattern -ForegroundColor Magenta


### PR DESCRIPTION
### Description

Related: #5568. See my [comment](https://github.com/ScoopInstaller/Scoop/issues/5568#issuecomment-1752724083).

The usage of `scoop shim list` should be more explicit: `scoop shim list [<shim_name>/<regex_pattern>...]`, since regular expression matching is used in this case.

### Motivation and Context

Closes #5568.

### How Has This Been Tested?

Run:

```powershell
scoop shim list scoo*
```

Output:

```
Name       Source   Alternatives IsGlobal IsHidden
----       ------   ------------ -------- --------
scoop-slim External              False    False
scoop      scoop                 False    False
```

### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
