### PR TITLE
added the ability to specify @ version when installing from url

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1192,7 +1192,7 @@ function applist($apps, $global) {
 }
 
 function parse_app([string]$app) {
-    if ($app -match '^(?:(?<bucket>[a-zA-Z0-9-_.]+)/)?(?<app>.*\.json$|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?$') {
+    if ($app -match '^(?:(?<bucket>[a-zA-Z0-9-_.]+)/)?(?<app>.*\.json|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?$') {
         return $Matches['app'], $Matches['bucket'], $Matches['version']
     } else {
         return $app, $null, $null


### PR DESCRIPTION
added the ability to use the @ symbol when using `scoop install` with a url

#### Description
<!-- Describe your changes in detail -->

Simple change to the regex that matches the name of the app to not require the whole string to be ending with .json

fixes #5977 

This has been tested with all installation methods that have been mentioned in the `scoop install --help` 

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the b all install methods oxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
