### PR TITLE
fix(checkver): Correct error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **core:** Search for Git executable instead of any cmdlet ([#5998](https://github.com/ScoopInstaller/Scoop/issues/5998))
 - **core:** Use correct path in 'bash' ([#6006](https://github.com/ScoopInstaller/Scoop/issues/6006))
 - **core:** Limit the number of commands to get when search for git executable ([#6013](https://github.com/ScoopInstaller/Scoop/pull/6013))
+- **checkver:** Correct error messages ([#6024](https://github.com/ScoopInstaller/Scoop/issues/6024))
 
 ### Code Refactoring
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -294,8 +294,10 @@ while ($in_progress -gt 0) {
             }
             $page = (New-Object System.IO.StreamReader($ms, (Get-Encoding $wc))).ReadToEnd()
         }
+        $source = $url
         if ($script) {
             $page = Invoke-Command ([scriptblock]::Create($script -join "`r`n"))
+            $source = 'the output of script'
         }
 
         if ($jsonpath) {
@@ -310,7 +312,7 @@ while ($in_progress -gt 0) {
                 $ver = json_path_legacy $page $jsonpath
             }
             if (!$ver) {
-                next "couldn't find '$jsonpath' in $url"
+                next "couldn't find '$jsonpath' in $source"
                 continue
             }
         }
@@ -332,7 +334,7 @@ while ($in_progress -gt 0) {
             # Getting version from XML, using XPath
             $ver = $xml.SelectSingleNode($xpath, $nsmgr).'#text'
             if (!$ver) {
-                next "couldn't find '$($xpath -replace 'ns:', '')' in $url"
+                next "couldn't find '$($xpath -replace 'ns:', '')' in $source"
                 continue
             }
         }
@@ -366,13 +368,13 @@ while ($in_progress -gt 0) {
                     $ver = $matchesHashtable['version']
                 }
             } else {
-                next "couldn't match '$regexp' in $url"
+                next "couldn't match '$regexp' in $source"
                 continue
             }
         }
 
         if (!$ver) {
-            next "couldn't find new version in $url"
+            next "couldn't find new version in $source"
             continue
         }
     }


### PR DESCRIPTION
### Description

When checking update and the `$script` is used, an error message should mention `the output of script` instead of `$url`.

### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
