### PR TITLE
Fix-autoupdate: Remove unnecessary architectures to prevent download errors and improve hash speed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 *.log
 .DS_Store
 ._.DS_Store


### PR DESCRIPTION
This pull request aims to solve issue https://github.com/ScoopInstaller/Scoop/issues/5582, by removing useless architecture property from `$Manifest` and `$Manifest.autoupdate`. The user generated manifest can be found in "$ScoopDir\workspace" directory. It seems this change does not influence any other scoop functions, and should work as expect.