### PR TITLE
Update autoupdate.ps1 to drop the `sha256:` prefix of GitHub asset.digest

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -116,7 +116,7 @@ function find_hash_in_json([String] $url, [Hashtable] $substitutions, [String] $
     if (!$hash) {
         $hash = json_path_legacy $json $jsonpath $substitutions
     }
-    if ($hash -match '[md5|sha1|sha256|sha512]:(?<hash>[a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{128})') {
+    if ($hash -match '[sha256]:(?<hash>[a-fA-F0-9]{64})') {
         $hash = $matches.hash
     }
     return format_hash $hash

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -116,6 +116,9 @@ function find_hash_in_json([String] $url, [Hashtable] $substitutions, [String] $
     if (!$hash) {
         $hash = json_path_legacy $json $jsonpath $substitutions
     }
+    if ($hash -match '[md5|sha1|sha256|sha512]:(?<hash>[a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{128})') {
+        $hash = $matches.hash
+    }
     return format_hash $hash
 }
 


### PR DESCRIPTION
GitHub currently generates a corresponding SHA-256 hash for uploaded assets.

We can get the `asset.digest` (sha256 hash) by JSONPath fuction,  but the digest  has a `sha256:` prefix.

the function `find_hash_in_json([String] $url, [Hashtable] $substitutions, [String] $jsonpath)` in  `lib\autoupdate.ps1`  does not contain the regex function.

this pr  to  drop the `sha256:` prefix.
