### PR TITLE
refactor(Get-Manifest): Select actual source for manifest

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -554,6 +554,9 @@ function app_status($app, $global) {
     $status.failed = failed $app $global
     $status.hold = ($install_info.hold -eq $true)
 
+    $deprecated_dir = (Find-BucketDirectory -Name $install_info.bucket -Root) + "\deprecated"
+    $status.deprecated = (Get-ChildItem $deprecated_dir -Filter "$(sanitary_path $app).json" -Recurse).FullName
+
     $manifest = manifest $app $install_info.bucket $install_info.url
     $status.removed = (!$manifest)
     if ($manifest.version) {
@@ -581,7 +584,6 @@ function app_status($app, $global) {
     if ($deps) {
         $status.missing_deps += , $deps
     }
-
     return $status
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1140,19 +1140,7 @@ function applist($apps, $global) {
 
 function parse_app([string]$app) {
     if ($app -match '^(?:(?<bucket>[a-zA-Z0-9-_.]+)/)?(?<app>.*\.json|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?$') {
-        $app = $Matches['app']
-        $bucket = $Matches['bucket']
-        $version = $Matches['version']
-        if (installed $app) {
-            $global = installed $app $true
-            $ver = Select-CurrentVersion -AppName $app -Global:$global
-            $install_info_path = "$(versiondir $app $ver $global)\install.json"
-            if (Test-Path $install_info_path) {
-                $install_info = parse_json $install_info_path
-                $bucket = $install_info.bucket
-            }
-        }
-        return $app, $bucket, $version
+        return $Matches['app'], $Matches['bucket'], $Matches['version']
     } else {
         return $app, $null, $null
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1140,7 +1140,19 @@ function applist($apps, $global) {
 
 function parse_app([string]$app) {
     if ($app -match '^(?:(?<bucket>[a-zA-Z0-9-_.]+)/)?(?<app>.*\.json|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?$') {
-        return $Matches['app'], $Matches['bucket'], $Matches['version']
+        $app = $Matches['app']
+        $bucket = $Matches['bucket']
+        $version = $Matches['version']
+        if (installed $app) {
+            $global = installed $app $true
+            $ver = Select-CurrentVersion -AppName $app -Global:$global
+            $install_info_path = "$(versiondir $app $ver $global)\install.json"
+            if (Test-Path $install_info_path) {
+                $install_info = parse_json $install_info_path
+                $bucket = $install_info.bucket
+            }
+        }
+        return $app, $bucket, $version
     } else {
         return $app, $null, $null
     }

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -50,10 +50,8 @@ function Get-Manifest($app) {
                 $bucket = $install_info.bucket
                 if (!$bucket) {
                     $url = $install_info.url
-                    if ($url) {
-                        if ($url -match '^(ht|f)tps?://|\\\\') {
-                            $manifest = url_manifest $url
-                        }
+                    if ($url -match '^(ht|f)tps?://|\\\\') {
+                        $manifest = url_manifest $url
                     }
                     if (!$manifest) {
                         if (Test-Path $url) {

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -32,7 +32,7 @@ function url_manifest($url) {
 }
 
 function Get-Manifest($app) {
-    $bucket, $manifest, $url = $null
+    $bucket, $manifest, $url, $deprecated = $null
     $app = $app.TrimStart('/')
     # check if app is a URL or UNC path
     if ($app -match '^(ht|f)tps?://|\\\\') {
@@ -63,6 +63,10 @@ function Get-Manifest($app) {
                     }
                 } else {
                     $manifest = manifest $app $bucket
+                    if (!$manifest) {
+                        $deprecated_dir = (Find-BucketDirectory -Name $bucket -Root) + "\deprecated"
+                        $manifest = parse_json (Get-ChildItem $deprecated_dir -Filter "$(sanitary_path $app).json" -Recurse).FullName
+                    }
                 }
             }
         } else {

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -87,7 +87,7 @@ function Get-Manifest($app) {
                 if (Test-Path $app) {
                     $url = Convert-Path $app
                     $app = appname_from_url $url
-                    $manifest = url_manifest $url
+                    $manifest = parse_json $url
                 } else {
                     if (($app -match '\\/') -or $app.EndsWith('.json')) { $url = $app }
                     $app = appname_from_url $app

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -78,16 +78,15 @@ function Get-Manifest($app) {
             if ($bucket) {
                 $manifest = manifest $app $bucket
             } else {
-                $count = 0
+                $matched_buckets = @()
                 foreach ($tekcub in Get-LocalBucket) {
-                    if (!$manifest) {
-                        $manifest = manifest $app $tekcub
+                    $current_manifest = manifest $app $tekcub
+                    if (!$manifest -and $current_manifest) {
+                        $manifest = $current_manifest
+                        $bucket = $tekcub
                     }
-                    if ($manifest) {
-                        if (!$bucket) {
-                            $bucket = $tekcub
-                        }
-                        $count++
+                    if ($current_manifest) {
+                        $matched_buckets += $tekcub
                     }
                 }
             }
@@ -105,10 +104,8 @@ function Get-Manifest($app) {
         }
     }
 
-    if ($count) {
-        if ($count -gt 1) {
-            warn "Multiple buckets contain manifest '$app', the current selection is '$bucket/$app'."
-        }
+    if ($matched_buckets -gt 1) {
+        warn "Multiple buckets contain manifest '$app', the current selection is '$bucket/$app'."
     }
 
     return $app, $manifest, $bucket, $url

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -104,7 +104,7 @@ function Get-Manifest($app) {
         }
     }
 
-    if ($matched_buckets -gt 1) {
+    if ($matched_buckets.Length -gt 1) {
         warn "Multiple buckets contain manifest '$app', the current selection is '$bucket/$app'."
     }
 

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -40,27 +40,49 @@ function Get-Manifest($app) {
         $app = appname_from_url $url
         $manifest = url_manifest $url
     } else {
-        $app, $bucket, $version = parse_app $app
-        if ($bucket) {
-            $manifest = manifest $app $bucket
-        } else {
-            foreach ($tekcub in Get-LocalBucket) {
-                $manifest = manifest $app $tekcub
-                if ($manifest) {
-                    $bucket = $tekcub
-                    break
+        # Check if the manifest is already installed
+        if (installed $app) {
+            $global = installed $app $true
+            $ver = Select-CurrentVersion -AppName $app -Global:$global
+            $install_info_path = "$(versiondir $app $ver $global)\install.json"
+            if (Test-Path $install_info_path) {
+                $install_info = parse_json $install_info_path
+                $bucket = $install_info.bucket
+                if (!$bucket) {
+                    $url = $install_info.url
+                    if ($url -and (Test-Path $url)) {
+                        $manifest = parse_json $url
+                    } else {
+                        # Fallback to installed manifest
+                        $manifest = installed_manifest $app $ver $global
+                    }
+                } else {
+                    $manifest = manifest $app $bucket
                 }
             }
-        }
-        if (!$manifest) {
-            # couldn't find app in buckets: check if it's a local path
-            if (Test-Path $app) {
-                $url = Convert-Path $app
-                $app = appname_from_url $url
-                $manifest = url_manifest $url
+        } else {
+            $app, $bucket, $version = parse_app $app
+            if ($bucket) {
+                $manifest = manifest $app $bucket
             } else {
-                if (($app -match '\\/') -or $app.EndsWith('.json')) { $url = $app }
-                $app = appname_from_url $app
+                foreach ($tekcub in Get-LocalBucket) {
+                    $manifest = manifest $app $tekcub
+                    if ($manifest) {
+                        $bucket = $tekcub
+                        break
+                    }
+                }
+            }
+            if (!$manifest) {
+                # couldn't find app in buckets: check if it's a local path
+                if (Test-Path $app) {
+                    $url = Convert-Path $app
+                    $app = appname_from_url $url
+                    $manifest = url_manifest $url
+                } else {
+                    if (($app -match '\\/') -or $app.EndsWith('.json')) { $url = $app }
+                    $app = appname_from_url $app
+                }
             }
         }
     }

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -32,7 +32,7 @@ function url_manifest($url) {
 }
 
 function Get-Manifest($app) {
-    $bucket, $manifest, $url, $deprecated = $null
+    $bucket, $manifest, $url = $null
     $app = $app.TrimStart('/')
     # check if app is a URL or UNC path
     if ($app -match '^(ht|f)tps?://|\\\\') {

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -78,11 +78,16 @@ function Get-Manifest($app) {
             if ($bucket) {
                 $manifest = manifest $app $bucket
             } else {
+                $count = 0
                 foreach ($tekcub in Get-LocalBucket) {
-                    $manifest = manifest $app $tekcub
+                    if (!$manifest) {
+                        $manifest = manifest $app $tekcub
+                    }
                     if ($manifest) {
-                        $bucket = $tekcub
-                        break
+                        if (!$bucket) {
+                            $bucket = $tekcub
+                        }
+                        $count++
                     }
                 }
             }
@@ -99,6 +104,13 @@ function Get-Manifest($app) {
             }
         }
     }
+
+    if ($count) {
+        if ($count -gt 1) {
+            warn "Multiple buckets contain '$app', selected manifest are '$bucket/$app'."
+        }
+    }
+
     return $app, $manifest, $bucket, $url
 }
 

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -44,6 +44,10 @@ function Get-Manifest($app) {
         if (installed $app) {
             $global = installed $app $true
             $ver = Select-CurrentVersion -AppName $app -Global:$global
+            if (!$ver) {
+                $app, $bucket, $ver = parse_app $app
+                $ver = Select-CurrentVersion -AppName $app -Global:$global
+            }
             $install_info_path = "$(versiondir $app $ver $global)\install.json"
             if (Test-Path $install_info_path) {
                 $install_info = parse_json $install_info_path
@@ -64,7 +68,7 @@ function Get-Manifest($app) {
                 } else {
                     $manifest = manifest $app $bucket
                     if (!$manifest) {
-                        $deprecated_dir = (Find-BucketDirectory -Name $bucket -Root) + "\deprecated"
+                        $deprecated_dir = (Find-BucketDirectory -Name $bucket -Root) + '\deprecated'
                         $manifest = parse_json (Get-ChildItem $deprecated_dir -Filter "$(sanitary_path $app).json" -Recurse).FullName
                     }
                 }

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -107,7 +107,7 @@ function Get-Manifest($app) {
 
     if ($count) {
         if ($count -gt 1) {
-            warn "Multiple buckets contain '$app', selected manifest are '$bucket/$app'."
+            warn "Multiple buckets contain manifest '$app', the current selection is '$bucket/$app'."
         }
     }
 

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -53,6 +53,16 @@ function Get-Manifest($app) {
             }
         }
         if (!$manifest) {
+            if (installed $app) {
+                $global = installed $app $true
+                $ver = Select-CurrentVersion -AppName $app -Global:$global
+                $install_info_path = "$(versiondir $app $ver $global)\install.json"
+                if (Test-Path $install_info_path) {
+                    $install_info = parse_json $install_info_path
+                    $url = $install_info.url
+                }
+                $manifest = if (Test-Path $url) { parse_json $url } else { installed_manifest $app $ver $global }
+            }
             # couldn't find app in buckets: check if it's a local path
             if (Test-Path $app) {
                 $url = Convert-Path $app

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -53,16 +53,6 @@ function Get-Manifest($app) {
             }
         }
         if (!$manifest) {
-            if (installed $app) {
-                $global = installed $app $true
-                $ver = Select-CurrentVersion -AppName $app -Global:$global
-                $install_info_path = "$(versiondir $app $ver $global)\install.json"
-                if (Test-Path $install_info_path) {
-                    $install_info = parse_json $install_info_path
-                    $url = $install_info.url
-                }
-                $manifest = if (Test-Path $url) { parse_json $url } else { installed_manifest $app $ver $global }
-            }
             # couldn't find app in buckets: check if it's a local path
             if (Test-Path $app) {
                 $url = Convert-Path $app

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -50,11 +50,18 @@ function Get-Manifest($app) {
                 $bucket = $install_info.bucket
                 if (!$bucket) {
                     $url = $install_info.url
-                    if ($url -and (Test-Path $url)) {
-                        $manifest = parse_json $url
-                    } else {
-                        # Fallback to installed manifest
-                        $manifest = installed_manifest $app $ver $global
+                    if ($url) {
+                        if ($url -match '^(ht|f)tps?://|\\\\') {
+                            $manifest = url_manifest $url
+                        }
+                    }
+                    if (!$manifest) {
+                        if (Test-Path $url) {
+                            $manifest = parse_json $url
+                        } else {
+                            # Fallback to installed manifest
+                            $manifest = installed_manifest $app $ver $global
+                        }
                     }
                 } else {
                     $manifest = manifest $app $bucket

--- a/libexec/scoop-cat.ps1
+++ b/libexec/scoop-cat.ps1
@@ -7,7 +7,6 @@
 param($app)
 
 . "$PSScriptRoot\..\lib\json.ps1" # 'ConvertToPrettyJson'
-. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
 
 if (!$app) { error '<app> missing'; my_usage; exit 1 }

--- a/libexec/scoop-cat.ps1
+++ b/libexec/scoop-cat.ps1
@@ -7,6 +7,7 @@
 param($app)
 
 . "$PSScriptRoot\..\lib\json.ps1" # 'ConvertToPrettyJson'
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
 
 if (!$app) { error '<app> missing'; my_usage; exit 1 }

--- a/libexec/scoop-cat.ps1
+++ b/libexec/scoop-cat.ps1
@@ -9,6 +9,7 @@ param($app)
 . "$PSScriptRoot\..\lib\json.ps1" # 'ConvertToPrettyJson'
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
+. "$PSScriptRoot\..\lib\download.ps1" # 'Get-UserAgent'
 
 if (!$app) { error '<app> missing'; my_usage; exit 1 }
 

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -5,6 +5,7 @@
 . "$PSScriptRoot\..\lib\depends.ps1" # 'Get-Dependency'
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest' (indirectly)
+. "$PSScriptRoot\..\lib\download.ps1" # 'Get-UserAgent'
 
 $opt, $apps, $err = getopt $args 'a:' 'arch='
 $app = $apps[0]
@@ -21,7 +22,14 @@ try {
 $deps = @()
 Get-Dependency $app $architecture | ForEach-Object {
     $dep = [ordered]@{}
-    $dep.Source, $dep.Name = $_ -split '/'
+
+    $app, $null, $bucket, $url = Get-Manifest $_
+    if (!$url) {
+        $bucket, $app = $_ -split '/'
+    }
+    $dep.Source = if ($url) { $url } else { $bucket }
+    $dep.Name = $app
+
     $deps += [PSCustomObject]$dep
 }
 $deps

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -3,6 +3,7 @@
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\depends.ps1" # 'Get-Dependency'
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest' (indirectly)
 
 $opt, $apps, $err = getopt $args 'a:' 'arch='

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -22,7 +22,6 @@
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' (indirectly)
 . "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
-. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'generate_user_manifest' 'Get-Manifest'
 . "$PSScriptRoot\..\lib\download.ps1"
 if (get_config USE_SQLITE_CACHE) {

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -22,6 +22,7 @@
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\json.ps1" # 'autoupdate.ps1' (indirectly)
 . "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'generate_user_manifest' 'Get-Manifest'
 . "$PSScriptRoot\..\lib\download.ps1"
 if (get_config USE_SQLITE_CACHE) {

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -2,6 +2,7 @@
 # Summary: Opens the app homepage
 param($app)
 
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
 
 if ($app) {

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -2,7 +2,6 @@
 # Summary: Opens the app homepage
 param($app)
 
-. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
 
 if ($app) {

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -4,6 +4,7 @@ param($app)
 
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
+. "$PSScriptRoot\..\lib\download.ps1" # 'Get-UserAgent'
 
 if ($app) {
     $null, $manifest, $bucket, $null = Get-Manifest $app

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -62,9 +62,9 @@ if ($manifest.description) {
     $item.Description = $manifest.description
 }
 $item.Version = $version_output
-if ($bucket) {
-    $item.Bucket = $bucket
-}
+
+$item.Source = if ($install.bucket) { $install.bucket } else { $install.url }
+
 if ($manifest.homepage) {
     $item.Website = $manifest.homepage.TrimEnd('/')
 }

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -32,19 +32,22 @@ $manifest_file = if ($bucket) {
     $url
 }
 
-if ($install.url -and (Test-Path $original_app) -or ($original_app -match '^(ht|f)tps?://|\\\\')) {
+# Standalone and Source detection
+if ((Test-Path $original_app) -or ($original_app -match '^(ht|f)tps?://|\\\\')) {
     $standalone = $true
     if (Test-Path $original_app) {
         $original_app = (Get-AbsolutePath "$original_app")
     }
-    if (Test-Path $install.url) {
-        $install_url = (Get-AbsolutePath $install.url)
-    } else {
-        $install_url = $install.url
+    if ($install.url) {
+        if (Test-Path $install.url) {
+            $install_url = (Get-AbsolutePath $install.url)
+        } else {
+            $install_url = $install.url
+        }
     }
-}
-if ($original_app -eq $install_url) {
-    $same_source = $true
+    if ($original_app -eq $install_url) {
+        $same_source = $true
+    }
 }
 
 if ($verbose) {

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -5,7 +5,7 @@
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
-. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-InstalledVersion'
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-InstalledVersion', 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\download.ps1" # 'Get-RemoteFileSize'
 
 $opt, $app, $err = getopt $args 'v' 'verbose'
@@ -23,7 +23,7 @@ if (!$manifest) {
 $global = installed $app $true
 $status = app_status $app $global
 $install = install_info $app $status.version $global
-$status.installed = $bucket -and $install.bucket -eq $bucket
+$status.installed = installed $app
 $version_output = $manifest.version
 $manifest_file = if ($bucket) {
     manifest_path $app $bucket

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -5,7 +5,7 @@
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
-. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-InstalledVersion'
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-InstalledVersion', 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\download.ps1" # 'Get-RemoteFileSize'
 
 $opt, $app, $err = getopt $args 'v' 'verbose'
@@ -23,7 +23,7 @@ if (!$manifest) {
 $global = installed $app $true
 $status = app_status $app $global
 $install = install_info $app $status.version $global
-$status.installed = $bucket -and $install.bucket -eq $bucket
+$status.installed = ($bucket -and $install.bucket -eq $bucket) -or (installed $app)
 $version_output = $manifest.version
 $manifest_file = if ($bucket) {
     manifest_path $app $bucket

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -36,7 +36,7 @@ if ($verbose) {
     $original_dir = versiondir $app $manifest.version $global
     $persist_dir = persistdir $app $global
 } else {
-    $dir, $original_dir, $persist_dir = "<root>", "<root>", "<root>"
+    $dir, $original_dir, $persist_dir = '<root>', '<root>', '<root>'
 }
 
 if ($status.installed) {
@@ -44,14 +44,20 @@ if ($status.installed) {
     if ($install.url) {
         $manifest_file = $install.url
     }
-    if ($status.version -eq $manifest.version) {
+    if ($status.deprecated) {
+        $manifest_file = $status.deprecated
+    } elseif ($status.version -eq $manifest.version) {
         $version_output = $status.version
     } else {
         $version_output = "$($status.version) (Update to $($manifest.version) available)"
     }
+
 }
 
 $item = [ordered]@{ Name = $app }
+if ($status.deprecated) {
+    $item.Name += ' (DEPRECATED)'
+}
 if ($manifest.description) {
     $item.Description = $manifest.description
 }
@@ -70,7 +76,7 @@ if ($manifest.license) {
         $manifest.license
     } elseif ($manifest.license -match '[|,]') {
         if ($verbose) {
-            "$($manifest.license) ($(($manifest.license -Split "\||," | ForEach-Object { "https://spdx.org/licenses/$_.html" }) -join ', '))"
+            "$($manifest.license) ($(($manifest.license -Split '\||,' | ForEach-Object { "https://spdx.org/licenses/$_.html" }) -join ', '))"
         } else {
             $manifest.license
         }
@@ -103,7 +109,7 @@ if ($status.installed) {
     # Show installed versions
     $installed_output = @()
     Get-InstalledVersion -AppName $app -Global:$global | ForEach-Object {
-        $installed_output += if ($verbose) { versiondir $app $_ $global } else { "$_$(if ($global) { " *global*" })" }
+        $installed_output += if ($verbose) { versiondir $app $_ $global } else { "$_$(if ($global) { ' *global*' })" }
     }
     $item.Installed = $installed_output -join "`n"
 
@@ -162,7 +168,7 @@ if ($status.installed) {
         foreach ($url in @(url $manifest (Get-DefaultArchitecture))) {
             try {
                 if (Test-Path (cache_path $app $manifest.version $url)) {
-                    $cached = " (latest version is cached)"
+                    $cached = ' (latest version is cached)'
                 } else {
                     $cached = $null
                 }
@@ -197,7 +203,7 @@ if ($binaries) {
             $binary_output += $_
         }
     }
-    $item.Binaries = $binary_output -join " | "
+    $item.Binaries = $binary_output -join ' | '
 }
 $shortcuts = @(arch_specific 'shortcuts' $manifest $install.architecture)
 if ($shortcuts) {
@@ -205,7 +211,7 @@ if ($shortcuts) {
     $shortcuts | ForEach-Object {
         $shortcut_output += $_[1]
     }
-    $item.Shortcuts = $shortcut_output -join " | "
+    $item.Shortcuts = $shortcut_output -join ' | '
 }
 $env_set = arch_specific 'env_set' $manifest $install.architecture
 if ($env_set) {

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -88,6 +88,8 @@ $item.Source = if ($standalone) {
         $install.bucket
     } elseif ($install.url) {
         $install.url
+    } else {
+        $bucket
     }
 }
 

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -5,7 +5,7 @@
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
-. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-InstalledVersion', 'Select-CurrentVersion'
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Get-InstalledVersion'
 . "$PSScriptRoot\..\lib\download.ps1" # 'Get-RemoteFileSize'
 
 $opt, $app, $err = getopt $args 'v' 'verbose'
@@ -23,7 +23,7 @@ if (!$manifest) {
 $global = installed $app $true
 $status = app_status $app $global
 $install = install_info $app $status.version $global
-$status.installed = installed $app
+$status.installed = $bucket -and $install.bucket -eq $bucket
 $version_output = $manifest.version
 $manifest_file = if ($bucket) {
     manifest_path $app $bucket

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -5,8 +5,9 @@ param($query)
 
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'parse_json' 'Select-CurrentVersion' (indirectly)
+. "$PSScriptRoot\..\lib\download.ps1" # 'Get-UserAgent'
 
-$def_arch = Get-DefaultArchitecture
+$defaultArchitecture = Get-DefaultArchitecture
 if (-not (Get-FormatData ScoopApps)) {
     Update-FormatData "$PSScriptRoot\..\supporting\formats\ScoopTypes.Format.ps1xml"
 }
@@ -47,10 +48,11 @@ $apps | Where-Object { !$query -or ($_.name -match $query) } | ForEach-Object {
     $item.Updated = $updated
 
     $info = @()
+    if ((app_status $app $global).deprecated) { $info += 'Deprecated package'}
     if ($global) { $info += 'Global install' }
     if (failed $app $global) { $info += 'Install failed' }
     if ($install_info.hold) { $info += 'Held package' }
-    if ($install_info.architecture -and $def_arch -ne $install_info.architecture) {
+    if ($install_info.architecture -and $defaultArchitecture -ne $install_info.architecture) {
         $info += $install_info.architecture
     }
     $item.Info = $info -join ', '

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -59,7 +59,7 @@ $true, $false | ForEach-Object { # local and global apps
     Get-ChildItem $dir | Where-Object name -NE 'scoop' | ForEach-Object {
         $app = $_.name
         $status = app_status $app $global
-        if (!$status.outdated -and !$status.failed -and !$status.removed -and !$status.missing_deps) { return }
+        if (!$status.outdated -and !$status.failed -and !$status.deprecated -and !$status.removed -and !$status.missing_deps) { return }
 
         $item = [ordered]@{}
         $item.Name = $app
@@ -67,9 +67,10 @@ $true, $false | ForEach-Object { # local and global apps
         $item.'Latest Version' = if ($status.outdated) { $status.latest_version } else { "" }
         $item.'Missing Dependencies' = $status.missing_deps -Split ' ' -Join ' | '
         $info = @()
-        if ($status.failed)  { $info += 'Install failed' }
-        if ($status.hold)    { $info += 'Held package' }
-        if ($status.removed) { $info += 'Manifest removed' }
+        if ($status.failed)     { $info += 'Install failed' }
+        if ($status.hold)       { $info += 'Held package' }
+        if ($status.deprecated) { $info += 'Deprecated' }
+        if ($status.removed)    { $info += 'Manifest removed' }
         $item.Info = $info -join ', '
         $list += [PSCustomObject]$item
     }

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -6,6 +6,7 @@
 
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'manifest' 'parse_json' "install_info"
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
+. "$PSScriptRoot\..\lib\download.ps1" # 'Get-UserAgent'
 
 # check if scoop needs updating
 $currentdir = versiondir 'scoop' 'current'

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -29,6 +29,7 @@
 #   -p, --passthru            Return reports as objects
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
 . "$PSScriptRoot\..\lib\json.ps1" # 'json_path'
 . "$PSScriptRoot\..\lib\download.ps1" # 'hash_for_url'

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -29,7 +29,6 @@
 #   -p, --passthru            Return reports as objects
 
 . "$PSScriptRoot\..\lib\getopt.ps1"
-. "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest'
 . "$PSScriptRoot\..\lib\json.ps1" # 'json_path'
 . "$PSScriptRoot\..\lib\download.ps1" # 'hash_for_url'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description

TODOs:

- [x] Consistency on `scoop-list` result
- [ ] Error handling and a better prompt when manifest file missing(removed/unavailable/inaccessible) from actual source 

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Relates to #2719, #3441, #3870, #5172, #5709

#### How Has This Been Tested?

before: LEFT pane, after: RIGHT pane

f6ce496: Select actual source for manifest

manifests with same name from different bucket:
![bucket](https://github.com/user-attachments/assets/69da304e-131b-43ff-900b-7a8f360aa39f)

manifest that installs with URI:
![local_and_remote_manfiest](https://github.com/user-attachments/assets/84c4b550-a8b1-4586-9c45-1254a6b12fa7)

Fallback to installed manifest:
![removed_from_sources_manifest](https://github.com/user-attachments/assets/56457229-b722-4969-a37d-7cc2d10de53e)

e7155ea: handling deprecated manifest
![deprecated](https://github.com/user-attachments/assets/23871ee2-a49e-43f1-953a-3d10bbc89dfe)

c525005:
standalone manifest: any query or installation that does not install with app name, e.g. PATH or URI

result of `scoop-info` will drop **Installed** version and **available update** when source of queried and installed are different.

BOTH pane are after effects

![standalone_same_source](https://github.com/user-attachments/assets/1683e4c7-87d9-4720-955e-3957eebeee52)

c38fc63: depends support for standalone manifest
```
❯ scoop depends .\ack.json

Source                                 Name
------                                 ----
main                                   perl
C:\Users\humorce\Desktop\6142\ack.json ack


❯ scoop depends http://127.0.0.1/ack.json

Source                    Name
------                    ----
main                      perl
http://127.0.0.1/ack.json ack
```

a65c84a: deprecated tag/mark on scoop-list
```
main on  master
❯ mv .\bucket\d2.json .\deprecated\
main on  master [✘?]
❯ scoop list d2
Installed apps matching 'd2':

Name Version Source Updated             Info
---- ------- ------ -------             ----
d2   0.6.6   main   2024-09-24 10:52:07 Deprecated package
                                        ↑
```

61b3259: show message when multiple buckets contain [querying app]

```
current on  refctor/parse_app-n-get-manifest
❯ scoop info d2
WARN  Multiple buckets contain manifest 'd2', the current selection is 'main/d2'.

Name        : d2
Description : A modern diagram scripting language that turns text to diagrams.
Version     : 0.6.6
Source      : main
Website     : https://d2lang.com
License     : MPL-2.0
Updated at  : 8/2/2024 4:29:10 AM
Updated by  : github-actions[bot]
Binaries    : bin\d2.exe

current on  refctor/parse_app-n-get-manifest
❯ scoop install d2
WARN  Multiple buckets contain manifest 'd2', the current selection is 'main/d2'.
Installing 'd2' (0.6.6) [64bit] from 'main' bucket
Loading d2-v0.6.6-windows-amd64.tar.gz from cache
Checking hash of d2-v0.6.6-windows-amd64.tar.gz ... ok.
Extracting d2-v0.6.6-windows-amd64.tar.gz ... done.
Linking ~\scoop\apps\d2\current => ~\scoop\apps\d2\0.6.6
Creating shim for 'd2'.
'd2' (0.6.6) was installed successfully!
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
