### PR TITLE
fix(shortcuts): find target in dir and Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **commands**: Handling broken aliases ([#6141](https://github.com/ScoopInstaller/Scoop/issues/6141))
 - **shim:** Do not suppress `stderr`, properly check `wslpath`/`cygpath` command first ([#6114](https://github.com/ScoopInstaller/Scoop/issues/6114))
 - **scoop-bucket:** Add missing import for `no_junction` envs ([#6181](https://github.com/ScoopInstaller/Scoop/issues/6181))
+- **shortcuts**: Add target match in Path and correctly set working directory ([#6243](https://github.com/ScoopInstaller/Scoop/issues/6243))
 
 ### Code Refactoring
 


### PR DESCRIPTION
#### Description
The shortcut target should find where the target is just like where the shim creation does. Not just append to `$dir`

#### Motivation and Context
Closes #6243 

#### How Has This Been Tested?

It now can successfully create the shortcut below
```
"shortcuts": [
        [
            "java",
            "App",
            "-jar \"$dir/App.jar\""
        ]
    ]
```

and it won't break the backward compatibility

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
