### PR TITLE
Fix persist non-existing targets created dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **commands**: Handling broken aliases ([#6141](https://github.com/ScoopInstaller/Scoop/issues/6141))
 - **shim:** Do not suppress `stderr`, properly check `wslpath`/`cygpath` command first ([#6114](https://github.com/ScoopInstaller/Scoop/issues/6114))
 - **scoop-bucket:** Add missing import for `no_junction` envs ([#6181](https://github.com/ScoopInstaller/Scoop/issues/6181))
+- **scoop-install:** Fix persist non-existing targets created dirs ([#5621](https://github.com/ScoopInstaller/Scoop/issues/5621))
 
 ### Code Refactoring
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -473,11 +473,13 @@ function persist_data($manifest, $original_dir, $persist_dir) {
                 ensure (Split-Path -Path $target) | Out-Null
                 Move-Item $source $target
                 # we don't have neither source nor target data! we need to create an empty target,
-                # but we can't make a judgement that the data should be a file or directory...
-                # so we create a directory by default. to avoid this, use pre_install
+                # if target has an extension, it's a file, otherwise it's a directory...
+                # To avoid this heuristic, use pre_install
                 # to create the source file before persisting (DON'T use post_install)
             } else {
-                $target = New-Object System.IO.DirectoryInfo($target)
+                $ext = [IO.Path]::GetExtension($target)
+                if ($ext -eq "" ){$target = New-Object System.IO.DirectoryInfo($target)
+                } else           {$target = New-Item -Path $target -ItemType "file"}
                 ensure $target | Out-Null
             }
 


### PR DESCRIPTION
#### Description

Instead of always creating non-existing persist targets as dirs, be smarter and if the target's final path has an extension, treat it as a file instead

#### Motivation and Context

properly closes https://github.com/ScoopInstaller/Scoop/issues/5621 without requiring manual editing of each of the bugged manifests

#### How Has This Been Tested?
Reinstalled an app creating dirs locally and observed it creating proper hardlinks to files, not dirs

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] no docs to update
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
