### PR TITLE
fix(core): guard null stream/reader/writer in PE subsys functions

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -16,8 +16,8 @@ function Get-PESubsystem($filePath) {
     } catch {
         return -1
     } finally {
-        $binaryReader.Close()
-        $fileStream.Close()
+        if ($binaryReader) { $binaryReader.Close() }
+        if ($fileStream) { $fileStream.Close() }
     }
 }
 
@@ -40,8 +40,9 @@ function Set-PESubsystem($filePath, $targetSubsystem) {
     } catch {
         return $false
     } finally {
-        $binaryReader.Close()
-        $fileStream.Close()
+        if ($binaryReader) { $binaryReader.Close() }
+        if ($fileStream) { $fileStream.Close() }
+        if ($binaryWriter) { $binaryWriter.Close() }
     }
     return $true
 }


### PR DESCRIPTION
Fix null-reference errors when creating shims during install.

`Get-PESubsystem` and `Set-PESubsystem` unconditionally called `.Close()` on stream/reader/writer objects in their `finally` blocks. If the constructor threw (e.g. file missing or unreadable), those variables were still \$null, causing:

  You cannot call a method on a null-valued expression.

This commit adds null checks and also closes \$binaryWriter in `Set-PESubsystem`, which was previously leaked.