### PR TITLE
fix(bin_match_json): check variable type before using

### DIFF
--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -30,7 +30,6 @@ function bin_match($manifest, $query) {
 
 function bin_match_json($json, $query) {
     [System.Text.Json.JsonElement]$bin = [System.Text.Json.JsonElement]::new()
-
     # check if RootElement is object type
     if ($json.RootElement.ValueKind -eq [System.Text.Json.JsonValueKind]::Object) {
         # try to get 'bin' attribute


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

To check the type of `RootElement`, if it's an array, then walk through all elements inside. Or it's an object type, run the original code.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes [#issue6140](https://github.com/ScoopInstaller/Scoop/issues/6140)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I ran my simple test in:

- Windows version: 11
- OS architecture: 64bit
- PowerShell version: 7.4.5

Without my commit, the `scoop search qqnt` shows this:

![image](https://github.com/user-attachments/assets/78ab9221-e050-4ad2-82de-8eaace414216)

With my commit, the `scoop search qqnt` shows this:

![image](https://github.com/user-attachments/assets/986755ce-b266-4b60-ac40-d84284186aec)

Displayed in one picture:

![image](https://github.com/user-attachments/assets/ae7ebbe2-9de5-4c44-8d2f-ddbc866bd505)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
