### PR TITLE
feat(scoop-update): add --allow-running flag to bypass running-process check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **download|scoop-config:** Allow disabling automatic fallback to the default downloader when Aria2c download fails ([#6538](https://github.com/ScoopInstaller/Scoop/issues/6538))
 - **checkver:** Set GitHub mode default jsonpath and regex ([#6653](https://github.com/ScoopInstaller/Scoop/issues/6653))
 - **download:** Enhance Get-GitHubToken to include more token sources ([#6712](https://github.com/ScoopInstaller/Scoop/issues/6712))
+- **scoop-update:** Add `--allow-running` flag to bypass running-process check ([#6342](https://github.com/ScoopInstaller/Scoop/issues/6342), [#6029](https://github.com/ScoopInstaller/Scoop/issues/6029))
 
 ### Bug Fixes
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -38,6 +38,7 @@ $use_cache = !($opt.k -or $opt.'no-cache')
 $quiet = $opt.q -or $opt.quiet
 $independent = $opt.i -or $opt.independent
 $all = $opt.a -or $opt.all
+$allowRunning = $opt.r -or $opt.'allow-running'
 
 # load config
 $configRepo = get_config SCOOP_REPO
@@ -399,11 +400,19 @@ if (-not ($apps -or $all)) {
     set_config LAST_UPDATE ([System.DateTime]::Now.ToString('o')) | Out-Null
     success 'Scoop was updated successfully!'
 } else {
-    if ($global -and !(is_admin)) {
-        error 'You need admin rights to update global apps.'; exit 1
+    # --allow-running: temporarily bypass running-process check.
+    # Scoop uses versioned directories (e.g., pwsh 7.6.1/ -> 7.6.2/),
+    # so the update creates a new directory without touching the running binary.
+    if ($allowRunning) {
+        $savedIgnoreRunning = get_config IGNORE_RUNNING_PROCESSES
+        set_config IGNORE_RUNNING_PROCESSES $true | Out-Null
     }
+    try {
+        if ($global -and !(is_admin)) {
+            error 'You need admin rights to update global apps.'; exit 1
+        }
 
-    $outdated = @()
+        $outdated = @()
     $updateScoop = $null -ne ($apps | Where-Object { $_ -eq 'scoop' }) -or (is_scoop_outdated)
     $apps = $apps | Where-Object { $_ -ne 'scoop' }
     $apps_param = $apps
@@ -463,6 +472,15 @@ if (-not ($apps -or $all)) {
     $suggested = @{}
     # $outdated is a list of ($app, $global) tuples
     $outdated | ForEach-Object { update @_ $quiet $independent $suggested $use_cache $check_hash }
+    } finally {
+        if ($allowRunning) {
+            if ($null -ne $savedIgnoreRunning) {
+                set_config IGNORE_RUNNING_PROCESSES $savedIgnoreRunning | Out-Null
+            } else {
+                set_config IGNORE_RUNNING_PROCESSES $false | Out-Null
+            }
+        }
+    }
 }
 
 exit 0


### PR DESCRIPTION
## Description

Adds `-r, --allow-running` flag to `scoop update` that temporarily sets `IGNORE_RUNNING_PROCESSES $true` for the duration of the update command, then restores the previous value.

This is safe for apps installed in versioned directories (e.g., pwsh, most portable apps), where the update creates a new version directory without touching the running binary. The existing `IGNORE_RUNNING_PROCESSES` config already handles this case — this flag simply exposes it as a one-shot CLI option so users don't need to toggle a global config.

```powershell
# Before: requires manual config toggle
scoop config IGNORE_RUNNING_PROCESSES $true
scoop update pwsh
scoop config IGNORE_RUNNING_PROCESSES $false

# After: single command
scoop update pwsh --allow-running
```

## Motivation and Context

Updating pwsh (or any scoop-managed app that is currently running) has required users to either:
1. Close all instances of the app first
2. Set the global `IGNORE_RUNNING_PROCESSES` config, update, then unset it

The scoop pwsh manifest itself notes: "Since Scoop uses pwsh.exe internally, to update PowerShell Core itself, run `scoop update pwsh` from Windows PowerShell." But even from Windows PowerShell, the running-process check can still block the update because the current pwsh.exe session matches the app directory.

For versioned-install apps like pwsh, the update is safe because scoop creates a new version directory (e.g., `7.6.2/`) without modifying the old directory (`7.6.1/`) where the running binary lives. The user merely needs to restart the app.

Closes #6342
Relates to #6029, #4713, #5799

## How Has This Been Tested?

- Verified that `scoop update pwsh` with `IGNORE_RUNNING_PROCESSES` set correctly creates a new version directory (`7.6.2/`) while the old binary (`7.6.1/`) continues running
- Verified that the `current` junction is updated to point to the new version
- Verified that the old `--skip-hash-check` and other flags still work alongside `--allow-running`
- Tested both single-app and bulk update paths (the config is set before the update loop and restored afterward)

## Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.