### PR TITLE
fix: do not call `scoop` externally from inside the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - **scoop-update:** Change error message to a better instruction ([#5677](https://github.com/ScoopInstaller/Scoop/issues/5677))
 - **shim:** Check literal path in `Get-ShimPath` ([#5680](https://github.com/ScoopInstaller/Scoop/issues/5680))
 - **shim:** Avoid unexpected output of `list` subcommand ([#5681](https://github.com/ScoopInstaller/Scoop/issues/5681))
-- **scoop** Do not call `scoop` externally from inside the code ([#5695](https://github.com/ScoopInstaller/Scoop/issues/5695))
+- **scoop:** Do not call `scoop` externally from inside the code ([#5695](https://github.com/ScoopInstaller/Scoop/issues/5695))
 
 ### Performance Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - **scoop-update:** Change error message to a better instruction ([#5677](https://github.com/ScoopInstaller/Scoop/issues/5677))
 - **shim:** Check literal path in `Get-ShimPath` ([#5680](https://github.com/ScoopInstaller/Scoop/issues/5680))
 - **shim:** Avoid unexpected output of `list` subcommand ([#5681](https://github.com/ScoopInstaller/Scoop/issues/5681))
+- **scoop** Do not call `scoop` externally from inside the code ([#5695](https://github.com/ScoopInstaller/Scoop/issues/5695))
 
 ### Performance Improvements
 

--- a/libexec/scoop-create.ps1
+++ b/libexec/scoop-create.ps1
@@ -59,7 +59,7 @@ function choose_item($list, $query) {
 }
 
 if (!$url) {
-    scoop help create
+    & "$PSScriptRoot\scoop-help.ps1" create
 } else {
     create_manifest $url
 }

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -43,7 +43,7 @@ if (is_scoop_outdated) {
     if ($opt.u -or $opt.'no-update-scoop') {
         warn "Scoop is out of date."
     } else {
-        scoop update
+        & "$PSScriptRoot\scoop-update.ps1"
     }
 }
 

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -56,7 +56,7 @@ if (is_scoop_outdated) {
     if ($opt.u -or $opt.'no-update-scoop') {
         warn "Scoop is out of date."
     } else {
-        scoop update
+        & "$PSScriptRoot\scoop-update.ps1"
     }
 }
 

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -43,7 +43,7 @@ if (is_scoop_outdated) {
     if ($opt.u -or $opt.'no-update-scoop') {
         warn 'Scoop is out of date.'
     } else {
-        scoop update
+        & "$PSScriptRoot\scoop-update.ps1"
     }
 }
 


### PR DESCRIPTION
#### Description
Call `scoop` internally instead of calling it externally from inside the code.

#### Motivation and Context
Overall, calling "myself" externally, it is bad practice, unless there is a good reason for doing it.  

Closes #5694

#### How Has This Been Tested?
```
> scoop create
Usage: scoop create <url>

Create your own custom app manifest

> scoop install make
WARN  Skipping self-update of Scoop Core until 12/31/2023 00:00:00...
WARN  If you want to update Scoop Core immediately, use 'scoop unhold scoop; scoop update'.
Updating Buckets...
Scoop was updated successfully!
Installing 'make' (4.4.1) [64bit] from main bucket
Loading make-4.4.1-without-guile-w32-bin.zip from cache
Checking hash of make-4.4.1-without-guile-w32-bin.zip ... ok.
Extracting make-4.4.1-without-guile-w32-bin.zip ... done.
Linking C:\codew\scoop\apps\make\current => C:\codew\scoop\apps\make\4.4.1
Creating shim for 'make'.
'make' (4.4.1) was installed successfully!

```
#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
