### PR TITLE
fix(config): correct scoop_repo help URL

### DIFF
--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -33,8 +33,8 @@
 # no_junction: $true|$false
 #       The 'current' version alias will not be used. Shims and shortcuts will point to specific version instead.
 #
-# scoop_repo: http://github.com/ScoopInstaller/Scoop
-#       Git repository containining scoop source code.
+# scoop_repo: https://github.com/ScoopInstaller/Scoop
+#       Git repository containing scoop source code.
 #       This configuration is useful for custom forks.
 #
 # scoop_branch: master|develop


### PR DESCRIPTION
## Summary
- Update the documented `scoop_repo` default URL in `scoop config --help` to use HTTPS instead of HTTP
- Correct typo: `containining` to `containing`
- Make the help text match the actual default config value

Closes #6633.

## Motivation and Context
The `scoop config --help` text showed an outdated HTTP URL for the default `scoop_repo`, which did not match the actual default value. This is a help-text-only fix with no runtime behavior changes.

## How Has This Been Tested?
- Ran `scoop config --help` and confirmed the output now shows the correct HTTPS URL
- Confirmed the typo is corrected and the description is clearer

## Checks
- [x] I have read the Contributing Guide.
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly. ***(Not applicable: help-text only)***
- [ ] I have added an entry in the CHANGELOG. ***(Not applicable: help-text only)***


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed typo in configuration help text.

* **Documentation**
  * Updated repository configuration URL to use HTTPS protocol.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Scoop/pull/6649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->