### PR TITLE
fix(system): `$dir` parameter passing to `Split-PathLikeEnvVar` at `strip_path` with `-Pattern` switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - **json:** Serialize jsonpath return ([#5921](https://github.com/ScoopInstaller/Scoop/issues/5921))
 - **scoop-search:** Catch error of parsing invalid manifest ([#5930](https://github.com/ScoopInstaller/Scoop/issues/5930))
 - **autoupdate:** Copy `PSCustomObject`-type properties within `autoupdate` to prevent reference changes ([#5934](https://github.com/ScoopInstaller/Scoop/issues/5934))
-- **system:** Fix `$dir` parameter passing to `Split-PathLikeEnvVar` at `strip_path` with `-Pattern` switch ([#5936](https://github.com/ScoopInstaller/Scoop/issues/5936))
+- **system:** Fix argument passing to `Split-PathLikeEnvVar()` in deprecated `strip_path()` ([#5937](https://github.com/ScoopInstaller/Scoop/issues/5937))
 
 ## [v0.4.1](https://github.com/ScoopInstaller/Scoop/compare/v0.4.0...v0.4.1) - 2024-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **json:** Serialize jsonpath return ([#5921](https://github.com/ScoopInstaller/Scoop/issues/5921))
 - **scoop-search:** Catch error of parsing invalid manifest ([#5930](https://github.com/ScoopInstaller/Scoop/issues/5930))
 - **autoupdate:** Copy `PSCustomObject`-type properties within `autoupdate` to prevent reference changes ([#5934](https://github.com/ScoopInstaller/Scoop/issues/5934))
+- **system:** Fix `$dir` parameter passing to `Split-PathLikeEnvVar` at `strip_path` with `-Pattern` switch ([#5936](https://github.com/ScoopInstaller/Scoop/issues/5936))
 
 ## [v0.4.1](https://github.com/ScoopInstaller/Scoop/compare/v0.4.0...v0.4.1) - 2024-04-25
 

--- a/lib/system.ps1
+++ b/lib/system.ps1
@@ -162,10 +162,7 @@ function env($name, $global, $val) {
 
 function strip_path($orig_path, $dir) {
     Show-DeprecatedWarning $MyInvocation 'Split-PathLikeEnvVar'
-    if ($dir -is [string]) {
-        $dir = @($dir)
-    }
-    Split-PathLikeEnvVar -Pattern $dir -Path $orig_path
+    Split-PathLikeEnvVar -Pattern @($dir) -Path $orig_path
 }
 
 function add_first_in_path($dir, $global) {

--- a/lib/system.ps1
+++ b/lib/system.ps1
@@ -162,7 +162,10 @@ function env($name, $global, $val) {
 
 function strip_path($orig_path, $dir) {
     Show-DeprecatedWarning $MyInvocation 'Split-PathLikeEnvVar'
-    Split-PathLikeEnvVar -Name $dir -Path $orig_path
+    if ($dir -is [string]) {
+        $dir = @($dir)
+    }
+    Split-PathLikeEnvVar -Pattern $dir -Path $orig_path
 }
 
 function add_first_in_path($dir, $global) {


### PR DESCRIPTION
#### Description
Correct parameter's name, `-Name` to `-Pattern`. Corresponds to the new parameter name -Pattern for the `Split-PathLikeEnvVar` function.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Function `Test-PathLikeEnvVar` is changed to `Split-PathLikeEnvVar` recently, which also updated to provide `-Pattern` parameter with string array type to the function. But `strip_path`, which is now deprecated function and implemented to invoke warning and `Split-PathLikeEnvVar` function with `$dir` and `$orig_path` parameters, is still passing `$dir` parameter as `-Name` to the newer function. So `$Pattern` has `$null` value and causes null-valued expression error.

![error](https://github.com/ScoopInstaller/Scoop/assets/16485236/9b88248c-4f37-4ae8-8e90-b0cbd52a04ea)

As we can see, the function could not receive the value to `$Pattern` correctly.


The error was that:
```powershell
WARN  "env" will be deprecated. Please change your code/manifest to use "Get-EnvVar"
      -> :4:38
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :4:26
InvalidOperation: C:\Users\[redacted]\scoop\apps\scoop\current\lib\system.ps1:85
Line |
  85 |          $splitPattern = $Pattern.Split(';', [System.StringSplitOption …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
```

I discovered this issue when I invoked `scoop update *` to try to update SDL2, null-valued expression errors were occurred.

I fixed `split_path` function to pass the parameter as `-Pattern` correctly. Moreover, add casting related code, that's because `Split-PathLikeEnvVar` requires `$Pattern` as a string array, not a single string, It would be better to explicitly change `$dir` to an array.

I believe that we can troubleshoot this problem by updating `strip_path` function for now, we should also update manifests not to use deprecated functions like this ultimately.

Before:
```powershell
function strip_path($orig_path, $dir) {
    Show-DeprecatedWarning $MyInvocation 'Split-PathLikeEnvVar'
    Split-PathLikeEnvVar -Name $dir -Path $orig_path
}
```

After:
```powershell
function strip_path($orig_path, $dir) {
    Show-DeprecatedWarning $MyInvocation 'Split-PathLikeEnvVar'
    if ($dir -is [string]) {
        $dir = @($dir)
    }
    Split-PathLikeEnvVar -Pattern $dir -Path $orig_path
}
```

<!-- If it fixes an open issue, please link to the issue here. -->
* Closes #5936
* And relates to ScoopInstaller/Extras#13212

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on both Windows 10 (22H2) and Windows 11(23H2)

* Before:
```powershelll
PowerShell 7.4.2
Loading personal and system profiles took 828ms.
PS> scoop install extras/sdl2
Installing 'sdl2' (2.30.3) [64bit] from 'extras' bucket
Loading SDL2-devel-2.30.3-VC.zip from cache.
Loading SDL2-2.30.3.zip from cache.
Checking hash of SDL2-devel-2.30.3-VC.zip ... ok.
Checking hash of SDL2-2.30.3.zip ... ok.
Extracting SDL2-devel-2.30.3-VC.zip ... done.
Extracting SDL2-2.30.3.zip ... done.
Running installer script...
WARN  "env" will be deprecated. Please change your code/manifest to use "Get-EnvVar"
      -> :33:32
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :33:20
InvalidOperation: C:\Users\[redacted]\scoop\apps\scoop\current\lib\system.ps1:85
Line |
  85 |          $splitPattern = $Pattern.Split(';', [System.StringSplitOption …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
WARN  "env" will be deprecated. Please change your code/manifest to use "Set-EnvVar"
      -> :34:1
WARN  "env" will be deprecated. Please change your code/manifest to use "Get-EnvVar"
      -> :35:32
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :35:20
InvalidOperation: C:\Users\[redacted]\scoop\apps\scoop\current\lib\system.ps1:85
Line |
  85 |          $splitPattern = $Pattern.Split(';', [System.StringSplitOption …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
WARN  "env" will be deprecated. Please change your code/manifest to use "Set-EnvVar"
      -> :36:1
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :38:31
InvalidOperation: C:\Users\[redacted]\scoop\apps\scoop\current\lib\system.ps1:85
Line |
  85 |          $splitPattern = $Pattern.Split(';', [System.StringSplitOption …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :40:33
InvalidOperation: C:\Users\[redacted]\scoop\apps\scoop\current\lib\system.ps1:85
Line |
  85 |          $splitPattern = $Pattern.Split(';', [System.StringSplitOption …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
Linking ~\scoop\apps\sdl2\current => ~\scoop\apps\sdl2\2.30.3
'sdl2' (2.30.3) was installed successfully!

PS> scoop uninstall sdl2 --purge
Uninstalling 'sdl2' (2.30.3).
Running uninstaller script...
WARN  "env" will be deprecated. Please change your code/manifest to use "Get-EnvVar"
      -> :4:38
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :4:26
InvalidOperation: C:\Users\[redacted]\scoop\apps\scoop\current\lib\system.ps1:85
Line |
  85 |          $splitPattern = $Pattern.Split(';', [System.StringSplitOption …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
WARN  "env" will be deprecated. Please change your code/manifest to use "Get-EnvVar"
      -> :9:38
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :9:26
InvalidOperation: C:\Users\[redacted]\scoop\apps\scoop\current\lib\system.ps1:85
Line |
  85 |          $splitPattern = $Pattern.Split(';', [System.StringSplitOption …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :15:26
InvalidOperation: C:\Users\[redacted]\scoop\apps\scoop\current\lib\system.ps1:85
Line |
  85 |          $splitPattern = $Pattern.Split(';', [System.StringSplitOption …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :17:26
InvalidOperation: C:\Users\[redacted]\scoop\apps\scoop\current\lib\system.ps1:85
Line |
  85 |          $splitPattern = $Pattern.Split(';', [System.StringSplitOption …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
Unlinking ~\scoop\apps\sdl2\current
Removing persisted data.
'sdl2' was uninstalled.
```

* After my fix:
```powershell
PS C:\Users\[redacted]> scoop install sdl2
Installing 'sdl2' (2.30.3) [64bit] from 'extras' bucket
Loading SDL2-devel-2.30.3-VC.zip from cache
Checking hash of SDL2-devel-2.30.3-VC.zip ... ok.
Loading SDL2-2.30.3.zip from cache
Checking hash of SDL2-2.30.3.zip ... ok.
Extracting SDL2-devel-2.30.3-VC.zip ... done.
Extracting SDL2-2.30.3.zip ... done.
Running installer script...
WARN  "env" will be deprecated. Please change your code/manifest to use "Get-EnvVar"
      -> :33:32
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :33:20
WARN  "env" will be deprecated. Please change your code/manifest to use "Set-EnvVar"
      -> :34:1
WARN  "env" will be deprecated. Please change your code/manifest to use "Get-EnvVar"
      -> :35:32
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :35:20
WARN  "env" will be deprecated. Please change your code/manifest to use "Set-EnvVar"
      -> :36:1
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :38:31
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :40:33
Linking ~\scoop\apps\sdl2\current => ~\scoop\apps\sdl2\2.30.3
'sdl2' (2.30.3) was installed successfully!
PS C:\Users\[redacted]> scoop uninstall sdl2 --purge
Uninstalling 'sdl2' (2.30.3).
Running uninstaller script...
WARN  "env" will be deprecated. Please change your code/manifest to use "Get-EnvVar"
      -> :4:38
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :4:26
Removing ~\scoop\apps\sdl2\current\lib\pkgconfig from your path.
WARN  "env" will be deprecated. Please change your code/manifest to use "Set-EnvVar"
      -> :7:5
WARN  "env" will be deprecated. Please change your code/manifest to use "Get-EnvVar"
      -> :9:38
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :9:26
Removing ~\scoop\apps\sdl2\current from your path.
WARN  "env" will be deprecated. Please change your code/manifest to use "Set-EnvVar"
      -> :12:5
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :15:26
WARN  "strip_path" will be deprecated. Please change your code/manifest to use "Split-PathLikeEnvVar"
      -> :17:26
Unlinking ~\scoop\apps\sdl2\current
Removing persisted data.
'sdl2' was uninstalled.
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
