### PR TITLE
feat(core): New cache filename format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - **scoop-search:** Use SQLite for caching apps to speed up local search ([#5851](https://github.com/ScoopInstaller/Scoop/issues/5851), [#5918](https://github.com/ScoopInstaller/Scoop/issues/5918))
+- **core:** New cache filename format ([#5929](https://github.com/ScoopInstaller/Scoop/issues/5929)
 
 ### Bug Fixes
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -419,7 +419,7 @@ function cache_path($app, $version, $url) {
     }
 
     $urlStream = [System.IO.MemoryStream]::new([System.Text.Encoding]::UTF8.GetBytes($url))
-    $sha = (Get-FileHash -Algorithm SHA1 -InputStream $urlStream).Hash.ToLower()
+    $sha = (Get-FileHash -Algorithm SHA256 -InputStream $urlStream).Hash.ToLower().Substring(0, 7)
     $extension = [System.IO.Path]::GetExtension($url)
     $filePath = $filePath -replace "$underscoredUrl", "$sha$extension"
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -413,7 +413,7 @@ function cache_path($app, $version, $url) {
     $underscoredUrl = $url -replace '[^\w\.\-]+', '_'
     $filePath = "$cachedir\$app#$version#$underscoredUrl"
 
-    # NOTE: Scoop cache files migration. Remove this 6 months after it ships.
+    # NOTE: Scoop cache files migration. Remove this 6 months after the feature ships.
     if (Test-Path $filePath) {
         return $filePath
     }

--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -16,7 +16,7 @@ param($cmd)
 
 function cacheinfo($file) {
     $app, $version, $url = $file.Name -split '#'
-    New-Object PSObject -Property @{ Name = $app; Version = $version; Length = $file.Length; URL = $url }
+    New-Object PSObject -Property @{ Name = $app; Version = $version; Length = $file.Length }
 }
 
 function cacheshow($app) {
@@ -28,7 +28,7 @@ function cacheshow($app) {
     $files = @(Get-ChildItem $cachedir | Where-Object -Property Name -Value "^$app#" -Match)
     $totalLength = ($files | Measure-Object -Property Length -Sum).Sum
 
-    $files | ForEach-Object { cacheinfo $_ } | Select-Object Name, Version, Length, URL
+    $files | ForEach-Object { cacheinfo $_ } | Select-Object Name, Version, Length
 
     Write-Host "Total: $($files.Length) $(pluralize $files.Length 'file' 'files'), $(filesize $totalLength)" -ForegroundColor Yellow
 }

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -270,8 +270,7 @@ Describe 'cache_path' -Tag 'Scoop' {
 
     # # NOTE: Remove this 6 months after the feature ships.
     It 'returns the old format cache path for a given input' {
-        $fixture = "$cachedir\git#2.44.0#https_example.com_git.zip"
-        New-Item -ItemType File -Path $fixture -Force
+        Mock Test-Path { $true }
         $ret = cache_path 'git' '2.44.0' 'https://example.com/git.zip'
         $ret | Should -Be $fixture
         Remove-Item -Path $fixture -Force

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -268,7 +268,7 @@ Describe 'cache_path' -Tag 'Scoop' {
         $url = 'https://example.com/git.zip'
         $ret = cache_path 'git' '2.44.0' $url
         $inputStream = [System.IO.MemoryStream]::new([System.Text.Encoding]::UTF8.GetBytes($url))
-        $sha = (Get-FileHash -Algorithm SHA1 -InputStream $inputStream).Hash.ToLower()
+        $sha = (Get-FileHash -Algorithm SHA256 -InputStream $inputStream).Hash.ToLower().Substring(0, 7)
         $ret | Should -Be "$cachedir\git#2.44.0#$sha.zip"
     }
 

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -260,10 +260,6 @@ Describe 'get_app_name_from_shim' -Tag 'Scoop', 'Windows' {
 }
 
 Describe 'cache_path' -Tag 'Scoop' {
-    BeforeAll {
-        $cachedir = "$([IO.Path]::GetTempPath())ScoopTestFixtures\cache"
-    }
-
     It 'returns the correct cache path for a given input' {
         $url = 'https://example.com/git.zip'
         $ret = cache_path 'git' '2.44.0' $url

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -272,8 +272,7 @@ Describe 'cache_path' -Tag 'Scoop' {
     It 'returns the old format cache path for a given input' {
         Mock Test-Path { $true }
         $ret = cache_path 'git' '2.44.0' 'https://example.com/git.zip'
-        $ret | Should -Be $fixture
-        Remove-Item -Path $fixture -Force
+        $ret | Should -Be "$cachedir\git#2.44.0#https_example.com_git.zip"
     }
 }
 

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -259,6 +259,29 @@ Describe 'get_app_name_from_shim' -Tag 'Scoop', 'Windows' {
     }
 }
 
+Describe 'cache_path' -Tag 'Scoop' {
+    BeforeAll {
+        $cachedir = "$([IO.Path]::GetTempPath())ScoopTestFixtures\cache"
+    }
+
+    It 'returns the correct cache path for a given input' {
+        $url = 'https://example.com/git.zip'
+        $ret = cache_path 'git' '2.44.0' $url
+        $inputStream = [System.IO.MemoryStream]::new([System.Text.Encoding]::UTF8.GetBytes($url))
+        $sha = (Get-FileHash -Algorithm SHA1 -InputStream $inputStream).Hash.ToLower()
+        $ret | Should -Be "$cachedir\git#2.44.0#$sha.zip"
+    }
+
+    # # NOTE: Remove this 6 months after the feature ships.
+    It 'returns the old format cache path for a given input' {
+        $fixture = "$cachedir\git#2.44.0#https_example.com_git.zip"
+        New-Item -ItemType File -Path $fixture -Force
+        $ret = cache_path 'git' '2.44.0' 'https://example.com/git.zip'
+        $ret | Should -Be $fixture
+        Remove-Item -Path $fixture -Force
+    }
+}
+
 Describe 'sanitary_path' -Tag 'Scoop' {
     It 'removes invalid path characters from a string' {
         $path = 'test?.json'


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail -->
Replaces #4349, with sha1 for shorter output. For a better migration experience and implicit bandwidth saving, old cache files will still be used when available but this check may be removed sometime in the future.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #4327
Closes #4349

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

unit tests added

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
