### PR TITLE
fix: Adjusting extension handling order for rm_shim() function and scoop `shim alter` command

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -197,7 +197,7 @@ function create_shims($manifest, $dir, $global, $arch) {
 }
 
 function rm_shim($name, $shimdir, $app) {
-    '', '.shim', '.cmd', '.ps1' | ForEach-Object {
+    '.shim', '.ps1', '.cmd', '' | ForEach-Object {
         $shimPath = "$shimdir\$name$_"
         $altShimPath = "$shimPath.$app"
         if ($app -and (Test-Path -Path $altShimPath -PathType Leaf)) {

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -212,7 +212,7 @@ switch ($SubCommand) {
                 Write-Host $newApp -ForegroundColor DarkYellow -NoNewline
                 Write-Host ' as default...' -NoNewline
                 $pathNoExt = strip_ext $shimPath
-                '', '.shim', '.cmd', '.ps1' | ForEach-Object {
+                '.shim', '.ps1', '.cmd', '' | ForEach-Object {
                     $oldShimPath = "$pathNoExt$_"
                     $newShimPath = "$oldShimPath.$newApp"
                     if (Test-Path -Path $oldShimPath -PathType Leaf) {


### PR DESCRIPTION
a trivial modified, see as: #6311