### PR TITLE
fix(autoupdate): Remove unnecessary architectures to prevent download errors and improve hash speed

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -478,6 +478,12 @@ function Invoke-AutoUpdate {
     debug [$updatedProperties]
     $hasChanged = Update-ManifestProperty -Manifest $Manifest -Property $updatedProperties -AppName $AppName -Version $Version -Substitutions $substitutions
 
+    # Remove unnecessary architectures to prevent download errors and improve hash speed.
+    $archlessManifest = [PSCustomObject]@{}
+    $targetArch = Get-DefaultArchitecture
+    Get-ArchlessManifest $Manifest $archlessManifest $targetArch
+    $Manifest = $archlessManifest
+
     if ($hasChanged) {
         # write file
         Write-Host "Writing updated $AppName manifest" -ForegroundColor DarkGreen
@@ -506,6 +512,32 @@ function Invoke-AutoUpdate {
     } else {
         # This if-else branch may not be in use.
         Write-Host "No updates for $AppName" -ForegroundColor DarkGray
+    }
+}
+
+function Get-ArchlessManifest {
+    param (
+        [PSObject]
+        $Manifest,
+        [PSObject]
+        $targetManifest,
+        [String]
+        $targetArch
+    )
+
+    $Manifest.PSObject.Properties | ForEach-Object {
+        $propertyName = $_.Name
+        if ($propertyName -eq 'architecture') {
+            $Manifest.architecture.$targetArch.PSObject.Properties | ForEach-Object {
+                $archPropertyName = $_.Name
+                $targetManifest | Add-Member -MemberType NoteProperty -Name $archPropertyName -Value $Manifest.architecture.$targetArch.$archPropertyName -Force
+            }
+        } elseif ($propertyName -eq 'autoupdate') {
+            $targetManifest | Add-Member -MemberType NoteProperty -Name 'autoupdate' -Value ([PSCustomObject]@{}) -Force
+            Get-ArchlessManifest $Manifest.autoupdate $targetManifest.autoupdate $targetArch
+        } else {
+            $targetManifest | Add-Member -MemberType NoteProperty -Name $propertyName -Value $Manifest.$propertyName -Force
+        }
     }
 }
 


### PR DESCRIPTION
This pull request aims to solve issue https://github.com/ScoopInstaller/Scoop/issues/5582, by removing useless architecture property from `$Manifest` and `$Manifest.autoupdate`. The user generated manifest can be found in "$ScoopDir\workspace" directory. It seems this change does not influence any other scoop functions, and should work as expect.