### PR TITLE
fix(search): Improve error handling for manifest file parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **autoupdate:** Use origin URL to handle URLs with fragment in GitHub mode ([#6455](https://github.com/ScoopInstaller/Scoop/issues/6455))
 - **buckets|scoop-info:** Switch git log date format to ISO 8601 to avoid locale issues ([#6446](https://github.com/ScoopInstaller/Scoop/issues/6446))
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
+- **scoop-search:** Add error handling for parsing manifests in the legacy search ([#6345](https://github.com/ScoopInstaller/Scoop/issues/6345))
 
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 
@@ -23,7 +24,6 @@
 - **scoop-bucket:** Add missing import for `no_junction` envs ([#6181](https://github.com/ScoopInstaller/Scoop/issues/6181))
 - **scoop-uninstall:** Fix uninstaller does not gain Global state ([#6430](https://github.com/ScoopInstaller/Scoop/issues/6430))
 - **scoop-depends-tests:** Mocking `USE_EXTERNAL_7ZIP` as $false to avoding error when it is $true ([#6431](https://github.com/ScoopInstaller/Scoop/issues/6431))
-- **scoop-search:** Add error handling for parsing manifests in the legacy search ([#6345](https://github.com/ScoopInstaller/Scoop/issues/6345))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **commands**: Handling broken aliases ([#6141](https://github.com/ScoopInstaller/Scoop/issues/6141))
 - **shim:** Do not suppress `stderr`, properly check `wslpath`/`cygpath` command first ([#6114](https://github.com/ScoopInstaller/Scoop/issues/6114))
 - **scoop-bucket:** Add missing import for `no_junction` envs ([#6181](https://github.com/ScoopInstaller/Scoop/issues/6181))
+- **scoop-search:** Add error handling for parsing manifests in the legacy search ([#6345](https://github.com/ScoopInstaller/Scoop/issues/6345))
 
 ### Code Refactoring
 


### PR DESCRIPTION
#### Description

When doing a search, if there's a bucket that contains invalid json, the search throws an error and continues to display the rest of the search results. The expectation is to not get an error if a manifest is not formatted correctly unless debug is enabled.

#### Motivation and Context

Closes #6345 regarding scoop search throwing an error.


#### How Has This Been Tested?

1. Ran `scoop search pyenv` (having a bucket that contains an invalid json file) to get the error
2. Applied the relevant error handling
3. Ran `scoop search pyenv` to verify that the error is gone
4. Ran `scoop config debug $true` to enable debugging, then `scoop search pyenv` to ensure that the caught error is shown when debugging is enabled

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.