### PR TITLE
Removing persistent data after uninstall app(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/installer/tmp/*
 test/tmp/*
 *~
 TestResults.xml
+.vscode

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1203,6 +1203,33 @@ function unlink_persist_data($manifest, $dir) {
     }
 }
 
+Function Remove-PersistentData {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [string]$App,
+        $Global
+    )
+
+    $Status = Get-AppStatus -App $App -Global:$Global
+    $App = $Status.App;
+
+    if (!$Status.Installed) {
+        # remove persistend data if app not installed
+        Write-Host 'Removing persisted data.'
+        $persistDir = persistdir $App $Global
+
+        if (Test-Path $persistDir) {
+            try {
+                Remove-Item $persistDir -Recurse -Force -ErrorAction Stop
+            } catch {
+                error "Couldn't remove '$(friendly_path $persistDir)'; it may be in use."
+                continue
+            }
+        }
+    }
+}
+
+
 # check whether write permission for Users usergroup is set to global persist dir, if not then set
 function persist_permission($manifest, $global) {
     if($global -and $manifest.persist -and (is_admin)) {


### PR DESCRIPTION
#### Description
Made some adjustments:

- Check if app is installed before removing persistent data (`Get-AppStatus`; only apps that aren't installed get removed)
   - I think think was already the case cause there  was a `continue app_loop` and a `throw` when the app couldn't get deleted
- But the uninstall check was necessary for the `cleanup`-function to be safe.
    - Cleanup persistent data of not yet deleted apps seems vary bad (tested with Brave; it didn't start, or showed it any errors)
- `cleanup`-function now needs named params
- When no installed apps are found, but the `-p` flag exists, then we are still looping trough the $apps to removing persistent data

#### Motivation and Context
Closes #5630 

#### How Has This Been Tested?
``` sh
# Case 1
scoop install brave
scoop uninstall brave
scoop uninstall brave -p

# Case 2.a
scoop install brave
scoop cleanup brave -p # this will not remove the persistent data, 'bc it is still installed
scoop uninstall brave
scoop cleanup brave -p # persistent data is removed

# Case 2.b
scoop install brave
scoop uninstall brave
scoop cleanup * -p  # persistent data is removed of ALL uninstalled apps

```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
