### PR TITLE
fix(autoupdate): support non hash update manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **commands**: Handling broken aliases ([#6141](https://github.com/ScoopInstaller/Scoop/issues/6141))
 - **shim:** Do not suppress `stderr`, properly check `wslpath`/`cygpath` command first ([#6114](https://github.com/ScoopInstaller/Scoop/issues/6114))
 - **scoop-bucket:** Add missing import for `no_junction` envs ([#6181](https://github.com/ScoopInstaller/Scoop/issues/6181))
+- **autoupdate:** support non hash update manifest
 
 ### Code Refactoring
 

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -366,7 +366,7 @@ function Update-ManifestProperty {
                     $newHash = HashHelper -AppName $AppName -Version $Version -HashExtraction $Manifest.autoupdate.hash -URL $newURL -Substitutions $Substitutions
                     $Manifest.hash, $hasPropertyChanged = PropertyHelper -Property $Manifest.hash -Value $newHash
                     $hasManifestChanged = $hasManifestChanged -or $hasPropertyChanged
-                } else {
+                } elseif ($Manifest.architecture.hash) {
                     # Arch-spec
                     $Manifest.architecture | Get-Member -MemberType NoteProperty | ForEach-Object {
                         $arch = $_.Name
@@ -375,6 +375,8 @@ function Update-ManifestProperty {
                         $Manifest.architecture.$arch.hash, $hasPropertyChanged = PropertyHelper -Property $Manifest.architecture.$arch.hash -Value $newHash
                         $hasManifestChanged = $hasManifestChanged -or $hasPropertyChanged
                     }
+                } else {
+                    Write-Warning "Manifest for $AppName does not contain a 'hash' field, skipping hash update."
                 }
             } elseif ($Manifest.$currentProperty -and $Manifest.autoupdate.$currentProperty) {
                 # Update other property (global)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In current version of scoop, if one manifest want to bypass hash check, it should have `nightly` version, but in most cases, some manifest have proper version information, and it should bypass hash check too for some reason.

But current version of scoop will show an error when encounter this kind of situation like below:

```powershell
ERROR You cannot call a method on a null-valued expression.
```

This PR aim to fix this issue.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

my test manifest:


https://github.com/cscnk52/cetacea/blob/53b0ffe93ed8d83f4b20d2af4a574d2e436040a1/bucket/todesk.json#L6-L10



Before:

```
Autoupdating todesk
Computed hash: 78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237
ERROR You cannot call a method on a null-valued expression.
```

After:

```
Autoupdating todesk
WARNING: Manifest for todesk does not contain a 'hash' field, skipping hash update.
Writing updated todesk manifest
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
