### PR TITLE
fix(scoop-install): Prevent installation of Scoop itself

### DIFF
--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -59,6 +59,13 @@ try {
 
 if (!$apps) { error '<app> missing'; my_usage; exit 1 }
 
+# Prevent installation of Scoop itself
+foreach ($app in $apps) {
+    if (($app -eq 'scoop') -or ($app -match '.*/scoop$')) {
+        abort "ERROR: You cannot install Scoop via 'scoop install'"
+    }
+}
+
 if ($global -and !(is_admin)) {
     abort 'ERROR: you need admin rights to install global apps'
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #5739

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
```
❯ scoop install scoop
ERROR: You cannot install Scoop via 'scoop install'

❯ scoop install main/scoop
ERROR: You cannot install Scoop via 'scoop install'

❯ scoop install /scoop
ERROR: You cannot install Scoop via 'scoop install'

❯ scoop install openssl scoop scoop scoop x
ERROR: You cannot install Scoop via 'scoop install'
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
