### PR TITLE
fix(core): Search for Git executable instead of any cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **scoop-info:** Fix download size estimating ([#5958](https://github.com/ScoopInstaller/Scoop/issues/5958))
 - **decompress:** Match `extract_dir`/`extract_to` and archives ([#5983](https://github.com/ScoopInstaller/Scoop/issues/5983))
 - **checkver:** Correct variable 'regex' to 'regexp' ([#5993](https://github.com/ScoopInstaller/Scoop/issues/5993))
+- **core:** Search for Git executable instead of any cmdlet ([#5979](https://github.com/ScoopInstaller/Scoop/pull/5979))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - **scoop-info:** Fix download size estimating ([#5958](https://github.com/ScoopInstaller/Scoop/issues/5958))
 - **decompress:** Match `extract_dir`/`extract_to` and archives ([#5983](https://github.com/ScoopInstaller/Scoop/issues/5983))
 - **checkver:** Correct variable 'regex' to 'regexp' ([#5993](https://github.com/ScoopInstaller/Scoop/issues/5993))
-- **core:** Search for Git executable instead of any cmdlet ([#5979](https://github.com/ScoopInstaller/Scoop/pull/5979))
+- **core:** Search for Git executable instead of any cmdlet ([#5998](https://github.com/ScoopInstaller/Scoop/pull/5998))
 
 ### Code Refactoring
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -512,7 +512,7 @@ function Get-HelperPath {
                 if ($internalgit) {
                     $HelperPath = $internalgit
                 } else {
-                    $HelperPath = (Get-Command git -ErrorAction Ignore).Source
+                    $HelperPath = (Get-Command git -CommandType Application -ErrorAction Ignore).Source
                 }
             }
             '7zip' { $HelperPath = Get-AppFilePath '7zip' '7z.exe' }


### PR DESCRIPTION
#5979

#### Motivation and Context

Before this commit, if a user had a custom alias or function for `git` specified in their PowerShell profile, `Get-HelperPath` would return path to the PowerShell module where the function is defined instead of path to the actual Git binary.

#### How Has This Been Tested?

Tested interactively, the code seems reasonably obvious to me. To test the fix, run the following snippet:

```powershell
New-Module -Script {function git {}}
scoop update
```
Without this PR, the invocation results in the folowing error:
```
> scoop update
&: D:\_custom\scoop\app\apps\scoop\current\lib\core.ps1:273
Line |
 273 |          return & $git @ArgumentList
     |                   ~~~~
     | The term '__DynamicModule_cbe178d9-14c2-494d-8004-fbdc292d59d2' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling of the name, or if a path was
     | included, verify that the path is correct and try again.
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [-] I have updated the documentation accordingly.
- [-] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
