### PR TITLE
fix(scoop-export): Make exported JSON key order deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - **core:** Give `dark` higher priority when use `Extract-DarkArchive` ([#6637](https://github.com/ScoopInstaller/Scoop/issues/6637))
 - **checkver:** Harden github checkver ([#6641](https://github.com/ScoopInstaller/Scoop/issues/6641))
 - **scoop-search:** Select latest search result semantically ([#6643](https://github.com/ScoopInstaller/Scoop/issues/6643))
+- **scoop-export|scoop-list:** Make exported JSON key order deterministic ([#6697](https://github.com/ScoopInstaller/Scoop/issues/6697))
 
 ### Code Refactoring
 

--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -5,7 +5,7 @@
 
 . "$PSScriptRoot\..\lib\json.ps1" # 'ConvertToPrettyJson'
 
-$export = @{}
+$export = [ordered]@{}
 
 if ($args[0] -eq '-c' -or $args[0] -eq '--config') {
     $export.config = $scoopConfig

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -26,7 +26,7 @@ Write-Host "Installed apps$(if($query) { `" matching '$query'`"}):"
 $apps | Where-Object { !$query -or ($_.name -match $query) } | ForEach-Object {
     $app = $_.name
     $global = $_.global
-    $item = @{}
+    $item = [ordered]@{}
     $ver = Select-CurrentVersion -AppName $app -Global:$global
     $item.Name = $app
     $item.Version = $ver


### PR DESCRIPTION
#### Description

One one-line change, `@{}` → `[ordered]@{}`, so that `scoop export` produces byte-identical output when nothing has changed.

`ConvertToPrettyJson` follows the hashtable's *enumeration* order. For a hashtable **literal** PowerShell preserves the written order — but a hashtable built by assigning keys one at a time enumerates in bucket order, which depends on `String.GetHashCode()`, and .NET randomizes string hashing per process.

- **`libexec/scoop-export.ps1:8`** — `$export` is built by assigning `.config` / `.buckets` / `.apps`, so the three top-level keys were emitted in a random order.

`[ordered]@{}` gives insertion order — no sorting pass needed, and no behaviour change for consumers, since `scoop import` reads by property name (`$item.Name`, `$item.Source`, …).

(App property order within the `apps` array was the second facet of #5862; it is already stable on develop — #6732 rewrote the list objects into `[PSCustomObject]` hashtable literals — so merging this PR closes out the whole issue.)

#### Motivation and Context

Closes #5862

`scoop export`'s main use is checking the file into version control, and non-deterministic key order defeats that. On a machine committing a daily `scoop export`, **62 of 80 commits were pure property reordering with no content change at all** — typically over 100 changed lines each, from only ~18 installed apps. Real version bumps were buried in the noise.

Worth noting #5862 is currently labelled `enhancement`, but the output is non-deterministic rather than merely unsorted, which is arguably a bug.

#### How Has This Been Tested?

PowerShell 7.6.1 on Windows 11, against a real install with 18 apps and 1 bucket.

**1. Determinism, running `bin/scoop.ps1 export` in 4 separate processes** and hashing the output — once on unmodified `develop`, once with this change:

| | distinct outputs / 4 | top-level key order |
|---|---|---|
| `develop` | **4** | `buckets, apps, config` (varied) |
| this PR | **1** | `config, buckets, apps` |

**2. Minimal repro of the underlying mechanism** (5 separate processes):

```powershell
1..5 | ForEach-Object { pwsh -NoProfile -Command '$e=@{}; $e.buckets=1; $e.apps=2; $e.config=3; ($e.Keys) -join ", "' }
# apps, config, buckets / config, apps, buckets / buckets, apps, config / buckets, apps, config / config, buckets, apps
```

With `[ordered]@{}` the same loop returns insertion order every time. This is also why exporting twice in one session looks stable — the reordering only shows up across processes.

**3. `scoop export -c`** — the riskiest part of the change, since it does `$export.config.PSObject.Properties.Remove(...)`. Verified on both variants that the output is still valid JSON, that `config` is present, and that `last_update` / `root_path` / `global_path` / `cache_path` / `alias` are still stripped. Property access and `.Remove()` work the same on an `OrderedDictionary`.

**4. `scoop list`** — unchanged output: identical on both variants (the list command emits `[PSCustomObject]` hashtable literals, which this change does not touch).

**5. Linting** — `Invoke-ScriptAnalyzer` with the repo's `PSScriptAnalyzerSettings.psd1`: 0 findings on the changed file and 0 across `libexec` as a whole, matching `Scoop-00Linting.Tests.ps1`.

There is currently no test coverage for `scoop export` in `test/`, so nothing existing needed updating. A regression test would have to spawn a child process to defeat per-process hash seeding, which felt disproportionate for a one-line change — happy to add one if you'd prefer.

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
