### PR TITLE
chore(release): Bump to version 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - **sqlite:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
+- **install:** Expand `env_set` items before setting Environment Variables ([#6050](https://github.com/ScoopInstaller/Scoop/issues/6050))
 
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
-## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+## [v0.5.1](https://github.com/ScoopInstaller/Scoop/compare/v0.5.0...v0.5.1) - 2024-07-16
 
 ### Bug Fixes
 
-- **sqlite:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
-- **install:** Expand `env_set` items before setting Environment Variables ([#6050](https://github.com/ScoopInstaller/Scoop/issues/6050))
-- **bucket:** Implement error handling for failed bucket addition ([#6051](https://github.com/ScoopInstaller/Scoop/issues/6051))
-- **scoop-virustotal:** Adjust `json_path` parameters to retrieve correct analysis stats ([#6044](https://github.com/ScoopInstaller/Scoop/issues/6044))
-- **install:** Fix parsing error when installing multiple apps w/ specific version ([#6039](https://github.com/ScoopInstaller/Scoop/issues/6039))
 - **scoop-alias:** Pass options correctly ([#6003](https://github.com/ScoopInstaller/Scoop/issues/6003))
+- **scoop-virustotal:** Adjust `json_path` parameters to retrieve correct analysis stats ([#6044](https://github.com/ScoopInstaller/Scoop/issues/6044))
+- **bucket:** Implement error handling for failed bucket addition ([#6051](https://github.com/ScoopInstaller/Scoop/issues/6051))
+- **database:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
+- **install:** Expand `env_set` items before setting Environment Variables ([#6050](https://github.com/ScoopInstaller/Scoop/issues/6050))
+- **install:** Fix parsing error when installing multiple apps w/ specific version ([#6039](https://github.com/ScoopInstaller/Scoop/issues/6039))
 
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **sqlite:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
 - **install:** Expand `env_set` items before setting Environment Variables ([#6050](https://github.com/ScoopInstaller/Scoop/issues/6050))
+- **bucket:** Implement error handling for failed bucket addition ([#6051](https://github.com/ScoopInstaller/Scoop/issues/6051))
 
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - **sqlite:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
 - **install:** Expand `env_set` items before setting Environment Variables ([#6050](https://github.com/ScoopInstaller/Scoop/issues/6050))
 - **bucket:** Implement error handling for failed bucket addition ([#6051](https://github.com/ScoopInstaller/Scoop/issues/6051))
-- **install:** Fix parsing error when installing multiple apps w/ specific version ([#6039](https://github.com/ScoopInstaller/Scoop/pull/6039))
+- **scoop-virustotal:** Adjust `json_path` parameters to retrieve correct analysis stats ([#6044](https://github.com/ScoopInstaller/Scoop/issues/6044))
+- **install:** Fix parsing error when installing multiple apps w/ specific version ([#6039](https://github.com/ScoopInstaller/Scoop/issues/6039))
 
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **bucket:** Implement error handling for failed bucket addition ([#6051](https://github.com/ScoopInstaller/Scoop/issues/6051))
 - **scoop-virustotal:** Adjust `json_path` parameters to retrieve correct analysis stats ([#6044](https://github.com/ScoopInstaller/Scoop/issues/6044))
 - **install:** Fix parsing error when installing multiple apps w/ specific version ([#6039](https://github.com/ScoopInstaller/Scoop/issues/6039))
+- **scoop-alias:** Pass options correctly ([#6003](https://github.com/ScoopInstaller/Scoop/issues/6003))
 
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+
+### Bug Fixes
+
+- **sqlite:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
+
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **sqlite:** Fix compatibility with Windows PowerShell ([#6045](https://github.com/ScoopInstaller/Scoop/issues/6045))
 - **install:** Expand `env_set` items before setting Environment Variables ([#6050](https://github.com/ScoopInstaller/Scoop/issues/6050))
 - **bucket:** Implement error handling for failed bucket addition ([#6051](https://github.com/ScoopInstaller/Scoop/issues/6051))
+- **install:** Fix parsing error when installing multiple apps w/ specific version ([#6039](https://github.com/ScoopInstaller/Scoop/pull/6039))
 
 ## [v0.5.0](https://github.com/ScoopInstaller/Scoop/compare/v0.4.2...v0.5.0) - 2024-07-01
 

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -154,7 +154,12 @@ function add_bucket($name, $repo) {
     }
     ensure $bucketsdir | Out-Null
     $dir = ensure $dir
-    Invoke-Git -ArgumentList @('clone', $repo, $dir, '-q')
+    $out = Invoke-Git -ArgumentList @('clone', $repo, $dir, '-q')
+    if ($LASTEXITCODE -ne 0) {
+        error "Failed to clone '$repo' to '$dir'.`n`nError given:`n$out`n`nPlease check the repository URL or network connection and try again."
+        Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+        return 1
+    }
     Write-Host 'OK'
     if (get_config USE_SQLITE_CACHE) {
         info 'Updating cache...'

--- a/lib/commands.ps1
+++ b/lib/commands.ps1
@@ -1,3 +1,7 @@
+# Description: Functions for managing commands and aliases.
+
+## Functions for commands
+
 function command_files {
     (Get-ChildItem "$PSScriptRoot\..\libexec") + (Get-ChildItem "$scoopdir\shims") |
         Where-Object 'scoop-.*?\.ps1$' -Property Name -Match
@@ -19,11 +23,10 @@ function command_path($cmd) {
         # get path from shim
         $shim_path = "$scoopdir\shims\scoop-$cmd.ps1"
         $line = ((Get-Content $shim_path) | Where-Object { $_.startswith('$path') })
-        if($line) {
+        if ($line) {
             Invoke-Command ([scriptblock]::Create($line)) -NoNewScope
             $cmd_path = $path
-        }
-        else { $cmd_path = $shim_path }
+        } else { $cmd_path = $shim_path }
     }
 
     $cmd_path
@@ -33,4 +36,83 @@ function exec($cmd, $arguments) {
     $cmd_path = command_path $cmd
 
     & $cmd_path @arguments
+}
+
+## Functions for aliases
+
+function add_alias {
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]$name,
+        [ValidateNotNullOrEmpty()]
+        [string]$command,
+        [string]$description
+    )
+
+    $aliases = get_config ALIAS ([PSCustomObject]@{})
+    if ($aliases.$name) {
+        abort "Alias '$name' already exists."
+    }
+
+    $alias_script_name = "scoop-$name"
+    $shimdir = shimdir $false
+    if (Test-Path "$shimdir\$alias_script_name.ps1") {
+        abort "File '$alias_script_name.ps1' already exists in shims directory."
+    }
+    $script = @(
+        "# Summary: $description",
+        "$command"
+    ) -join "`n"
+    try {
+        $script | Out-UTF8File "$shimdir\$alias_script_name.ps1"
+    } catch {
+        abort $_.Exception
+    }
+
+    # Add the new alias to the config.
+    $aliases | Add-Member -MemberType NoteProperty -Name $name -Value $alias_script_name
+    set_config ALIAS $aliases | Out-Null
+}
+
+function rm_alias {
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]$name
+    )
+
+    $aliases = get_config ALIAS ([PSCustomObject]@{})
+    if (!$aliases.$name) {
+        abort "Alias '$name' doesn't exist."
+    }
+
+    info "Removing alias '$name'..."
+    Remove-Item "$(shimdir $false)\scoop-$name.ps1"
+    $aliases.PSObject.Properties.Remove($name)
+    set_config ALIAS $aliases | Out-Null
+}
+
+function list_aliases {
+    param(
+        [bool]$verbose
+    )
+
+    $aliases = get_config ALIAS ([PSCustomObject]@{})
+    $alias_info = $aliases.PSObject.Properties.Name | Where-Object { $_ } | ForEach-Object {
+        $content = Get-Content (command_path $_)
+        [PSCustomObject]@{
+            Name    = $_
+            Summary = (summary $content).Trim()
+            Command = ($content | Select-Object -Skip 1).Trim()
+        }
+    }
+    if (!$alias_info) {
+        info 'No alias found.'
+        return
+    }
+    $alias_info = $alias_info | Sort-Object Name
+    $properties = @('Name', 'Command')
+    if ($verbose) {
+        $properties += 'Summary'
+    }
+    $alias_info | Select-Object $properties
 }

--- a/lib/database.ps1
+++ b/lib/database.ps1
@@ -21,15 +21,14 @@ function Get-SQLite {
     # Install SQLite
     try {
         Write-Host "Downloading SQLite $Version..." -ForegroundColor DarkYellow
-        $sqlitePkgPath = "$env:TEMP\sqlite.nupkg"
+        $sqlitePkgPath = "$env:TEMP\sqlite.zip"
         $sqliteTempPath = "$env:TEMP\sqlite"
         $sqlitePath = "$PSScriptRoot\..\supporting\sqlite"
         Invoke-WebRequest -Uri "https://api.nuget.org/v3-flatcontainer/stub.system.data.sqlite.core.netframework/$version/stub.system.data.sqlite.core.netframework.$version.nupkg" -OutFile $sqlitePkgPath
         Write-Host "Extracting SQLite $Version..." -ForegroundColor DarkYellow -NoNewline
         Expand-Archive -Path $sqlitePkgPath -DestinationPath $sqliteTempPath -Force
         New-Item -Path $sqlitePath -ItemType Directory -Force | Out-Null
-        Move-Item -Path "$sqliteTempPath\build\net45\*" -Destination $sqlitePath -Exclude '*.targets' -Force
-        Move-Item -Path "$sqliteTempPath\lib\net45\System.Data.SQLite.dll" -Destination $sqlitePath -Force
+        Move-Item -Path "$sqliteTempPath\build\net451\*", "$sqliteTempPath\lib\net451\System.Data.SQLite.dll" -Destination $sqlitePath -Force
         Remove-Item -Path $sqlitePkgPath, $sqliteTempPath -Recurse -Force
         Write-Host ' Done' -ForegroundColor DarkYellow
         return $true

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -60,7 +60,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     create_startmenu_shortcuts $manifest $dir $global $architecture
     install_psmodule $manifest $dir $global
     env_add_path $manifest $dir $global $architecture
-    env_set $manifest $dir $global $architecture
+    env_set $manifest $global $architecture
 
     # persist data
     persist_data $manifest $original_dir $persist_dir
@@ -898,12 +898,12 @@ function env_rm_path($manifest, $dir, $global, $arch) {
     }
 }
 
-function env_set($manifest, $dir, $global, $arch) {
+function env_set($manifest, $global, $arch) {
     $env_set = arch_specific 'env_set' $manifest $arch
     if ($env_set) {
-        $env_set | Get-Member -Member NoteProperty | ForEach-Object {
-            $name = $_.name
-            $val = substitute $env_set.$($_.name) @{ '$dir' = $dir }
+        $env_set | Get-Member -MemberType NoteProperty | ForEach-Object {
+            $name = $_.Name
+            $val = $ExecutionContext.InvokeCommand.ExpandString($env_set.$($name))
             Set-EnvVar -Name $name -Value $val -Global:$global
             Set-Content env:\$name $val
         }
@@ -912,8 +912,8 @@ function env_set($manifest, $dir, $global, $arch) {
 function env_rm($manifest, $global, $arch) {
     $env_set = arch_specific 'env_set' $manifest $arch
     if ($env_set) {
-        $env_set | Get-Member -Member NoteProperty | ForEach-Object {
-            $name = $_.name
+        $env_set | Get-Member -MemberType NoteProperty | ForEach-Object {
+            $name = $_.Name
             Set-EnvVar -Name $name -Value $null -Global:$global
             if (Test-Path env:\$name) { Remove-Item env:\$name }
         }

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -91,7 +91,7 @@ $specific_versions = $apps | Where-Object {
 }
 
 # compare object does not like nulls
-if ($specific_versions.length -gt 0) {
+if ($specific_versions.Count -gt 0) {
     $difference = Compare-Object -ReferenceObject $apps -DifferenceObject $specific_versions -PassThru
 } else {
     $difference = $apps
@@ -100,13 +100,13 @@ if ($specific_versions.length -gt 0) {
 $specific_versions_paths = $specific_versions | ForEach-Object {
     $app, $bucket, $version = parse_app $_
     if (installed_manifest $app $version) {
-        warn "'$app' ($version) is already installed.`nUse 'scoop update $app$(if ($global) { " --global" })' to install a new version."
+        warn "'$app' ($version) is already installed.`nUse 'scoop update $app$(if ($global) { ' --global' })' to install a new version."
         continue
     }
 
     generate_user_manifest $app $bucket $version
 }
-$apps = @(($specific_versions_paths + $difference) | Where-Object { $_ } | Sort-Object -Unique)
+$apps = @((@($specific_versions_paths) + $difference) | Where-Object { $_ } | Select-Object -Unique)
 
 # remember which were explictly requested so that we can
 # differentiate after dependencies are added

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -84,7 +84,7 @@ $apps | ForEach-Object {
     env_rm_path $manifest $dir $global $architecture
     env_rm $manifest $global $architecture
     env_add_path $manifest $dir $global $architecture
-    env_set $manifest $dir $global $architecture
+    env_set $manifest $global $architecture
     # unlink all potential old link before re-persisting
     unlink_persist_data $manifest $original_dir
     persist_data $manifest $original_dir $persist_dir

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -102,14 +102,14 @@ Function Get-VirusTotalResultByHash ($hash, $url, $app) {
     $response = Invoke-WebRequest -Uri $api_url -Method GET -Headers $headers -UseBasicParsing
     $result = $response.Content
     $stats = json_path $result '$.data.attributes.last_analysis_stats'
-    [int]$malicious = json_path $stats '$.malicious'
-    [int]$suspicious = json_path $stats '$.suspicious'
-    [int]$timeout = json_path $stats '$.timeout'
-    [int]$undetected = json_path $stats '$.undetected'
+    [int]$malicious = json_path $stats '$[0].malicious' $null $false $true
+    [int]$suspicious = json_path $stats '$[0].suspicious' $null $false $true
+    [int]$timeout = json_path $stats '$[0].timeout' $null $false $true
+    [int]$undetected = json_path $stats '$[0].undetected' $null $false $true
     [int]$unsafe = $malicious + $suspicious
     [int]$total = $unsafe + $undetected
-    [int]$fileSize = json_path $result '$.data.attributes.size'
-    $report_hash = json_path $result '$.data.attributes.sha256'
+    [int]$fileSize = json_path $result '$.data.attributes.size' $null $false $true
+    $report_hash = json_path $result '$.data.attributes.sha256' $null $false $true
     $report_url = "https://www.virustotal.com/gui/file/$report_hash"
     if ($total -eq 0) {
         info "$app`: Analysis in progress."

--- a/test/Scoop-Commands.Tests.ps1
+++ b/test/Scoop-Commands.Tests.ps1
@@ -1,8 +1,7 @@
 BeforeAll {
     . "$PSScriptRoot\Scoop-TestLib.ps1"
     . "$PSScriptRoot\..\lib\core.ps1"
-    . "$PSScriptRoot\..\lib\help.ps1"
-    . "$PSScriptRoot\..\libexec\scoop-alias.ps1" | Out-Null
+    . "$PSScriptRoot\..\lib\commands.ps1"
 }
 
 Describe 'Manipulate Alias' -Tag 'Scoop' {
@@ -15,32 +14,32 @@ Describe 'Manipulate Alias' -Tag 'Scoop' {
         ensure $shimdir
     }
 
-    It 'Creates a new alias if alias doesn''t exist' {
-        $alias_file = "$shimdir\scoop-rm.ps1"
-        $alias_file | Should -Not -Exist
+    It 'Creates a new alias if it does not exist' {
+        $alias_script = "$shimdir\scoop-rm.ps1"
+        $alias_script | Should -Not -Exist
 
         add_alias 'rm' '"hello, world!"'
-        & $alias_file | Should -Be 'hello, world!'
+        & $alias_script | Should -Be 'hello, world!'
     }
 
-    It 'Does not change existing file if its filename same as alias name' {
-        $alias_file = "$shimdir\scoop-rm.ps1"
+    It 'Skips an existing alias' {
+        $alias_script = "$shimdir\scoop-rm.ps1"
         Mock abort {}
-        New-Item $alias_file -Type File -Force
-        $alias_file | Should -Exist
+        New-Item $alias_script -Type File -Force
+        $alias_script | Should -Exist
 
         add_alias 'rm' '"test"'
         Should -Invoke -CommandName abort -Times 1 -ParameterFilter { $msg -eq "File 'scoop-rm.ps1' already exists in shims directory." }
     }
 
     It 'Removes an existing alias' {
-        $alias_file = "$shimdir\scoop-rm.ps1"
-        $alias_file | Should -Exist
+        $alias_script = "$shimdir\scoop-rm.ps1"
+        $alias_script | Should -Exist
         Mock get_config { @(@{'rm' = 'scoop-rm' }) }
         Mock info {}
 
         rm_alias 'rm'
-        $alias_file | Should -Not -Exist
+        $alias_script | Should -Not -Exist
         Should -Invoke -CommandName info -Times 1 -ParameterFilter { $msg -eq "Removing alias 'rm'..." }
     }
 }


### PR DESCRIPTION
## Changelog

### Bug Fixes

- **scoop-alias:** Pass options correctly (#6003)
- **scoop-virustotal:** Adjust `json_path` parameters to retrieve correct analysis stats (#6044)
- **bucket:** Implement error handling for failed bucket addition (#6051)
- **database:** Fix compatibility with Windows PowerShell (#6045)
- **install:** Expand `env_set` items before setting Environment Variables (#6050)
- **install:** Fix parsing error when installing multiple apps w/ specific version (#6039)

## Close Issues

- Closes #6041
- Closes #6043
- Closes https://github.com/ScoopInstaller/Extras/issues/13600
- Closes #6048
- Closes #6038
- Closes #6042
- Closes #5767

## Credits

Thanks to the following contributors (ordered by PR merging time):

@niheaven @qwertyhjklxyz @Lutra-Fs @lewis-yeung