### PR TITLE
fix(search_bucket): set default and check type before using

### DIFF
--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -54,7 +54,6 @@ function bin_match_json($json, $query) {
 
 function search_bucket($bucket, $query) {
     $apps = Get-ChildItem (Find-BucketDirectory $bucket) -Filter '*.json' -Recurse
-
     $apps | ForEach-Object {
         $filepath = $_.FullName
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

1. check type of `RootElement` before calling `TryGetProperty`
2. if `RootElement` is an array, do not try to get `version`, use default value instead

Changes above should avoid calling `TryGetProperty` when `RootElement` is an array.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes [#issue6149](https://github.com/ScoopInstaller/Scoop/issues/6149)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I ran my simple test in:

- Windows version: 11
- OS architecture: 64bit
- PowerShell version: 7.4.5

Without my commit, the `scoop search` shows this:

![image](https://github.com/user-attachments/assets/b46530ab-5d38-4460-98f9-0359f2c3c314)

> note: the error message will be shown for multiple times, I sent siginit to powershell to avoid too many messages

With my commit, the `scoop search` shows this:

![image](https://github.com/user-attachments/assets/138ee9cc-b500-4d71-bad9-1323a1475d84)

> no error messages are shown

Displayed in one picture:

![image](https://github.com/user-attachments/assets/9de375f7-6bf1-45dd-b159-b7ae744798b3)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
