### PR TITLE
fix(checkver): skip default JSONPath for scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug Fixes
 
+- **checkver:** Skip default GitHub JSONPath when using custom script ([#6681](https://github.com/ScoopInstaller/Scoop/issues/6681))
 - **core:** Fix the grep parameter in the `Invoke-GitLog` function ([#6407](https://github.com/ScoopInstaller/Scoop/issues/6407))
 - **buckets:** Skip Git invocation if unavailable in `new_issue_msg` ([#6591](https://github.com/ScoopInstaller/Scoop/issues/6591))
 - **buckets:** Fix the filtering condition when retrieving the number of manifests ([#6509](https://github.com/ScoopInstaller/Scoop/issues/6509))

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -179,7 +179,9 @@ $Queue | ForEach-Object {
 
         if ($url -like 'https://api.github.com*') {
             # Default jsonpath/regex in GitHub API mode
-            $jsonpath = '$.tag_name'
+            if (-not $json.checkver.script) {
+                $jsonpath = '$.tag_name'
+            }
             if (-not $regex) {
                 $regex = '(?:v|V)?([\d.-]+)'
             }


### PR DESCRIPTION
## Description

Skip the default GitHub API JSONPath when `checkver.script` is configured. Explicit `jsonpath` settings continue to work.

Closes #6681

## Testing

- Reproduced the issue with GitHub mode, a custom script, and regex
- Verified normal GitHub mode still uses `$.tag_name`
- Verified explicit JSONPath still applies to script output
- Windows PowerShell 5.1: 121 passed, 0 failed
- PowerShell 7: 121 passed, 0 failed