### PR TITLE
fix(shim): properly check `wslpath`/`cygpath` command first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - **decompress**: `Expand-7zipArchive` only delete temp dir / `$extractDir` if it is empty ([#6092](https://github.com/ScoopInstaller/Scoop/issues/6092))
+- **shim:** Do not suppress `stderr`, properly check `wslpath`/`cygpath` command first ([#6114](https://github.com/ScoopInstaller/Scoop/pull/6114))
 
 ### Code Refactoring
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1005,14 +1005,12 @@ function shim($path, $global, $name, $arg) {
         warn_on_overwrite "$shim.cmd" $path
         @(
             "@rem $resolved_path",
-            '@bash -c "command -v wslpath >/dev/null 2>&1"',
-            '@if %errorlevel% equ 0 (',
-            "  @bash `"`$(wslpath -u '$resolved_path')`" $arg %*",
+            '@echo off',
+            'bash -c "command -v wslpath >/dev/null"',
+            'if %errorlevel% equ 0 (',
+            "  bash `"`$(wslpath -u '$resolved_path')`" $arg %*",
             ') else (',
-            '  @bash -c "command -v cygpath >/dev/null 2>&1"',
-            '  @if %errorlevel% equ 0 (',
-            "    @bash `"`$(cygpath -u '$resolved_path')`" $arg %*",
-            '  )',
+            "  bash `"`$(cygpath -u '$resolved_path')`" $arg %*",
             ')'
         ) -join "`r`n" | Out-UTF8File "$shim.cmd"
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1005,9 +1005,14 @@ function shim($path, $global, $name, $arg) {
         warn_on_overwrite "$shim.cmd" $path
         @(
             "@rem $resolved_path",
-            "@bash `"`$(wslpath -u '$resolved_path')`" $arg %* 2>nul",
-            '@if %errorlevel% neq 0 (',
-            "  @bash `"`$(cygpath -u '$resolved_path')`" $arg %* 2>nul",
+            '@bash -c "command -v wslpath >/dev/null 2>&1"',
+            '@if %errorlevel% equ 0 (',
+            "  @bash `"`$(wslpath -u '$resolved_path')`" $arg %*",
+            ') else (',
+            '  @bash -c "command -v cygpath >/dev/null 2>&1"',
+            '  @if %errorlevel% equ 0 (',
+            "    @bash `"`$(cygpath -u '$resolved_path')`" $arg %*",
+            '  )',
             ')'
         ) -join "`r`n" | Out-UTF8File "$shim.cmd"
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1003,14 +1003,18 @@ function shim($path, $global, $name, $arg) {
         ) -join "`n" | Out-UTF8File $shim -NoNewLine
     } else {
         warn_on_overwrite "$shim.cmd" $path
+        $quoted_arg = if ($arg.Count -gt 0) { $arg | ForEach-Object { "`"$_`"" } }
         @(
             "@rem $resolved_path",
             '@echo off',
             'bash -c "command -v wslpath >/dev/null"',
             'if %errorlevel% equ 0 (',
-            "  bash `"`$(wslpath -u '$resolved_path')`" $arg %*",
+            "  bash `"`$(wslpath -u '$resolved_path')`" $quoted_arg %*",
             ') else (',
-            "  bash `"`$(cygpath -u '$resolved_path')`" $arg %*",
+            "  set args=$quoted_arg %*",
+            '  setlocal enabledelayedexpansion',
+            '  if not "!args!"=="" set args=!args:"=""!',
+            "  bash -c `"`$(cygpath -u '$resolved_path') !args!`"",
             ')'
         ) -join "`r`n" | Out-UTF8File "$shim.cmd"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
Do not suppress stderr for commands, only suppress output when checking for `wslpath`/`cygpath` commands first.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #6112

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
`wcurl` at https://github.com/ScoopInstaller/Main/pull/6117

Before: Error, no output
![image](https://github.com/user-attachments/assets/4b3a3be3-ee8c-4862-8461-397c5152954f)

After: now returns an error with the output
![image](https://github.com/user-attachments/assets/cbf0f07c-e734-4ea5-894e-afd5eeaa1afb)


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
