### PR TITLE
fix(checkver): Harden github checkver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - **core:** Check `$deprecated_dir` exists before accessing it ([#6574](https://github.com/ScoopInstaller/Scoop/issues/6574))
 - **checkver:** Remove redundant always-true condition in GitHub checkver logic ([#6571](https://github.com/ScoopInstaller/Scoop/issues/6571))
 - **core:** Give `dark` higher priority when use `Extract-DarkArchive` ([#6637](https://github.com/ScoopInstaller/Scoop/issues/6637))
+- **checkver:** Harden github checkver ([#6641](https://github.com/ScoopInstaller/Scoop/issues/6641))
 
 ### Code Refactoring
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -257,8 +257,8 @@ $Queue | ForEach-Object {
 
     $wc.Headers.Add('Referer', (strip_filename $url))
     Register-ObjectEvent $wc downloadDataCompleted -ErrorAction Stop | Out-Null
-    $in_progress++
     $wc.DownloadDataAsync($url, $state)
+    $in_progress++
 }
 
 function next($er) {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -108,6 +108,7 @@ Get-Event | Remove-Event
 Get-EventSubscriber | Unregister-Event
 
 # start all downloads
+$in_progress = 0
 $Queue | ForEach-Object {
     $name, $json, $file = $_
 
@@ -119,7 +120,6 @@ $Queue | ForEach-Object {
     } else {
         $wc.Headers.Add('User-Agent', (Get-UserAgent))
     }
-    Register-ObjectEvent $wc downloadDataCompleted -ErrorAction Stop | Out-Null
 
     # Not Specified
     if ($json.checkver.url) {
@@ -168,6 +168,7 @@ $Queue | ForEach-Object {
 
         if ($inputGithubUrl -notmatch $githubUrlPattern) {
             error "$name checkver expects $fieldUsed to be a valid GitHub repository URL"
+            return
         }
 
         $url = $inputGithubUrl.TrimEnd('/')
@@ -260,6 +261,8 @@ $Queue | ForEach-Object {
     }
 
     $wc.Headers.Add('Referer', (strip_filename $url))
+    Register-ObjectEvent $wc downloadDataCompleted -ErrorAction Stop | Out-Null
+    $in_progress++
     $wc.DownloadDataAsync($url, $state)
 }
 
@@ -269,7 +272,6 @@ function next($er) {
 }
 
 # wait for all to complete
-$in_progress = $Queue.length
 while ($in_progress -gt 0) {
     $ev = Wait-Event
     Remove-Event $ev.SourceIdentifier

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -156,7 +156,7 @@ $Queue | ForEach-Object {
     # }
     # ```
     if (($json.checkver -eq 'github') -or $json.checkver.github) {
-        $githubUrlPattern = '^https://((www\.)?github\.com/[\w.-]+/[\w.-]+/?|api\.github\.com/repos/[\w.-]+/[\w.-]+(/.*)?)$'
+        $githubUrlPattern = '^https://((www\.)?github\.com/[\w.-]+/[\w.-]+/?|api\.github\.com/repos/[\w.-]+/[\w.-]+/.+)$'
         $regex = if ($regex) { $regex } else { '/releases/tag/(?:v|V)?([\d.]+)' }
 
         $inputGithubUrl = $json.homepage

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -141,25 +141,44 @@ $Queue | ForEach-Object {
     $replace = ''
     $useGithubAPI = $false
 
-    # GitHub
-    if ($regex) {
-        $githubRegex = $regex
-    } else {
-        $githubRegex = '/releases/tag/(?:v|V)?([\d.]+)'
-    }
-    if ($json.checkver -eq 'github') {
-        if (!$json.homepage.StartsWith('https://github.com/')) {
-            error "$name checkver expects the homepage to be a github repository"
-        }
-        $url = $json.homepage.TrimEnd('/') + '/releases/latest'
-        $regex = $githubRegex
-        $useGithubAPI = $true
-    }
+    ## GitHub
+    #
+    # ```json
+    # "homepage": "<valid-repository-url>",
+    # "checkver": "github"
+    # ```
+    #
+    # or
+    #
+    # ```json
+    # "checkver": {
+    #     "github": "<valid-repository-url-or-repository-api-url>"
+    # }
+    # ```
+    if (($json.checkver -eq 'github') -or $json.checkver.github) {
+        $githubUrlPattern = '^https://((www\.)?github\.com/[\w.-]+/[\w.-]+/?|api\.github\.com/repos/[\w.-]+/[\w.-]+(/.*)?)$'
+        $regex = if ($regex) { $regex } else { '/releases/tag/(?:v|V)?([\d.]+)' }
 
-    if ($json.checkver.github) {
-        $url = $json.checkver.github.TrimEnd('/') + '/releases/latest'
-        $regex = $githubRegex
-        $useGithubAPI = $true
+        $inputGithubUrl = $json.homepage
+        $fieldUsed = 'homepage'
+        if ($json.checkver.github) {
+            $inputGithubUrl = $json.checkver.github
+            $fieldUsed = 'checkver.github'
+        }
+
+        if ($inputGithubUrl -notmatch $githubUrlPattern) {
+            error "$name checkver expects $fieldUsed to be a valid GitHub repository URL"
+        }
+
+        $url = $inputGithubUrl.TrimEnd('/')
+        if ($url -notlike 'https://api.github.com*') {
+            $url = $url + '/releases/latest'
+        }
+
+        if ($GitHubToken) {
+            $url = $url -replace '//(www\.)?github.com/', '//api.github.com/repos/'
+            $useGithubAPI = $true
+        }
     }
 
     # SourceForge
@@ -216,10 +235,7 @@ $Queue | ForEach-Object {
 
     $reverse = $json.checkver.reverse -and $json.checkver.reverse -eq 'true'
 
-    if ($url -like '*api.github.com/*') { $useGithubAPI = $true }
-
-    if ($useGithubAPI -and ($null -ne $GitHubToken)) {
-        $url = $url -replace '//(www\.)?github.com/', '//api.github.com/repos/'
+    if ($useGithubAPI) {
         $wc.Headers.Add('Authorization', "token $GitHubToken")
     }
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -139,7 +139,6 @@ $Queue | ForEach-Object {
     $jsonpath = ''
     $xpath = ''
     $replace = ''
-    $useGithubAPI = $false
 
     ## GitHub
     #
@@ -178,7 +177,7 @@ $Queue | ForEach-Object {
 
         if ($GitHubToken) {
             $url = $url -replace '//(www\.)?github.com/', '//api.github.com/repos/'
-            $useGithubAPI = $true
+            $wc.Headers.Add('Authorization', "token $GitHubToken")
         }
     }
 
@@ -235,10 +234,6 @@ $Queue | ForEach-Object {
     }
 
     $reverse = $json.checkver.reverse -and $json.checkver.reverse -eq 'true'
-
-    if ($useGithubAPI) {
-        $wc.Headers.Add('Authorization', "token $GitHubToken")
-    }
 
     $url = substitute $url $substitutions
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -176,7 +176,7 @@ $Queue | ForEach-Object {
         }
 
         if ($GitHubToken) {
-            $url = $url -replace '//(www\.)?github.com/', '//api.github.com/repos/'
+            $url = $url -replace '//(www\.)?github\.com/', '//api.github.com/repos/'
             $wc.Headers.Add('Authorization', "token $GitHubToken")
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
**NOTE**: With this change, one has to use `"github":` instead of `"url":` to specify checkver urls in github url format, explicitly. This could be considered a breaking change and is by intention, to narrow down the use of GitHub token to only when the checkver is explicitly set to `github` mode.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #XXXX
<!-- or -->
Relates to #XXXX

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Run `checkver.ps1` over local buckets.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
