### PR TITLE
feat(download): Block apps without file hash by default for security reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/v0.5.3...develop)
 
+### Features
+
+- **download**: Block apps without file hash by default for security reasons ([#6387](https://github.com/ScoopInstaller/Scoop/issues/6387))
+
 ### Bug Fixes
 
 - **scoop-download**: Fix function `nightly_version` not defined error ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- **download**: Block apps without file hash by default for security reasons ([#6387](https://github.com/ScoopInstaller/Scoop/issues/6387))
 - **install:** Add output for the setting and removal of environment variables ([#6460](https://github.com/ScoopInstaller/Scoop/issues/6460))
 - **scoop-uninstall:** Allow access to `$bucket` in uninstall scripts ([#6380](https://github.com/ScoopInstaller/Scoop/issues/6380))
 - **install:** Add separator at the end of notes, highlight suggestions ([#6418](https://github.com/ScoopInstaller/Scoop/issues/6418))

--- a/lib/download.ps1
+++ b/lib/download.ps1
@@ -40,7 +40,7 @@ function Invoke-ScoopDownload ($app, $version, $manifest, $bucket, $architecture
                         Write-Host -ForegroundColor Yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
                     if ($err.Contains('No-hash apps')) {
-                        abort "Please run 'scoop config allow-no-hash true' if you want to continue anyway."
+                        abort "Please run 'scoop config allow_no_hash true' if you want to continue anyway."
                     }
                     abort $(new_issue_msg $app $bucket 'hash check failed')
                 }
@@ -507,7 +507,7 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
                     Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                 }
                 if ($err.Contains('No-hash apps')) {
-                    abort "Please run 'scoop config allow-no-hash true' if you want to continue anyway."
+                    abort "Please run 'scoop config allow_no_hash true' if you want to continue anyway."
                 }
                 abort $(new_issue_msg $app $bucket 'hash check failed')
             }
@@ -725,10 +725,10 @@ function hash_for_url($manifest, $url, $arch) {
 function check_hash($file, $hash, $app_name) {
     # returns (ok, err)
     if (!$hash) {
-        if (get_config 'allow-no-hash' $false){
+        if (get_config 'allow_no_hash' $false){
             warn "No hash provided in manifest. SHA256 for '$(fname $file)' is:"
             warn "$((Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower())"
-            warn "To block no-hash apps for security reasons, run 'scoop config allow-no-hash false'."
+            warn "To block no-hash apps for security reasons, run 'scoop config allow_no_hash false'."
             return $true, $null
         } else {
             $msg = "No hash provided in manifest.`nERROR No-hash apps are blocked by default for security reasons, except for nightly builds."

--- a/lib/download.ps1
+++ b/lib/download.ps1
@@ -40,7 +40,7 @@ function Invoke-ScoopDownload ($app, $version, $manifest, $bucket, $architecture
                         Write-Host -ForegroundColor Yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
                     if ($err.Contains('No-hash apps')) {
-                        abort "Please run 'scoop config allow_no_hash true' if you want to continue anyway."
+                        abort "If you want to allow no-hash apps, run 'scoop config allow_no_hash true', or use the parameter '--skip-hash-check' in a single download."
                     }
                     abort $(new_issue_msg $app $bucket 'hash check failed')
                 }
@@ -507,7 +507,7 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
                     Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                 }
                 if ($err.Contains('No-hash apps')) {
-                    abort "Please run 'scoop config allow_no_hash true' if you want to continue anyway."
+                    abort "If you want to allow no-hash apps, run 'scoop config allow_no_hash true', or use the parameter '--skip-hash-check' in a single download."
                 }
                 abort $(new_issue_msg $app $bucket 'hash check failed')
             }

--- a/lib/download.ps1
+++ b/lib/download.ps1
@@ -39,6 +39,9 @@ function Invoke-ScoopDownload ($app, $version, $manifest, $bucket, $architecture
                     if ($url.Contains('sourceforge.net')) {
                         Write-Host -ForegroundColor Yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
+                    if ($err.Contains('No-hash apps')) {
+                        abort "Please run 'scoop config allow-no-hash true' if you want to continue anyway."
+                    }
                     abort $(new_issue_msg $app $bucket 'hash check failed')
                 }
             }
@@ -503,6 +506,9 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
                 if ($url.Contains('sourceforge.net')) {
                     Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                 }
+                if ($err.Contains('No-hash apps')) {
+                    abort "Please run 'scoop config allow-no-hash true' if you want to continue anyway."
+                }
                 abort $(new_issue_msg $app $bucket 'hash check failed')
             }
         }
@@ -719,8 +725,15 @@ function hash_for_url($manifest, $url, $arch) {
 function check_hash($file, $hash, $app_name) {
     # returns (ok, err)
     if (!$hash) {
-        warn "Warning: No hash in manifest. SHA256 for '$(fname $file)' is:`n    $((Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower())"
-        return $true, $null
+        if (get_config 'allow-no-hash' $false){
+            warn "No hash provided in manifest. SHA256 for '$(fname $file)' is:"
+            warn "$((Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower())"
+            warn "To block no-hash apps for security reasons, run 'scoop config allow-no-hash false'."
+            return $true, $null
+        } else {
+            $msg = "No hash provided in manifest.`nERROR No-hash apps are blocked by default for security reasons, except for nightly builds."
+            return $false, $msg
+        }
     }
 
     Write-Host 'Checking hash of ' -NoNewline

--- a/lib/download.ps1
+++ b/lib/download.ps1
@@ -40,6 +40,9 @@ function Invoke-ScoopDownload ($app, $version, $manifest, $bucket, $architecture
                     if ($url.Contains('sourceforge.net')) {
                         Write-Host -ForegroundColor Yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
+                    if ($err.Contains('No-hash apps')) {
+                        abort "If you want to allow no-hash apps, run 'scoop config allow_no_hash true', or use the parameter '--skip-hash-check' in a single download."
+                    }
                     abort $(new_issue_msg $app $bucket 'hash check failed')
                 }
             }
@@ -509,6 +512,9 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
                 if ($url.Contains('sourceforge.net')) {
                     Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                 }
+                if ($err.Contains('No-hash apps')) {
+                    abort "If you want to allow no-hash apps, run 'scoop config allow_no_hash true', or use the parameter '--skip-hash-check' in a single download."
+                }
                 abort $(new_issue_msg $app $bucket 'hash check failed')
             }
         }
@@ -725,8 +731,15 @@ function hash_for_url($manifest, $url, $arch) {
 function check_hash($file, $hash, $app_name) {
     # returns (ok, err)
     if (!$hash) {
-        warn "Warning: No hash in manifest. SHA256 for '$(fname $file)' is:`n    $((Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower())"
-        return $true, $null
+        if (get_config 'allow_no_hash' $false){
+            warn "No hash provided in manifest. SHA256 for '$(fname $file)' is:"
+            warn "$((Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower())"
+            warn "To block no-hash apps for security reasons, run 'scoop config allow_no_hash false'."
+            return $true, $null
+        } else {
+            $msg = "No hash provided in manifest.`nERROR No-hash apps are blocked by default for security reasons, except for nightly builds."
+            return $false, $msg
+        }
     }
 
     Write-Host "Checking hash of $([char]0x1b)[36m$(url_remote_filename $url)$([char]0x1b)[0m... " -NoNewline

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -123,6 +123,10 @@
 #       When set to arbitrary non-empty string, Scoop will use that string as the environment variable name instead.
 #       This is useful when you want to isolate Scoop from the system `PATH`.
 #
+# allow_no_hash: $true|$false
+#       Allow to download or install apps with no hash provided in manifest.
+#       This option is NOT RECOMMENDED as it may cause security issues.
+#
 # ARIA2 configuration
 # -------------------
 #

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -125,7 +125,7 @@
 #
 # allow_no_hash: $true|$false
 #       Allow to download or install apps with no hash provided in manifest.
-#       Using this option is not recommended, as it may lead to security issues.
+#       This option is NOT RECOMMENDED as it may cause security issues.
 #
 # ARIA2 configuration
 # -------------------

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -123,6 +123,10 @@
 #       When set to arbitrary non-empty string, Scoop will use that string as the environment variable name instead.
 #       This is useful when you want to isolate Scoop from the system `PATH`.
 #
+# allow_no_hash: $true|$false
+#       Allow to download or install apps with no hash provided in manifest.
+#       Using this option is not recommended, as it may lead to security issues.
+#
 # ARIA2 configuration
 # -------------------
 #

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -128,7 +128,7 @@ foreach ($curr_app in $apps) {
                         warn 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
                     if ($err.Contains('No-hash apps')) {
-                        error "Please run 'scoop config allow_no_hash true' if you want to download it anyway."
+                        error "If you want to allow no-hash apps, run 'scoop config allow_no_hash true', or use the parameter '--skip-hash-check' in a single download."
                         continue
                     }
                     error (new_issue_msg $app $bucket "hash check failed")

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -128,7 +128,7 @@ foreach ($curr_app in $apps) {
                         warn 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
                     if ($err.Contains('No-hash apps')) {
-                        error "Please run 'scoop config allow-no-hash true' if you want to download it anyway."
+                        error "Please run 'scoop config allow_no_hash true' if you want to download it anyway."
                         continue
                     }
                     error (new_issue_msg $app $bucket "hash check failed")

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -127,6 +127,10 @@ foreach ($curr_app in $apps) {
                     if ($url -like '*sourceforge.net*') {
                         warn 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
+                    if ($err.Contains('No-hash apps')) {
+                        error "Please run 'scoop config allow-no-hash true' if you want to download it anyway."
+                        continue
+                    }
                     error (new_issue_msg $app $bucket "hash check failed")
                     continue
                 }

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -132,6 +132,10 @@ foreach ($curr_app in $apps) {
                     if ($url -like '*sourceforge.net*') {
                         warn 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
+                    if ($err.Contains('No-hash apps')) {
+                        error "If you want to allow no-hash apps, run 'scoop config allow_no_hash true', or use the parameter '--skip-hash-check' in a single download."
+                        continue
+                    }
                     error (new_issue_msg $app $bucket "hash check failed")
                     $dl_failure = $true
                     continue

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -134,6 +134,7 @@ foreach ($curr_app in $apps) {
                     }
                     if ($err.Contains('No-hash apps')) {
                         error "If you want to allow no-hash apps, run 'scoop config allow_no_hash true', or use the parameter '--skip-hash-check' in a single download."
+                        $dl_failure = $true
                         continue
                     }
                     error (new_issue_msg $app $bucket "hash check failed")

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -326,6 +326,9 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
                     if ($url.Contains('sourceforge.net')) {
                         Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
+                    if ($err.Contains('No-hash apps')) {
+                        abort "If you want to allow no-hash apps, run 'scoop config allow_no_hash true', or use the parameter '--skip-hash-check' in a single download."
+                    }
                     abort $(new_issue_msg $app $bucket 'hash check failed')
                 }
             }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -326,6 +326,9 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
                     if ($url.Contains('sourceforge.net')) {
                         Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
+                    if ($err.Contains('No-hash apps')) {
+                        abort "Please run 'scoop config allow-no-hash true' if you want to continue anyway."
+                    }
                     abort $(new_issue_msg $app $bucket 'hash check failed')
                 }
             }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -327,7 +327,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
                         Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
                     if ($err.Contains('No-hash apps')) {
-                        abort "Please run 'scoop config allow_no_hash true' if you want to continue anyway."
+                        abort "If you want to allow no-hash apps, run 'scoop config allow_no_hash true', or use the parameter '--skip-hash-check' in a single download."
                     }
                     abort $(new_issue_msg $app $bucket 'hash check failed')
                 }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -327,7 +327,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
                         Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
                     if ($err.Contains('No-hash apps')) {
-                        abort "Please run 'scoop config allow-no-hash true' if you want to continue anyway."
+                        abort "Please run 'scoop config allow_no_hash true' if you want to continue anyway."
                     }
                     abort $(new_issue_msg $app $bucket 'hash check failed')
                 }

--- a/test/Scoop-Config.Tests.ps1
+++ b/test/Scoop-Config.Tests.ps1
@@ -70,6 +70,16 @@ Describe 'config' -Tag 'Scoop' {
         (get_config 'unicode') | Should -Be $unicode
     }
 
+    It 'get_config should return correct default values' {
+        $scoopConfig = load_cfg $configFile
+        (get_config 'this_is_null') | Should -BeNullOrEmpty
+        (get_config 'this_is_null' $true) | Should -BeTrue
+        (get_config 'this_is_null' $false) | Should -BeFalse
+        (get_config 'this_is_null' 'zero') | Should -BeExactly 'zero'
+        (get_config 'this_is_null' 1) | Should -BeExactly 1
+        (get_config 'this_is_null' $unicode) | Should -Be $unicode
+    }
+
     It 'set_config should remove a value if being set to $null' {
         $scoopConfig = load_cfg $configFile
         $scoopConfig = set_config 'five' $null

--- a/test/Scoop-Download.Tests.ps1
+++ b/test/Scoop-Download.Tests.ps1
@@ -47,3 +47,51 @@ Describe 'url_remote_filename' -Tag 'Scoop' {
         url_remote_filename 'http://example.org/foo-v2.zip#/foo.zip' | Should -Be 'foo-v2.zip'
     }
 }
+
+Describe 'check_hash' -Tag 'Scoop' {
+    BeforeAll {
+        $working_dir = setup_working 'decompress'
+        $testcases = "$working_dir\TestCases.zip"
+        Mock url_remote_filename { 'TestCases.zip' }
+        Mock Write-Host { }
+    }
+
+    It 'should return true for a valid sha256 hash' {
+        Mock get_config { $false } -ParameterFilter { $name -eq 'allow_no_hash' }
+        $ok, $err = check_hash $testcases '591072faabd419b77932b7023e5899b4e05c0bf8e6859ad367398e6bfe1eb203' 'TestCases'
+        $ok | Should -BeTrue
+        $err | Should -BeNullOrEmpty
+    }
+
+    It 'should return true for a valid non-sha256 hash' {
+        Mock get_config { $false } -ParameterFilter { $name -eq 'allow_no_hash' }
+        $ok, $err = check_hash $testcases 'sha512:ed47a7fa15c85be8348ecc0e8a8d6140e3caa72ad344c7a3313a026fed0ac07432b969751cb09484045b4335a53c5031ea7e3c0c2802f8f02a4ebe3d27129dc2' 'TestCases'
+        $ok | Should -BeTrue
+        $err | Should -BeNullOrEmpty
+    }
+
+    It 'should return false for an invalid hash' {
+        Mock get_config { $false } -ParameterFilter { $name -eq 'allow_no_hash' }
+        $ok, $err = check_hash $testcases '591072faabd419b79932b7023e5899b4e05c0bf8e6859ad367398e6bfe1eb203' 'TestCases'
+        $ok | Should -BeFalse
+        $err | Should -Match 'Hash check failed'
+    }
+
+    It 'should return false for a null hash' {
+        Mock get_config { $false } -ParameterFilter { $name -eq 'allow_no_hash' }
+        $ok, $err = check_hash $testcases $null 'TestCases'
+        $ok | Should -BeFalse
+        $err | Should -Match 'No hash provided in manifest'
+    }
+
+    It 'should return true for a null hash with allow_no_hash set to true' {
+        Mock get_config { $true } -ParameterFilter { $name -eq 'allow_no_hash' }
+        $ok, $err = check_hash $testcases $null 'TestCases'
+        $ok | Should -BeTrue
+        $err | Should -BeNullOrEmpty
+    }
+
+    AfterAll {
+        Remove-Item -Path $working_dir -Recurse -Force
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

For apps without file hash provided in manifest, add a switch `allow_no_hash` and set default to be `false` in scoop config, fetch the config value in `check_hash` process and only allow the no-hash files when it is set to `true`.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #6387

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested with manifest https://github.com/cscnk52/cetacea/blob/master/bucket/todesk.json

1. Test using a no-hash manifest without setting `allow_no_hash` 

```
> scoop config

aria2-enabled                   : True
aria2-max-connection-per-server : 16
aria2-split                     : 16
aria2-min-split-size            : 1M
last_update                     : 2025-06-16T22:33:49.9348613+08:00
scoop_branch                    : add-no-hash-options
scoop_repo                      : https://github.com/AkariiinMKII/Scoop
debug                           : False
aria2-warning-enabled           : False
```

```
> scoop download todesk
INFO  Downloading 'todesk' [64bit] from cetacea bucket
Starting download with aria2 ...
Download: Download Results:                                                                                                                
Download: gid   |stat|avg speed  |path/URI                                                                                                 
Download: ======+====+===========+=======================================================                                                  
Download: e4cc7a|OK  |    58MiB/s|C:/Users/A1/scoop/cache/todesk#4.7.7.1#4bccddf.7z                                                        
Download: Status Legend:                                                                                                                   
Download: (OK):download completed.                                                                                                         
ERROR No hash provided in manifest.
ERROR No-hash apps are blocked by default for security reasons, except for nightly builds.
Please run 'scoop config allow_no_hash true' if you want to continue anyway.
```

```
> scoop install todesk
Installing 'todesk' (4.7.7.1) [64bit] from 'cetacea' bucket
Starting download with aria2 ...
Download: Download Results:                                                                                                                
Download: gid   |stat|avg speed  |path/URI                                                                                                 
Download: ======+====+===========+=======================================================                                                  
Download: af1652|OK  |    66MiB/s|C:/Users/A1/scoop/cache/todesk#4.7.7.1#4bccddf.7z                                                        
Download: Status Legend:                                                                                                                   
Download: (OK):download completed.                                                                                                         
ERROR No hash provided in manifest.
ERROR No-hash apps are blocked by default for security reasons, except for nightly builds.
Please run 'scoop config allow_no_hash true' if you want to continue anyway.
```

2. Test using a no-hash manifest with `allow_no_hash` set to be `true`

```
> scoop config allow_no_hash true
'allow_no_hash' has been set to 'true'

> scoop config

aria2-enabled                   : True
aria2-max-connection-per-server : 16
aria2-split                     : 16
aria2-min-split-size            : 1M
last_update                     : 2025-06-16T22:33:49.9348613+08:00
scoop_branch                    : add-no-hash-options
scoop_repo                      : https://github.com/AkariiinMKII/Scoop
debug                           : False
aria2-warning-enabled           : False
allow_no_hash                   : True
```

```
> scoop download todesk
INFO  Downloading 'todesk' [64bit] from cetacea bucket
Starting download with aria2 ...
Download: Download Results:                                                                                                                
Download: gid   |stat|avg speed  |path/URI                                                                                                 
Download: ======+====+===========+=======================================================                                                  
Download: c177f5|OK  |    58MiB/s|C:/Users/A1/scoop/cache/todesk#4.7.7.1#4bccddf.7z                                                        
Download: Status Legend:                                                                                                                   
Download: (OK):download completed.                                                                                                         
WARN  No hash provided in manifest. SHA256 for 'todesk#4.7.7.1#4bccddf.7z' is:
WARN  78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237
WARN  To block no-hash apps for security reasons, run 'scoop config allow_no_hash false'.
'todesk' (4.7.7.1) was downloaded successfully!
```

```
> scoop install todesk
Installing 'todesk' (4.7.7.1) [64bit] from 'cetacea' bucket
Starting download with aria2 ...
Download: Download Results:                                                                                                                
Download: gid   |stat|avg speed  |path/URI                                                                                                 
Download: ======+====+===========+=======================================================                                                  
Download: 20af02|OK  |    56MiB/s|C:/Users/A1/scoop/cache/todesk#4.7.7.1#4bccddf.7z                                                        
Download: Status Legend:                                                                                                                   
Download: (OK):download completed.                                                                                                         
WARN  No hash provided in manifest. SHA256 for 'todesk#4.7.7.1#4bccddf.7z' is:
WARN  78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237
WARN  To block no-hash apps for security reasons, run 'scoop config allow_no_hash false'.
Extracting ToDesk_4.7.7.1.exe ... done.
Running pre_install script...done.
Linking ~\scoop\apps\todesk\current => ~\scoop\apps\todesk\4.7.7.1
Creating shortcut for ToDesk (ToDesk.exe)
Persisting Logs
Persisting config.ini
Running post_install script...done.
'todesk' (4.7.7.1) was installed successfully!
```

3. Test using a no-hash manifest with `allow_no_hash` set to be `false`

```
> scoop config allow_no_hash false
'allow_no_hash' has been set to 'false

> scoop config

aria2-enabled                   : True
aria2-max-connection-per-server : 16
aria2-split                     : 16
aria2-min-split-size            : 1M
last_update                     : 2025-06-16T22:33:49.9348613+08:00
scoop_branch                    : add-no-hash-options
scoop_repo                      : https://github.com/AkariiinMKII/Scoop
debug                           : False
aria2-warning-enabled           : False
allow_no_hash                   : False
```

```
> scoop download todesk
INFO  Downloading 'todesk' [64bit] from cetacea bucket
Starting download with aria2 ...
Download: Download Results:                                                                                                                
Download: gid   |stat|avg speed  |path/URI                                                                                                 
Download: ======+====+===========+=======================================================                                                  
Download: 8a088d|OK  |    69MiB/s|C:/Users/A1/scoop/cache/todesk#4.7.7.1#4bccddf.7z                                                        
Download: Status Legend:                                                                                                                   
Download: (OK):download completed.                                                                                                         
ERROR No hash provided in manifest.
ERROR No-hash apps are blocked by default for security reasons, except for nightly builds.
Please run 'scoop config allow_no_hash true' if you want to continue anyway.
```

```
> scoop install todesk
Installing 'todesk' (4.7.7.1) [64bit] from 'cetacea' bucket
Starting download with aria2 ...
Download: Download Results:                                                                                                                
Download: gid   |stat|avg speed  |path/URI                                                                                                 
Download: ======+====+===========+=======================================================                                                  
Download: 1e6398|OK  |    66MiB/s|C:/Users/A1/scoop/cache/todesk#4.7.7.1#4bccddf.7z                                                        
Download: Status Legend:                                                                                                                   
Download: (OK):download completed.                                                                                                         
ERROR No hash provided in manifest.
ERROR No-hash apps are blocked by default for security reasons, except for nightly builds.
Please run 'scoop config allow_no_hash true' if you want to continue anyway.
```

4. Modify config after downloading

```
> scoop config allow_no_hash true 
'allow_no_hash' has been set to 'true'

> scoop download todesk
INFO  Downloading 'todesk' [64bit] from cetacea bucket
Starting download with aria2 ...
Download: Download Results:                                                                                                                
Download: gid   |stat|avg speed  |path/URI                                                                                                 
Download: ======+====+===========+=======================================================                                                  
Download: 6c3653|OK  |    65MiB/s|C:/Users/A1/scoop/cache/todesk#4.7.7.1#4bccddf.7z                                                        
Download: Status Legend:                                                                                                                   
Download: (OK):download completed.                                                                                                         
WARN  No hash provided in manifest. SHA256 for 'todesk#4.7.7.1#4bccddf.7z' is:
WARN  78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237
WARN  To block no-hash apps for security reasons, run 'scoop config allow_no_hash false'.
'todesk' (4.7.7.1) was downloaded successfully!

> scoop config allow_no_hash false
'allow_no_hash' has been set to 'false'

> scoop install todesk
Installing 'todesk' (4.7.7.1) [64bit] from 'cetacea' bucket
Loading ToDesk_4.7.7.1.exe from cache.
ERROR No hash provided in manifest.
ERROR No-hash apps are blocked by default for security reasons, except for nightly builds.
Please run 'scoop config allow_no_hash true' if you want to continue anyway.
```

5. Behaviors with parameter `--skip-hash-check`

```
> scoop config

aria2-enabled                   : True
aria2-max-connection-per-server : 16
aria2-split                     : 16
aria2-min-split-size            : 1M
last_update                     : 2025-07-22T15:54:01.1664482+08:00
scoop_branch                    : add-no-hash-options
scoop_repo                      : https://github.com/AkariiinMKII/Scoop
debug                           : True
aria2-warning-enabled           : False
allow_no_hash                   : False
```

```
> scoop download todesk -s
INFO  Downloading 'todesk' [64bit] from cetacea bucket
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: e1dc2e|OK  |    70MiB/s|C:/Users/A1/scoop/cache/todesk#4.8.0.1#da1d9b6.7z
Download: Status Legend:
Download: (OK):download completed.
'todesk' (4.8.0.1) was downloaded successfully!
```

```
> scoop install todesk -s
Installing 'todesk' (4.8.0.1) [64bit] from 'cetacea' bucket
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: 8336fe|OK  |    62MiB/s|C:/Users/A1/scoop/cache/todesk#4.8.0.1#da1d9b6.7z
Download: Status Legend:
Download: (OK):download completed.
Extracting ToDesk_4.8.0.1.exe ... done.
Running pre_install script...done.
Linking ~\scoop\apps\todesk\current => ~\scoop\apps\todesk\4.8.0.1
Creating shortcut for ToDesk (ToDesk.exe)
Persisting Logs
Persisting config.ini
Running post_install script...done.
'todesk' (4.8.0.1) was installed successfully!
```

```
> scoop update todesk -f -s
todesk: 4.8.0.1 -> 4.8.0.1
Updating one outdated app:
Updating 'todesk' (4.8.0.1 -> 4.8.0.1)
Downloading new version
Loading ToDesk_4.8.0.1.exe from cache.
Uninstalling 'todesk' (4.8.0.1)
Unlinking ~\scoop\apps\todesk\current
Installing 'todesk' (4.8.0.1) [64bit] from 'cetacea' bucket
Loading ToDesk_4.8.0.1.exe from cache.
Extracting ToDesk_4.8.0.1.exe ... done.
Running pre_install script...done.
Linking ~\scoop\apps\todesk\current => ~\scoop\apps\todesk\4.8.0.1
Creating shortcut for ToDesk (ToDesk.exe)
Persisting Logs
Persisting config.ini
Running post_install script...done.
'todesk' (4.8.0.1) was installed successfully!
```

```
> scoop update todesk -f
todesk: 4.8.0.1 -> 4.8.0.1
Updating one outdated app:
Updating 'todesk' (4.8.0.1 -> 4.8.0.1)
Downloading new version
Loading ToDesk_4.8.0.1.exe from cache.
ERROR No hash provided in manifest.
ERROR No-hash apps are blocked by default for security reasons, except for nightly builds.
Please run 'scoop config allow_no_hash true' if you want to continue anyway.
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps without file hashes are blocked by default for improved security.
  * Added a configuration option to permit no-hash apps when explicitly enabled.
* **Bug Fixes / UX**
  * Clearer, targeted error messages with actionable guidance to enable no-hash support or skip hash checks for a single download.
* **Documentation**
  * Help/usage text updated to document the new configuration and its security implications.
* **Tests**
  * New test coverage for hash-check behavior, including no-hash and allow-no-hash scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Scoop/pull/6388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->