### PR TITLE
fix(system): Update TargetEnvVar instead of PATH

### DIFF
--- a/lib/system.ps1
+++ b/lib/system.ps1
@@ -107,15 +107,17 @@ function Add-Path {
     if (!$inPath -or $Force) {
         if (!$Quiet) {
             $Path | ForEach-Object {
-                Write-Host "Adding $(friendly_path $_) to $(if ($Global) {'global'} else {'your'}) path."
+                Write-Host "Adding $(friendly_path $_) to $(if ($Global) {'global'} else {'your'}) $TargetEnvVar."
             }
         }
+        $strippedPath = if ($strippedPath) { @($strippedPath) } else { @() };
         Set-EnvVar -Name $TargetEnvVar -Value ((@($Path) + $strippedPath) -join ';') -Global:$Global
     }
     # current session
-    $inPath, $strippedPath = Split-PathLikeEnvVar $Path $env:PATH
+    $inPath, $strippedPath = Split-PathLikeEnvVar $Path (Get-Content "env:$TargetEnvVar" -ErrorAction Ignore)
     if (!$inPath -or $Force) {
-        $env:PATH = (@($Path) + $strippedPath) -join ';'
+        $strippedPath = if ($strippedPath) { @($strippedPath) } else { @() };
+        Set-Content "env:$TargetEnvVar" ((@($Path) + $strippedPath) -join ';')
     }
 }
 
@@ -133,15 +135,15 @@ function Remove-Path {
     if ($inPath) {
         if (!$Quiet) {
             $Path | ForEach-Object {
-                Write-Host "Removing $(friendly_path $_) from $(if ($Global) {'global'} else {'your'}) path."
+                Write-Host "Removing $(friendly_path $_) from $(if ($Global) {'global'} else {'your'}) $TargetEnvVar."
             }
         }
         Set-EnvVar -Name $TargetEnvVar -Value $strippedPath -Global:$Global
     }
     # current session
-    $inSessionPath, $strippedPath = Split-PathLikeEnvVar $Path $env:PATH
+    $inSessionPath, $strippedPath = Split-PathLikeEnvVar $Path (Get-Content "env:$TargetEnvVar" -ErrorAction Ignore)
     if ($inSessionPath) {
-        $env:PATH = $strippedPath
+        Set-Content "env:$TargetEnvVar" $strippedPath
     }
     if ($PassThru) {
         return $inPath


### PR DESCRIPTION
#### Description
The functions `Add-Path`, `Remove-Path` admit an argument `-TargetEnvVar` which would update the correct profile or system environment variable, but would always act on `PATH` in the current session.

I simply replaced `$env:PATH` with `Get/Set-Content "env:$TargetEnvVar"` to fix this. I have also updated the message 'Adding (...) to your path', so there will be a visible change to 'Adding (...) to your PATH'.

(I suppose this doesn't merit an entry in the CHANGELOG... does it?)

#### Motivation and Context
Closes #6579.

#### How Has This Been Tested?
I have checked the functions manually in the terminal, including with non-existing variables (hence the `-ErrorAction Ignore`).

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.