### PR TITLE
feat(autoupdate): Add new hash mode `none`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/v0.5.3...develop)
 
+### Features
+
+- **autoupdate**: Add new hash mode `none` ([#6389](https://github.com/ScoopInstaller/Scoop/issues/6389))
+
 ### Bug Fixes
 
 - **scoop-download**: Fix function `nightly_version` not defined error ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- **autoupdate**: Add new hash mode `none` ([#6389](https://github.com/ScoopInstaller/Scoop/issues/6389))
 - **install:** Add output for the setting and removal of environment variables ([#6460](https://github.com/ScoopInstaller/Scoop/issues/6460))
 - **scoop-uninstall:** Allow access to `$bucket` in uninstall scripts ([#6380](https://github.com/ScoopInstaller/Scoop/issues/6380))
 - **install:** Add separator at the end of notes, highlight suggestions ([#6418](https://github.com/ScoopInstaller/Scoop/issues/6418))

--- a/bin/checkhashes.ps1
+++ b/bin/checkhashes.ps1
@@ -69,26 +69,20 @@ foreach ($single in Get-ChildItem $Dir -Filter "$App.json" -Recurse) {
 
     $urls = @()
     $hashes = @()
+    [bool]$manifesthasurl = $false
 
-    if ($manifest.url) {
-        # Skip manifests for hash mode set to 'none'
-        if ($manifest.autoupdate.hash.mode -and ($manifest.autoupdate.hash.mode -eq 'none')) {
-            if ($manifest.hash) {
-                err "$name" 'Manifest should not contain a hash property.'
-            }
-            continue
-        }
-        $manifest.url | ForEach-Object { $urls += $_ }
-        $manifest.hash | ForEach-Object { $hashes += $_ }
-    } elseif ($manifest.architecture) {
+    if ($manifest.architecture) {
         $arches = @('64bit', '32bit', 'arm64')
         [bool]$errorinarches = $false
         foreach ($currentarch in $arches) {
-            # Skip architecture for hash mode set to 'none'
-            if ($manifest.autoupdate.architecture.$currentarch.hash.mode -and ($manifest.autoupdate.architecture.$currentarch.hash.mode -eq 'none')) {
+            if ($manifest.architecture.$currentarch.url) {
+                $manifesthasurl = $true
+            } else { continue }
+            # Skip architecture with hash mode set to 'none'
+            if ($manifest.autoupdate.architecture.$currentarch.hash.mode -eq 'none') {
                 if ($manifest.architecture.$currentarch.hash) {
                     $errorinarches = $true
-                    err "$name" "Manifest should not contain a hash property in '$currentarch' architecture."
+                    err $name "Manifest should not contain a hash property in '$currentarch' architecture."
                 }
                 continue
             }
@@ -97,12 +91,32 @@ foreach ($single in Get-ChildItem $Dir -Filter "$App.json" -Recurse) {
         }
         # Skip if errors found in architecture
         if ($errorinarches) { continue }
-    } else {
-        err $name 'Manifest does not contain valid URL property.'
     }
 
-    # Skip manifests with no hashes to check
+    if ($manifest.url) {
+        # Check URL conflicts
+        if ($manifesthasurl) {
+            err $name 'Manifest should not contain global and architecture specific URLs at the same time.'
+            continue
+        } else {
+            $manifesthasurl = $true
+        }
+        # Skip manifests with hash mode set to 'none'
+        if ($manifest.autoupdate.hash.mode -eq 'none') {
+            if ($manifest.hash) {
+                err $name 'Manifest should not contain a hash property.'
+            }
+            continue
+        }
+        $manifest.url | ForEach-Object { $urls += $_ }
+        $manifest.hash | ForEach-Object { $hashes += $_ }
+    }
+
+    # Skip manifests with no hash to check
     if ($urls.Length -eq 0) {
+        if (!$manifesthasurl) {
+            err $name 'Manifest does not contain valid URL property.'
+        }
         continue
     }
 

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -382,10 +382,19 @@ function Update-ManifestProperty {
                     $newHash = HashHelper -AppName $AppName -Version $Version -HashExtraction $Manifest.autoupdate.hash -URL $newURL -Substitutions $Substitutions
                     $Manifest.hash, $hasPropertyChanged = PropertyHelper -Property $Manifest.hash -Value $newHash
                     $hasManifestChanged = $hasManifestChanged -or $hasPropertyChanged
+                } elseif ($Manifest.autoupdate.hash.ignore) {
+                    # Skip global hash update
+                    Write-Host "Skipping hash update for $AppName according to manifest property" -ForegroundColor DarkYellow
+                    continue
                 } else {
                     # Arch-spec
                     $Manifest.architecture | Get-Member -MemberType NoteProperty | ForEach-Object {
                         $arch = $_.Name
+                        if ($Manifest.autoupdate.architecture.$arch.hash.ignore) {
+                            # Skip arch-specific hash update
+                            Write-Host "Skipping hash update for $AppName ($arch) according to manifest property" -ForegroundColor DarkYellow
+                            return
+                        }
                         $newURL = substitute (arch_specific 'url' $Manifest.autoupdate $arch) $Substitutions
                         $newHash = HashHelper -AppName $AppName -Version $Version -HashExtraction (arch_specific 'hash' $Manifest.autoupdate $arch) -URL $newURL -Substitutions $Substitutions
                         $Manifest.architecture.$arch.hash, $hasPropertyChanged = PropertyHelper -Property $Manifest.architecture.$arch.hash -Value $newHash

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -382,7 +382,7 @@ function Update-ManifestProperty {
                     $newHash = HashHelper -AppName $AppName -Version $Version -HashExtraction $Manifest.autoupdate.hash -URL $newURL -Substitutions $Substitutions
                     $Manifest.hash, $hasPropertyChanged = PropertyHelper -Property $Manifest.hash -Value $newHash
                     $hasManifestChanged = $hasManifestChanged -or $hasPropertyChanged
-                } elseif ($Manifest.autoupdate.hash.ignore) {
+                } elseif ($Manifest.autoupdate.hash.mode -eq 'none') {
                     # Skip global hash update
                     Write-Host "Skipping hash update for $AppName according to manifest property" -ForegroundColor DarkYellow
                     continue
@@ -390,7 +390,7 @@ function Update-ManifestProperty {
                     # Arch-spec
                     $Manifest.architecture | Get-Member -MemberType NoteProperty | ForEach-Object {
                         $arch = $_.Name
-                        if ($Manifest.autoupdate.architecture.$arch.hash.ignore) {
+                        if ($Manifest.autoupdate.architecture.$arch.hash.mode -eq 'none') {
                             # Skip arch-specific hash update
                             Write-Host "Skipping hash update for $AppName ($arch) according to manifest property" -ForegroundColor DarkYellow
                             return

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -388,10 +388,19 @@ function Update-ManifestProperty {
                     $newHash = HashHelper -AppName $AppName -Version $Version -HashExtraction $Manifest.autoupdate.hash -URL $newURL -Substitutions $Substitutions
                     $Manifest.hash, $hasPropertyChanged = PropertyHelper -Property $Manifest.hash -Value $newHash
                     $hasManifestChanged = $hasManifestChanged -or $hasPropertyChanged
+                } elseif ($Manifest.autoupdate.hash.mode -eq 'none') {
+                    # Skip global hash update
+                    Write-Host "Skipping hash update for $AppName according to manifest property" -ForegroundColor DarkYellow
+                    continue
                 } else {
                     # Arch-spec
                     $Manifest.architecture | Get-Member -MemberType NoteProperty | ForEach-Object {
                         $arch = $_.Name
+                        if ($Manifest.autoupdate.architecture.$arch.hash.mode -eq 'none') {
+                            # Skip arch-specific hash update
+                            Write-Host "Skipping hash update for $AppName ($arch) according to manifest property" -ForegroundColor DarkYellow
+                            return
+                        }
                         $newURL = substitute (arch_specific 'url' $Manifest.autoupdate $arch) $Substitutions
                         $newHash = HashHelper -AppName $AppName -Version $Version -HashExtraction (arch_specific 'hash' $Manifest.autoupdate $arch) -URL $newURL -Substitutions $Substitutions
                         $Manifest.architecture.$arch.hash, $hasPropertyChanged = PropertyHelper -Property $Manifest.architecture.$arch.hash -Value $newHash

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -384,14 +384,15 @@ function Update-ManifestProperty {
                 # Update hash
                 if ($Manifest.hash) {
                     # Global
+                    if ($Manifest.autoupdate.hash.mode -eq 'none') {
+                        # Skip global hash update
+                        Write-Host "Skipping hash update for $AppName according to manifest property" -ForegroundColor DarkYellow
+                        continue
+                    }
                     $newURL = substitute $Manifest.autoupdate.url $Substitutions
                     $newHash = HashHelper -AppName $AppName -Version $Version -HashExtraction $Manifest.autoupdate.hash -URL $newURL -Substitutions $Substitutions
                     $Manifest.hash, $hasPropertyChanged = PropertyHelper -Property $Manifest.hash -Value $newHash
                     $hasManifestChanged = $hasManifestChanged -or $hasPropertyChanged
-                } elseif ($Manifest.autoupdate.hash.mode -eq 'none') {
-                    # Skip global hash update
-                    Write-Host "Skipping hash update for $AppName according to manifest property" -ForegroundColor DarkYellow
-                    continue
                 } else {
                     # Arch-spec
                     $Manifest.architecture | Get-Member -MemberType NoteProperty | ForEach-Object {

--- a/schema.json
+++ b/schema.json
@@ -57,7 +57,8 @@
                         "rdf",
                         "metalink",
                         "fosshub",
-                        "sourceforge"
+                        "sourceforge",
+                        "none"
                     ]
                 },
                 "type": {

--- a/schema.json
+++ b/schema.json
@@ -58,7 +58,8 @@
                         "rdf",
                         "metalink",
                         "fosshub",
-                        "sourceforge"
+                        "sourceforge",
+                        "none"
                     ]
                 },
                 "type": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
Use a `mode: none` property in `hash` to skip hash update in `autoupdate` process

Since I'm not able to update wiki by opening a PR, here is a reference of document update
https://github.com/AkariiinMKII/Scoop/commit/4130be1a9ac63d32a573cd36fb613b66e673cbec

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #6389

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

The test manifest is based on [cetacea/todesk](https://github.com/cscnk52/cetacea/blob/master/bucket/todesk.json)

- Tests for `/lib/autoupdate.ps1`
1. Run force update with unmodified manifest
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        }
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z"
            }
        }
    }
```
```
 .\bin\checkver.ps1 -app C:\Users\A1\scoop\buckets\cetacea\bucket\todesk.json -f
todesk: 4.7.7.1 (scoop version is 4.7.7.1)
Forcing autoupdate!
Autoupdating todesk
Downloading ToDesk_4.7.7.1.exe to compute hashes!
Loading ToDesk_4.7.7.1.exe from cache
Computed hash: 78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237
ERROR You cannot call a method on a null-valued expression.
```
2. Modify `autoupdate` and run force update
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        }
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
                "hash":  {
                    "mode": "none"
                }
            }
        }
    }
```

```
 .\bin\checkver.ps1 -app C:\Users\A1\scoop\buckets\cetacea\bucket\todesk.json -f
todesk: 4.7.7.1 (scoop version is 4.7.7.1)
Forcing autoupdate!
Autoupdating todesk
Skipping hash update for todesk (64bit) according to manifest property
Writing updated todesk manifest
```
3. When using global URL
```json
    "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
    "autoupdate": {
        "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
        "hash": {
            "mode": "none"
        }
    }
```
```
.\bin\checkver.ps1 -app C:\Users\A1\scoop\buckets\cetacea\bucket\todesk.json -f
todesk: 4.7.7.1 (scoop version is 4.7.7.1)
Forcing autoupdate!
Autoupdating todesk
Skipping hash update for todesk according to manifest property
Writing updated todesk manifest
```
4. Partly in multi architecture specific properties
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
            "hash": "78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237"
        },
        "32bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        }
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z"
            },
            "32bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
                "hash": {
                    "mode": "none"
                }
            }
        }
    }
```
```
.\bin\checkver.ps1 -app C:\Users\A1\scoop\buckets\cetacea\bucket\todesk.json -f
todesk: 4.7.7.1 (scoop version is 4.7.7.1)
Forcing autoupdate!
Autoupdating todesk
Skipping hash update for todesk (32bit) according to manifest property
Downloading ToDesk_4.7.7.1.exe to compute hashes!
ToDesk_4.7.7.1.exe (84.7 MB) [=============================================================================================================] 100%
Computed hash: 78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237
Writing updated todesk manifest
```
---
- Tests for `/bin/checkhashes.ps1`
1. Run checkhashes with unmodified manifest
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        }
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z"
            }
        }
    }
```

```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
todesk: URLS and hashes count mismatch.
```

2. Modify `autoupdate` and run checkhashes
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        }
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
                "hash":  {
                    "mode": "none"
                }
            }
        }
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
```
Returned nothing, just like nightly version
Compare with [versions/rust-nightly](https://github.com/ScoopInstaller/Versions/blob/master/bucket/rust-nightly.json)
```
.\bin\checkhashes.ps1 rust-nightly C:\Users\A1\scoop\buckets\versions\bucket
```

---
- Other valid manifest tests for `/bin/checkhashes.ps1`
1. `mode: none` in global properties
```json
    "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
    "autoupdate": {
        "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
        "hash": {
            "mode": "none"
        }
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
```
Returned nothing
2. In multi architecture specific properties
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        },
        "32bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        }
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
                "hash": {
                    "mode": "none"
                }
            },
            "32bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
                "hash": {
                    "mode": "none"
                }
            }
        }
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
```
Returned nothing
3. Partly in multi architecture specific properties
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
            "hash": "78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237"
        },
        "32bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        }
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z"
            },
            "32bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
                "hash": {
                    "mode": "none"
                }
            }
        }
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
ToDesk_4.7.7.1.exe (84.7 MB) [=============================================================================================================] 100%
todesk: OK
```
---
- Other invalid manifest tests for `/bin/checkhashes.ps1`
1. URL conflicts
```json
    "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
            "hash": "78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237"
        },
        "32bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        }
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
todesk: Manifest should not contain global and architecture specific URLs at the same time.
```
2. no valid URL
Remove global URL and architecture specific URL in manifest and run
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
todesk: Manifest does not contain valid URL property.
```

3. mode mismatch 1 (missing hash)
```json
    "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
    "autoupdate": {
        "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z"
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
ToDesk_4.7.7.1.exe (84.7 MB) [=============================================================================================================] 100%
todesk: Mismatch found 
	URL:		https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z
	First bytes:	4D 5A 90 00 03 00 00 00
	Expected:	
	Actual:		78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237
```
4. mode mismatch 2 (redundant hash)
```json
    "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
    "hash": "78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237",
    "autoupdate": {
        "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
        "hash":{
            "mode": "none"
        }
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
todesk: Manifest should not contain a hash property.
```
5. mode mismatch 3 (missing hash in architecture)
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        },
        "32bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        }
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z"
            },
            "32bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
                "hash": {
                    "mode": "none"
                }
            }
        }
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
todesk: URLS and hashes count mismatch.
```
6. mode mismatch 4 (redundant hash in architecture)
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
            "hash": "78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237"
        },
        "32bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
            "hash": "78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237"
        }
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z"
            },
            "32bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
                "hash": {
                    "mode": "none"
                }
            }
        }
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
todesk: Manifest should not contain a hash property in '32bit' architecture.
```
7. mode mismatch 5 (all got sucks)
```json
    "architecture": {
        "64bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z"
        },
        "32bit": {
            "url": "https://dl.todesk.com/irrigation/ToDesk_4.7.7.1.exe#/dl.7z",
            "hash": "78bacfba23438526553960a45ef7dae817dab185421b00be33c8a70d155c1237"
        }
    },
    "autoupdate": {
        "architecture": {
            "32bit": {
                "url": "https://dl.todesk.com/irrigation/ToDesk_$version.exe#/dl.7z",
                "hash": {
                    "mode": "none"
                }
            }
        }
    }
```
```
.\bin\checkhashes.ps1 todesk C:\Users\A1\scoop\buckets\cetacea\bucket
todesk: Manifest should not contain a hash property in '32bit' architecture.
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `none` hash mode for autoupdate so manifests can opt out of hash collection and updates.

* **Bug Fixes**
  * Improved validation to prevent conflicting global vs per-architecture URL/hash configurations.
  * Manifests are now skipped or errored when hash handling is disabled (globally or per-architecture).
  * Added guards to prevent empty or mismatched URL/hash collections and avoid updating hashes when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->