### PR TITLE
fix(scoop-virustotal): Adjust `json_path` parameters to retrieve correct analysis stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **sqlite:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
 - **install:** Expand `env_set` items before setting Environment Variables ([#6050](https://github.com/ScoopInstaller/Scoop/issues/6050))
 - **bucket:** Implement error handling for failed bucket addition ([#6051](https://github.com/ScoopInstaller/Scoop/issues/6051))
+- **scoop-virustotal:** Adjust `json_path` parameters to retrieve correct analysis stats ([#6042](https://github.com/ScoopInstaller/Scoop/issues/6042))
 
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01
 

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -102,14 +102,14 @@ Function Get-VirusTotalResultByHash ($hash, $url, $app) {
     $response = Invoke-WebRequest -Uri $api_url -Method GET -Headers $headers -UseBasicParsing
     $result = $response.Content
     $stats = json_path $result '$.data.attributes.last_analysis_stats'
-    [int]$malicious = json_path $stats '$.malicious'
-    [int]$suspicious = json_path $stats '$.suspicious'
-    [int]$timeout = json_path $stats '$.timeout'
-    [int]$undetected = json_path $stats '$.undetected'
+    [int]$malicious = json_path $stats '$[0].malicious' $null $false $true
+    [int]$suspicious = json_path $stats '$[0].suspicious' $null $false $true
+    [int]$timeout = json_path $stats '$[0].timeout' $null $false $true
+    [int]$undetected = json_path $stats '$[0].undetected' $null $false $true
     [int]$unsafe = $malicious + $suspicious
     [int]$total = $unsafe + $undetected
-    [int]$fileSize = json_path $result '$.data.attributes.size'
-    $report_hash = json_path $result '$.data.attributes.sha256'
+    [int]$fileSize = json_path $result '$.data.attributes.size' $null $false $true
+    $report_hash = json_path $result '$.data.attributes.sha256' $null $false $true
     $report_url = "https://www.virustotal.com/gui/file/$report_hash"
     if ($total -eq 0) {
         info "$app`: Analysis in progress."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
This PR aims to fix the error introduced in https://github.com/ScoopInstaller/Scoop/issues/5920. It uses the $single arguments in json_path to correctly extract the data instead, as previously they are enclosed with square brackets.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Closes #6042 
<!-- or -->
- Related to #5957

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested using Powershell 7
```
scoop virustotal eza
main/eza: 0/64, see https://www.virustotal.com/gui/file/0c5e596c990e15cbc04dce52ed9629cc8adc9c967d5e79534d6ddea020323cc4
scoop virustotal -a
main/1password-cli: 0/67, see https://www.virustotal.com/gui/file/761f2aa0f8907b397940cb69d9514efbcc4c67de6d64426e99a542edc60d615c
main/7zip: 0/64, see https://www.virustotal.com/gui/file/eb94db7341e59f1871a4d4f60165563f1881e33aef093b7d8427651c2a0f4b6f
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
