### PR TITLE
fix(install): Fix parsing error when installing multiple apps w/ specific version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - **sqlite:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
+- **install:** Force the result to be an array ([#6039](https://github.com/ScoopInstaller/Scoop/pull/6039))
 
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01
 

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -97,7 +97,7 @@ if ($specific_versions.length -gt 0) {
     $difference = $apps
 }
 
-$specific_versions_paths = $specific_versions | ForEach-Object {
+$specific_versions_paths = @($specific_versions | ForEach-Object {
     $app, $bucket, $version = parse_app $_
     if (installed_manifest $app $version) {
         warn "'$app' ($version) is already installed.`nUse 'scoop update $app$(if ($global) { " --global" })' to install a new version."
@@ -105,7 +105,7 @@ $specific_versions_paths = $specific_versions | ForEach-Object {
     }
 
     generate_user_manifest $app $bucket $version
-}
+})
 $apps = @(($specific_versions_paths + $difference) | Where-Object { $_ } | Sort-Object -Unique)
 
 # remember which were explictly requested so that we can

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -91,22 +91,22 @@ $specific_versions = $apps | Where-Object {
 }
 
 # compare object does not like nulls
-if ($specific_versions.length -gt 0) {
+if ($specific_versions.Count -gt 0) {
     $difference = Compare-Object -ReferenceObject $apps -DifferenceObject $specific_versions -PassThru
 } else {
     $difference = $apps
 }
 
-$specific_versions_paths = @($specific_versions | ForEach-Object {
+$specific_versions_paths = $specific_versions | ForEach-Object {
     $app, $bucket, $version = parse_app $_
     if (installed_manifest $app $version) {
-        warn "'$app' ($version) is already installed.`nUse 'scoop update $app$(if ($global) { " --global" })' to install a new version."
+        warn "'$app' ($version) is already installed.`nUse 'scoop update $app$(if ($global) { ' --global' })' to install a new version."
         continue
     }
 
     generate_user_manifest $app $bucket $version
-})
-$apps = @(($specific_versions_paths + $difference) | Where-Object { $_ } | Sort-Object -Unique)
+}
+$apps = @((@($specific_versions_paths) + $difference) | Where-Object { $_ } | Select-Object -Unique)
 
 # remember which were explictly requested so that we can
 # differentiate after dependencies are added


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
When `foreach` returns only one value, the type of `$specific_versions_paths` is string.
When the value of `$specific_versions_paths` is a string, the value on the right side of the operator is appended to the string.
#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #6038

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Before:
```
$scoop  install mysql-workbench@8.0.32 firefox
...
Couldn't find manifest for 'mysql-workbench.jsonfirefox'.
```
After:
```
$scoop  install mysql-workbench@8.0.32 firefox
...
Succeed!
```
#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
