### PR TITLE
fix(scoop-hold): Use 'foreach' loop to allow 'continue' statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - **scoop-alias:** Fix 'Option --verbose not recognized.' ([#6062](https://github.com/ScoopInstaller/Scoop/issues/6062))
+- **scoop-hold:** Use 'foreach' loop to allow 'continue' statement ([#6078](https://github.com/ScoopInstaller/Scoop/issues/6078))
 - **json:** Don't serialize jsonpath return if only one result ([#6066](https://github.com/ScoopInstaller/Scoop/issues/6066), [#6073](https://github.com/ScoopInstaller/Scoop/issues/6073))
 
 ### Builds

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -29,14 +29,13 @@ if ($global -and !(is_admin)) {
     exit 1
 }
 
-$apps | ForEach-Object {
-    $app = $_
+foreach ($app in $apps) {
 
     if ($app -eq 'scoop') {
         $hold_update_until = [System.DateTime]::Now.AddDays(1)
         set_config HOLD_UPDATE_UNTIL $hold_update_until.ToString('o') | Out-Null
         success "$app is now held and might not be updated until $($hold_update_until.ToLocalTime())."
-        return
+        continue
     }
     if (!(installed $app $global)) {
         if ($global) {
@@ -44,7 +43,7 @@ $apps | ForEach-Object {
         } else {
             error "'$app' is not installed."
         }
-        return
+        continue
     }
 
     if (get_config NO_JUNCTION) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

`continue` statement shouldn't be used outside of a loop, switch, or trap.

> Using continue inside a pipeline, such as a ForEach-Object script block, not only exits the pipeline, it potentially terminates the entire runspace.

Ref: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_continue?view=powershell-7.4#do-not-use-continue-outside-of-a-loop-switch-or-trap

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Closes #6077

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
