### PR TITLE
fix(core): add null checks before closing BinaryReader/FileStream in update process

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -16,8 +16,8 @@ function Get-PESubsystem($filePath) {
     } catch {
         return -1
     } finally {
-        $binaryReader.Close()
-        $fileStream.Close()
+        if ($null -ne $binaryReader) { $binaryReader.Close() }
+        if ($null -ne $fileStream) { $fileStream.Close() }
     }
 }
 


### PR DESCRIPTION
#### Description
This PR adds null checks for **$binaryReader** and **$fileStream** in `core.ps1` to prevent **InvalidOperation** exceptions when running scoop update.

#### Motivation and Context
Running scoop update in PowerShell 7 consistently threw InvalidOperation errors because Close() was called on null objects.
This change ensures the objects are checked before attempting to close them.
Fixes #6506

#### How Has This Been Tested?
- [x] Tested on PowerShell 7.4.1 (Windows 11 x64)
- [x] Verified that `scoop update -a` no longer throws **InvalidOperation** exceptions.

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added safeguards during cleanup to prevent rare null-reference errors when closing file resources.
  - Eliminates occasional crashes when analyzing binaries, improving overall stability.
  - No changes to user-facing behavior or results; reliability is improved in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->