### PR TITLE
Patch-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **sqlite:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
 - **install:** Expand `env_set` items before setting Environment Variables ([#6050](https://github.com/ScoopInstaller/Scoop/issues/6050))
+- **install:** Show filesystem type and abort if Junction creation fails ([#5367](https://github.com/ScoopInstaller/Scoop/discussions/5367))
 - **bucket:** Implement error handling for failed bucket addition ([#6051](https://github.com/ScoopInstaller/Scoop/issues/6051))
 
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01


### PR DESCRIPTION
#### Description
Currently, if Scoop is running on exFAT or other filesystems with no Junction (a.k.a. Directory Junction) support, Scoop will fail to install app during `link app_name\current => app_name\0.0.1`.
If `mklink` is used, it will prompt `Local NTFS volumes are required to complete the operation.`. But for `New-Item`, a meaningless error will show, making it hard to debug.

This may be a BREAKING CHANGE, for it directly executes `abort` rather than continue with error.

#### Motivation and Context
Relates to #5367

#### How Has This Been Tested?
I applied this patch and and added the following code locally, and run Scoop with `scoop install adb`:

```powershell
function New-DirectoryJunction($source, $target) {
    $source = "G:\Windows11" # this doesn't exist
    $target = "G:\Windows" # this is a existed folder, on a exFAT disk
    # ...
}
```

The linking is failed as expected, and the following output is shown:

```plaintext
WARN  FileSystemType of target path G:\Windows: Unknown
Cannot link G:\Windows11 => G:\Windows
```

for the Docker part, i've done similar test.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly. (maybe document should mention that Scoop may not work on non-NTFS filesystems, but this PR won't cover it)
- [ ] I have updated the tests accordingly. (have no idea how to add tests)
- [x] I have added an entry in the CHANGELOG.

I may be slow to respond. If there is any change, feel free to directly edit!