### PR TITLE
fix(decompress): Match `extract_dir`/`extract_to` and archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **scoop-download|install|update:** Use consistent options ([#5956](https://github.com/ScoopInstaller/Scoop/issues/5956))
 - **core:** Fix "Invoke-ExternalCommand" quoting rules ([#5945](https://github.com/ScoopInstaller/Scoop/issues/5945))
 - **scoop-info:** Fix download size estimating ([#5958](https://github.com/ScoopInstaller/Scoop/issues/5958))
+- **decompress:** Match `extract_dir`/`extract_to` and archives ([#5983](https://github.com/ScoopInstaller/Scoop/issues/5983))
 
 ### Code Refactoring
 


### PR DESCRIPTION
### Description

This PR is to fix a regression introduced in the refactoring of #5951 which broke the match between entries of `extract_dir`/`extract_to` lists and files that require unpacking:

https://github.com/ScoopInstaller/Scoop/blob/a5bd2297c6227e5b09869acafaa12cbdc73f6132/lib/decompress.ps1#L22-L26

The directories specified by `extract_dir`/`extract_to` fields in an app manifest are only meaningful for download files that require unpacking, if a download URL of an unpacking-free file is placed before those of archive files, the latter will not be unpacked from/to the specified paths.

### How Has This Been Tested?

Tested by running:

```powershell
scoop install 'https://raw.githubusercontent.com/lewis-yeung/scoop-bucket/a9b9df6f918995d3c6f1323a6133b20a0d7b4c6d/bucket/oh-my-posh.json'
```

It works properly after the fix.

### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
