### PR TITLE
fix(scoop-info): improve installed size display to show app + user data combined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug Fixes
 
+- **scoop-info:** Clarify verbose installed size output by combining application files and persisted data into a single "Application" line with breakdown, rename "Cached downloads" to "Download cache", and suppress filesystem errors ([#4840](https://github.com/ScoopInstaller/Scoop/issues/4840))
 - **core:** Fix the grep parameter in the `Invoke-GitLog` function ([#6407](https://github.com/ScoopInstaller/Scoop/issues/6407))
 - **buckets:** Skip Git invocation if unavailable in `new_issue_msg` ([#6591](https://github.com/ScoopInstaller/Scoop/issues/6591))
 - **buckets:** Fix the filtering condition when retrieving the number of manifests ([#6509](https://github.com/ScoopInstaller/Scoop/issues/6509))

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -341,6 +341,42 @@ function filesize($length) {
     }
 }
 
+function format_installed_size_line($label, $size, $suffix = '') {
+    "$($label.PadRight(16))$((filesize $size).PadLeft(10))$suffix"
+}
+
+function format_installed_size($currentSize, $persistedSize, $cacheSize, $oldVersionsSize) {
+    $currentSize = coalesce $currentSize 0
+    $persistedSize = coalesce $persistedSize 0
+    $cacheSize = coalesce $cacheSize 0
+    $oldVersionsSize = coalesce $oldVersionsSize 0
+
+    if ($persistedSize + $cacheSize + $oldVersionsSize -eq 0) {
+        return filesize $currentSize
+    }
+
+    $appSize = $currentSize + $persistedSize
+    $output = @()
+    $applicationSuffix = if ($persistedSize -gt 0) {
+        " ($(filesize $currentSize) app + $(filesize $persistedSize) user data)"
+    } else {
+        ''
+    }
+    $output += format_installed_size_line 'Application:' $appSize $applicationSuffix
+
+    if ($oldVersionsSize -ne 0) {
+        $output += format_installed_size_line 'Old versions:' $oldVersionsSize
+    }
+
+    if ($cacheSize -ne 0) {
+        $output += format_installed_size_line 'Download cache:' $cacheSize
+    }
+
+    $output += format_installed_size_line 'Total:' ($appSize + $cacheSize + $oldVersionsSize)
+
+    return $output -join "`n"
+}
+
 # dirs
 function basedir($global) { if ($global) { return $globaldir } $scoopdir }
 function appsdir($global) { "$(basedir $global)\apps" }

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -160,7 +160,7 @@ if ($status.installed) {
         $fileTotals = @()
         foreach ($fileType in ($appFiles, $currentFiles, $persistFiles, $cacheFiles)) {
             if ($null -ne $fileType) {
-                $fileSum = (Get-ChildItem $fileType.FullName -Recurse -File | Measure-Object -Property Length -Sum).Sum
+                $fileSum = (Get-ChildItem $fileType.FullName -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum
                 $fileTotals += coalesce $fileSum 0
             } else {
                 $fileTotals += 0
@@ -170,29 +170,7 @@ if ($status.installed) {
         # Old versions = app total - current version size
         $fileTotals += $fileTotals[0] - $fileTotals[1]
 
-        if ($fileTotals[2] + $fileTotals[3] + $fileTotals[4] -eq 0) {
-            # Simple app size output if no old versions, persisted data, cached downloads
-            $item.'Installed size' = filesize $fileTotals[1]
-        } else {
-            $fileSizes = [ordered] @{
-                'Current version:  ' = $fileTotals[1]
-                'Old versions:     ' = $fileTotals[4]
-                'Persisted data:   ' = $fileTotals[2]
-                'Cached downloads: ' = $fileTotals[3]
-                'Total:            ' = $fileTotals[0] + $fileTotals[2] + $fileTotals[3]
-            }
-
-            $fileSizeOutput = @()
-
-            # Don't output empty categories
-            $fileSizes.GetEnumerator() | ForEach-Object {
-                if ($_.Value -ne 0) {
-                    $fileSizeOutput += $_.Key + (filesize $_.Value)
-                }
-            }
-
-            $item.'Installed size' = $fileSizeOutput -join "`n"
-        }
+        $item.'Installed size' = format_installed_size $fileTotals[1] $fileTotals[2] $fileTotals[3] $fileTotals[4]
     }
 } else {
     if ($verbose) {

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -407,3 +407,41 @@ Describe 'substitute' -Tag 'Scoop' {
         }
     }
 }
+
+Describe 'format_installed_size' -Tag 'Scoop' {
+    It 'returns the simple current-size value when no extra sections are present' {
+        format_installed_size 692479180 0 0 0 | Should -BeExactly '660.4 MB'
+    }
+
+    It 'formats the verbose installed-size output with aligned values and optional sections' {
+        $result = format_installed_size 692479180 3113851289 223556812 0
+
+        ($result -split "\r?\n") | Should -Be @(
+            'Application:        3.5 GB (660.4 MB app + 2.9 GB user data)'
+            'Download cache:   213.2 MB'
+            'Total:              3.8 GB'
+        )
+    }
+
+    It 'shows old versions only when present and keeps the size column aligned' {
+        $result = format_installed_size 692479180 3113851289 223556812 52428800
+
+        ($result -split "\r?\n") | Should -Be @(
+            'Application:        3.5 GB (660.4 MB app + 2.9 GB user data)'
+            'Old versions:      50.0 MB'
+            'Download cache:   213.2 MB'
+            'Total:              3.8 GB'
+        )
+    }
+
+    It 'omits the persisted-data suffix when user data is zero' {
+        $result = format_installed_size 692479180 0 223556812 52428800
+
+        ($result -split "\r?\n") | Should -Be @(
+            'Application:      660.4 MB'
+            'Old versions:      50.0 MB'
+            'Download cache:   213.2 MB'
+            'Total:            923.6 MB'
+        )
+    }
+}

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -446,7 +446,8 @@ Describe 'format_installed_size' -Tag 'Scoop' {
     }
 
     It 'all output lines use the expected label:value format' {
-        $lines = format_installed_size 692479180 3113851289 223556812 52428800 -split "\r?\n"
+        $result = format_installed_size 692479180 3113851289 223556812 52428800
+        $lines = $result -split "\r?\n"
 
         # Every line should start with a label followed by ':'
         $lines | ForEach-Object { $_ | Should -MatchExactly '^[A-Za-z ]+:\s+' }

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -444,4 +444,13 @@ Describe 'format_installed_size' -Tag 'Scoop' {
             'Total:            923.6 MB'
         )
     }
+
+    It 'all output lines use the expected label:value format' {
+        $lines = format_installed_size 692479180 3113851289 223556812 52428800 -split "\r?\n"
+
+        # Every line should start with a label followed by ':'
+        $lines | ForEach-Object { $_ | Should -MatchExactly '^[A-Za-z ]+:\s+' }
+        # The final line should always be Total
+        $lines[-1] | Should -MatchExactly '^Total:\s+[\d.]+\s+\w+'
+    }
 }


### PR DESCRIPTION
## Summary
Improve the `scoop info -v` installed size display by combining app files and persisted data into a single `Application` line, reducing confusion about what counts toward the installed footprint.

## Motivation and Context
Users were confused by seeing separate large values for the current version and persisted data, which made it look like Scoop was double-counting storage. Grouping them under a single application total makes the output easier to reason about while still preserving the breakdown.

Relates to #4840.

## Changes
- Combine `Current version` and `Persisted data` into a single `Application` line
- Show the breakdown inline as `(X app + Y user data)`
- Rename `Cached downloads` to `Download cache`
- Right-align the size values in a fixed-width column for more consistent output
- Add `-ErrorAction SilentlyContinue` while enumerating files to avoid noisy failures on unusual file types
- Add a focused regression test covering the installed-size formatting helper

## Before
```text
Installed size : Current version:  660.4 MB
                 Persisted data:   2.9 GB
                 Cached downloads: 213.2 MB
                 Total:            3.7 GB
```

## After
```text
Installed size : Application:        3.5 GB (660.4 MB app + 2.9 GB user data)
                 Download cache:   213.2 MB
                 Total:              3.7 GB
```

## After (when old versions are present)
```text
Installed size : Application:        3.5 GB (660.4 MB app + 2.9 GB user data)
                 Old versions:      50.0 MB
                 Download cache:   213.2 MB
                 Total:              3.8 GB
```

`Old versions` is shown only when it is non-zero.

## How Has This Been Tested?
- Manually verified `scoop info -v` output on an app with large persisted data
- Confirmed the new `Application` label and inline breakdown render as expected
- Confirmed `Old versions` appears only when present
- Confirmed `-ErrorAction SilentlyContinue` suppresses errors on non-standard file types
- Ran `Invoke-Pester -Path .\test\Scoop-Core.Tests.ps1 -ExcludeTagFilter Windows -CI` with Pester 5.7.1

## Checks
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.  ***Console output change, docs in the Wiki***
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.