### PR TITLE
feat(autoupdate): Try decoding invalid hash value with base64 in `format_hash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/v0.5.3...develop)
 
+### Features
+
+- **autoupdate**: Try decoding base64 encoded hash values in `format_hash` ([#6271](https://github.com/ScoopInstaller/Scoop/issues/6271))
+
 ### Bug Fixes
 
 - **scoop-download**: Fix function `nightly_version` not defined error ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- **autoupdate**: Try decoding base64 encoded hash values in `format_hash` ([#6271](https://github.com/ScoopInstaller/Scoop/issues/6271))
 - **install:** Add output for the setting and removal of environment variables ([#6460](https://github.com/ScoopInstaller/Scoop/issues/6460))
 - **scoop-uninstall:** Allow access to `$bucket` in uninstall scripts ([#6380](https://github.com/ScoopInstaller/Scoop/issues/6380))
 - **install:** Add separator at the end of notes, highlight suggestions ([#6418](https://github.com/ScoopInstaller/Scoop/issues/6418))

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -136,6 +136,19 @@ function find_hash_in_json([String] $url, [Hashtable] $substitutions, [String] $
     if (!$hash) {
         $hash = json_path_legacy $json $jsonpath $substitutions
     }
+
+    # convert base64 encoded hash values
+    if ($hash -match '^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$') {
+        $base64 = $matches[0]
+        if (!($hash -match '^[a-fA-F0-9]+$') -and $hash.Length -notin @(32, 40, 64, 128)) {
+            try {
+                $hash = ([System.Convert]::FromBase64String($base64) | ForEach-Object { $_.ToString('x2') }) -join ''
+            } catch {
+                $hash = $hash
+            }
+        }
+    }
+
     return format_hash $hash
 }
 

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -1,6 +1,21 @@
 # Must included with 'json.ps1'
 
 function format_hash([String] $hash) {
+
+    # convert base64 encoded hash values to hex string
+    if ($hash -match '^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$') {
+        $base64 = $matches[0]
+        if (!($hash -match '^[a-fA-F0-9]+$') -and $hash.Length -notin @(32, 40, 64, 128)) {
+            try {
+                $hash = ([System.Convert]::FromBase64String($base64) | ForEach-Object { $_.ToString('x2') }) -join ''
+            } catch {
+                $hash = $hash
+            }
+        }
+    }
+
+    debug $hash
+
     $hash = $hash.toLower()
 
     # Workaround for GitHub API:
@@ -81,18 +96,6 @@ function find_hash_in_textfile([String] $url, [Hashtable] $substitutions, [Strin
         $hash = $matches[1] -replace '\s', ''
     }
 
-    # convert base64 encoded hash values
-    if ($hash -match '^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$') {
-        $base64 = $matches[0]
-        if (!($hash -match '^[a-fA-F0-9]+$') -and $hash.Length -notin @(32, 40, 64, 128)) {
-            try {
-                $hash = ([System.Convert]::FromBase64String($base64) | ForEach-Object { $_.ToString('x2') }) -join ''
-            } catch {
-                $hash = $hash
-            }
-        }
-    }
-
     # find hash with filename in $hashfile
     if ($hash.Length -eq 0) {
         $filenameRegex = "([a-fA-F0-9]{32,128})[\x20\t]+.*`$basename(?:\s|$)|`$basename[\x20\t]+.*?([a-fA-F0-9]{32,128})"
@@ -142,6 +145,7 @@ function find_hash_in_json([String] $url, [Hashtable] $substitutions, [String] $
     if (!$hash) {
         $hash = json_path_legacy $json $jsonpath $substitutions
     }
+
     return format_hash $hash
 }
 
@@ -199,8 +203,7 @@ function find_hash_in_headers([String] $url) {
         $res = $req.GetResponse()
         if (([int]$res.StatusCode -ge 300) -and ([int]$res.StatusCode -lt 400)) {
             if ($res.Headers['Digest'] -match 'SHA-256=([^,]+)' -or $res.Headers['Digest'] -match 'SHA=([^,]+)' -or $res.Headers['Digest'] -match 'MD5=([^,]+)') {
-                $hash = ([System.Convert]::FromBase64String($matches[1]) | ForEach-Object { $_.ToString('x2') }) -join ''
-                debug $hash
+                $hash = $matches[1]
             }
         }
         $res.Close()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
This PR moves base64 decoding process to `format_hash` function, which is formerly in `find_hash_in_textfile` and `find_hash_in_headers`, and add debug output before formatting.

It will make following effects:
- `find_hash_in_rdf`: Try decoding invalid hash value with base64.
- `find_hash_in_textfile`: Additionally try decoding invalid hash value **found by file name** with base64.
- `find_hash_in_json`: Try decoding invalid hash value with base64 (Aimed to solve issue #6271).
- `find_hash_in_xml`: Try decoding invalid hash value with base64.
- `find_hash_in_headers`: Skip decoding if fetched hash value is valid.

It should not affect valid hash value that matches the format.

#### Motivation and Context

Closes #6271

#### How Has This Been Tested?

Tested with `checkver.ps1`

For related issue, use `json` mode in [wolai](https://github.com/AkariiinMKII/Scoop4kariiin/blob/05b4f5e2dca485077890fe105f2c8cf62fb45296/bucket/wolai.json) manifest:

```json
...
"hash": {
  "mode": "json",
  "url": "https://cdn.wostatic.cn/dist/installers/electron-versions.json",
  "jsonpath": "$.win.sha512"
}
```

Contents in url:

```json
...
"win": {
        "version": "1.2.11",
        "files": [
            {
                "url": "wolai.Setup.1.2.11.exe",
                "sha512": "JbiQs0Oi3jWZPmu06EpVdZM/CsfXR1NKkI1hRAZ/3x8GIBWbVsuJn+ku/i6z3eefbwU7Co4hLiOy7cY+3dN4+Q==",
                "size": 65819904
            }
        ],
        "path": "wolai.Setup.1.2.11.exe",
        "sha512": "JbiQs0Oi3jWZPmu06EpVdZM/CsfXR1NKkI1hRAZ/3x8GIBWbVsuJn+ku/i6z3eefbwU7Co4hLiOy7cY+3dN4+Q==",
        "releaseDate": "2024-11-29T08:33:05.283Z"
    },
```

Before changes

```PowerShell
> .\bin\checkver.ps1 -app C:\Users\A1\scoop\buckets\scoop4kariiin\bucket\wolai.json -f
wolai: 1.2.11 (scoop version is 1.2.11)
Forcing autoupdate!
Autoupdating wolai
Searching hash for wolai Setup 1.2.11.exe in https://cdn.wostatic.cn/dist/installers/electron-versions.json
Could not find hash in https://cdn.wostatic.cn/dist/installers/electron-versions.json
Downloading wolai Setup 1.2.11.exe to compute hashes!
wolai%20Setup%201.2.11.exe (62.8 MB) [========================================================================] 100%
Computed hash: d29b503f700c644d130fdccb93079011b2488912c4b140776f6783680a666281
Writing updated wolai manifest
```

After changes

```PowerShell
> .\bin\checkver.ps1 -app C:\Users\A1\scoop\buckets\scoop4kariiin\bucket\wolai.json -f
wolai: 1.2.11 (scoop version is 1.2.11)
Forcing autoupdate!
Autoupdating wolai
Searching hash for wolai Setup 1.2.11.exe in https://cdn.wostatic.cn/dist/installers/electron-versions.json
Found: sha512:25b890b343a2de35993e6bb4e84a5575933f0ac7d747534a908d6144067fdf1f0620159b56cb899fe92efe2eb3dde79f6f053b0a8e212e23b2edc63eddd378f9 using Json Mode
Writing updated wolai manifest
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `autoupdate` now supports base64-encoded hash values, automatically decoding and converting them for improved hash validation compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Scoop/pull/6272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->