### PR TITLE
refactor(install): Get reference for Users group via Enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - **output:** Replace raw prints with functions for standardized output ([#6449](https://github.com/ScoopInstaller/Scoop/issues/6449))
 - **output:** Combine the separated outputs into a single output ([#6545](https://github.com/ScoopInstaller/Scoop/issues/6545))
 - **scoop-list:** Use simpler method to check the deprecated status of the manifest to improve performance ([#6599](https://github.com/ScoopInstaller/Scoop/issues/6599))
+- **install:** Get reference for Users group via Principal.WellKnownSidType
 
 ### Performance Improvements
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -521,8 +521,8 @@ function unlink_persist_data($manifest, $dir) {
 function persist_permission($manifest, $global) {
     if ($global -and $manifest.persist -and (is_admin)) {
         $path = persistdir $null $global
-        $user = New-Object System.Security.Principal.SecurityIdentifier 'S-1-5-32-545'
-        $target_rule = New-Object System.Security.AccessControl.FileSystemAccessRule($user, 'Write', 'ObjectInherit', 'none', 'Allow')
+        $builtinUsersSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::BuiltinUsersSid, $null)
+        $target_rule = New-Object System.Security.AccessControl.FileSystemAccessRule($builtinUsersSid, 'Write', 'ObjectInherit', 'none', 'Allow')
         $acl = Get-Acl -Path $path
         $acl.SetAccessRule($target_rule)
         $acl | Set-Acl -Path $path


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
Get the reference to the well-known Users Group by using the WellKnown enum, instead of a magic string.

#### Motivation and Context
Make intended object name strongly typed and explicitly named.
Should be easier for humans to read and understand

#### How Has This Been Tested?
1. Step debugger confirms the resulting object is identical.
2. Current test suit has not regressed.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
