### PR TITLE
fix(scoop-search): Catch error of parsing invalid manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 
 - **json:** Serialize jsonpath return ([#5921](https://github.com/ScoopInstaller/Scoop/issues/5921))
+- **scoop-search:** Catch error of parsing invalid manifest ([#5930](https://github.com/ScoopInstaller/Scoop/issues/5930))
 
 ## [v0.4.1](https://github.com/ScoopInstaller/Scoop/compare/v0.4.0...v0.4.1) - 2024-04-25
 

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -61,7 +61,15 @@ function search_bucket($bucket, $query) {
     $apps = Get-ChildItem (Find-BucketDirectory $bucket) -Filter '*.json' -Recurse
 
     $apps | ForEach-Object {
-        $json = [System.Text.Json.JsonDocument]::Parse([System.IO.File]::ReadAllText($_.FullName))
+        $filepath = $_.FullName
+
+        $json = try {
+            [System.Text.Json.JsonDocument]::Parse([System.IO.File]::ReadAllText($filepath))
+        } catch {
+            debug "Failed to parse manifest file: $filepath (error: $_)"
+            return
+        }
+
         $name = $_.BaseName
 
         if ($name -match $query) {


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail -->

Catch error of parsing invalid manifest

before:
```pwsh
MethodInvocationException: <path_to_scoop>\apps\scoop\current\libexec\scoop-search.ps1:64
Line |
  64 |          $json = [System.Text.Json.JsonDocument]::Parse([System.IO.Fil …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "Parse" with "1" argument(s): "The input does not contain any JSON tokens.
     | Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 |
     | BytePositionInLine: 0."
```

after:

No error thrown, also the invalid manifest can be troubleshooted when turning on debug mode.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #XXXX
<!-- or -->
Relates to #XXXX

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
