### PR TITLE
Option to not add shortcuts to startmenu when installing a package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **core:** New cache filename format ([#5929](https://github.com/ScoopInstaller/Scoop/issues/5929))
 - **install:** Added the ability to install specific version of app from URL/file link ([#5988](https://github.com/ScoopInstaller/Scoop/issues/5988))
 - **decompress:** Use innounp-unicode as default Inno Setup Unpacker ([#6028](https://github.com/ScoopInstaller/Scoop/issues/6028))
+- **scoop-install** Option to not add shortcuts to startmenu when installing a package
 
 ### Bug Fixes
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -5,7 +5,7 @@ function nightly_version($quiet = $false) {
     return "nightly-$(Get-Date -Format 'yyyyMMdd')"
 }
 
-function install_app($app, $architecture, $global, $suggested, $use_cache = $true, $check_hash = $true) {
+function install_app($app, $architecture, $global, $suggested, $use_cache = $true, $check_hash = $true, $add_startmenu = $true) {
     $app, $manifest, $bucket, $url = Get-Manifest $app
 
     if (!$manifest) {
@@ -57,7 +57,9 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     ensure_install_dir_not_in_path $dir $global
     $dir = link_current $dir
     create_shims $manifest $dir $global $architecture
-    create_startmenu_shortcuts $manifest $dir $global $architecture
+    if ($add_startmenu) {
+        create_startmenu_shortcuts $manifest $dir $global $architecture
+    }
     install_psmodule $manifest $dir $global
     env_add_path $manifest $dir $global $architecture
     env_set $manifest $dir $global $architecture

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -24,6 +24,7 @@
 #   -i, --independent               Don't install dependencies automatically
 #   -k, --no-cache                  Don't use the download cache
 #   -s, --skip-hash-check           Skip hash validation (use with caution!)
+#   -m, --no-startmenu              Don't add the shortcut to the startmenu
 #   -u, --no-update-scoop           Don't update Scoop before installing if it's outdated
 #   -a, --arch <32bit|64bit|arm64>  Use the specified architecture, if the app supports it
 
@@ -42,13 +43,14 @@ if (get_config USE_SQLITE_CACHE) {
     . "$PSScriptRoot\..\lib\database.ps1"
 }
 
-$opt, $apps, $err = getopt $args 'giksua:' 'global', 'independent', 'no-cache', 'skip-hash-check', 'no-update-scoop', 'arch='
+$opt, $apps, $err = getopt $args 'giksmua:' 'global', 'independent', 'no-cache', 'skip-hash-check', 'no-startmenu', 'no-update-scoop', 'arch='
 if ($err) { "scoop install: $err"; exit 1 }
 
 $global = $opt.g -or $opt.global
 $check_hash = !($opt.s -or $opt.'skip-hash-check')
 $independent = $opt.i -or $opt.independent
 $use_cache = !($opt.k -or $opt.'no-cache')
+$add_startmenu = !($opt.m -or $opt.'no-startmenu')
 $architecture = Get-DefaultArchitecture
 try {
     $architecture = Format-ArchitectureString ($opt.a + $opt.arch)
@@ -131,7 +133,7 @@ if ((Test-Aria2Enabled) -and (get_config 'aria2-warning-enabled' $true)) {
     warn "Should it cause issues, run 'scoop config aria2-enabled false' to disable it."
     warn "To disable this warning, run 'scoop config aria2-warning-enabled false'."
 }
-$apps | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
+$apps | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash $add_startmenu }
 
 show_suggestions $suggested
 


### PR DESCRIPTION
#### Description
Added an option to skip creating the startmenu shortcuts when installing a package.

#### Motivation and Context
This is really useful in a fer specific use cases, for example i have two scoop installations on my pc for various purposes. This flag really helps avoid conflicts between installs and also because the paths of my installs are manually managed this, again, helps a lot.

#### How Has This Been Tested?
Ran the flag on multiple packages installs.
The code is really quite simple and only interacts with a small portion of the codebase.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
