### PR TITLE
Custom persist locations

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -402,7 +402,7 @@ function currentdir($app, $global) {
     "$(appdir $app $global)\$version"
 }
 
-function persistdir($app, $global) { "$(basedir $global)\persist\$app" }
+function persistdir($app, $global) { if($global) { return "$globalpersistdir\$app" } "$persistdir\$app" }
 function usermanifestsdir { "$(basedir)\workspace" }
 function usermanifest($app) { "$(usermanifestsdir)\$app.json" }
 function cache_path($app, $version, $url) {
@@ -1463,6 +1463,13 @@ $globaldir = $env:SCOOP_GLOBAL, (get_config GLOBAL_PATH), "$([System.Environment
 #       multiple users write and access cached files at the same time.
 #       Use at your own risk.
 $cachedir = $env:SCOOP_CACHE, (get_config CACHE_PATH), "$scoopdir\cache" | Where-Object { $_ } | Select-Object -First 1 | Get-AbsolutePath
+
+# Scoop persist directory
+# Note: Setting the SCOOP_PERSIST environment variable to use a shared directory
+#       may cause problems depending on the app.
+#       Use at your own risk.
+$persistdir = $env:SCOOP_PERSIST, (get_config PERSIST_PATH), "$scoopdir\persist" | Where-Object { $_ } | Select-Object -First 1 | Get-AbsolutePath
+$globalpersistdir = $env:SCOOP_PERSIST_GLOBAL, (get_config GLOBAL_PERSIST_PATH), "$globaldir\persist" | Where-Object { $_ } | Select-Object -First 1 | Get-AbsolutePath
 
 # Scoop apps' PATH Environment Variable
 $scoopPathEnvVar = switch (get_config USE_ISOLATED_PATH) {

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -83,6 +83,12 @@
 # cache_path:
 #       For downloads, defaults to 'cache' folder under Scoop root directory.
 #
+# persist_path:
+#       Directories persisted during installation of new versions , defaults to 'persist' folder under Scoop root directory.
+#
+# global_persist_path:
+#       Directories persisted during installation of new versions , defaults to 'persist' folder under Scoop global directory.
+#
 # gh_token:
 #       GitHub API token used to make authenticated requests.
 #       This is essential for checkver and similar functions to run without

--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -10,7 +10,7 @@ $export = @{}
 if ($args[0] -eq '-c' -or $args[0] -eq '--config') {
     $export.config = $scoopConfig
     # Remove machine-specific properties
-    foreach ($prop in 'last_update', 'root_path', 'global_path', 'cache_path', 'alias') {
+    foreach ($prop in 'last_update', 'root_path', 'global_path', 'cache_path', 'persist_path', 'global_persist_path', 'alias') {
         $export.config.PSObject.Properties.Remove($prop)
     }
 }


### PR DESCRIPTION
#### Description
Replaced fixed path "$scoopdir\persist" by the environment variable `SCOOP_PERSIST` or the config variable `persist_path`. It also replaces "$scoopglobaldir\persist" by the environment variable `SCOOP_PERSIST_GLOBAL` or the config variable `global_persist_path`.

#### Motivation and Context
This implements #4746

#### How Has This Been Tested?
I will test later

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
