### PR TITLE
test(bucket): Compatible with Pester v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@
 
 - **workflow:** Drop Appveyor support and refactor GitHub Actions workflow ([#6626](https://github.com/ScoopInstaller/Scoop/issues/6626))
 
+### Tests
+
+- **bucket:** Compatible with Pester v6 ([#6724](https://github.com/ScoopInstaller/Scoop/issues/6724))
+
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 
 ### Features

--- a/test/Import-Bucket-Tests.ps1
+++ b/test/Import-Bucket-Tests.ps1
@@ -27,24 +27,26 @@ Describe 'Manifest validates against the schema' {
         $validator = New-Object Scoop.Validator("$PSScriptRoot/../schema.json", $true)
         $global:quotaExceeded = $false
     }
-    It '<_>' -TestCases $manifestFiles {
-        if ($global:quotaExceeded) {
-            Set-ItResult -Skipped -Because 'Schema validation limit exceeded.'
-        } else {
-            $file = $_ # exception handling may overwrite $_
-            try {
-                $validator.Validate($file)
-                if ($validator.Errors.Count -gt 0) {
-                    Write-Host "  [-] $_ has $($validator.Errors.Count) Error$(If($validator.Errors.Count -gt 1) { 's' })!" -ForegroundColor Red
-                    Write-Host $validator.ErrorsAsString -ForegroundColor Yellow
-                }
-                $validator.Errors.Count | Should -Be 0
-            } catch {
-                if ($_.Exception.Message -like '*The free-quota limit of 1000 schema validations per hour has been reached.*') {
-                    $global:quotaExceeded = $true
-                    Set-ItResult -Skipped -Because 'Schema validation limit exceeded.'
-                } else {
-                    throw
+    if ($manifestFiles.Count -gt 0) {
+        It '<_>' -TestCases $manifestFiles {
+            if ($global:quotaExceeded) {
+                Set-ItResult -Skipped -Because 'Schema validation limit exceeded.'
+            } else {
+                $file = $_ # exception handling may overwrite $_
+                try {
+                    $validator.Validate($file)
+                    if ($validator.Errors.Count -gt 0) {
+                        Write-Host "  [-] $_ has $($validator.Errors.Count) Error$(If($validator.Errors.Count -gt 1) { 's' })!" -ForegroundColor Red
+                        Write-Host $validator.ErrorsAsString -ForegroundColor Yellow
+                    }
+                    $validator.Errors.Count | Should -Be 0
+                } catch {
+                    if ($_.Exception.Message -like '*The free-quota limit of 1000 schema validations per hour has been reached.*') {
+                        $global:quotaExceeded = $true
+                        Set-ItResult -Skipped -Because 'Schema validation limit exceeded.'
+                    } else {
+                        throw
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

`-AllowNullOrEmptyForEach` was not used as it's only available in Pester v6, Pester v5 is still supported in our scenario.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #6713

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Pester v6:

before:
<img width="1216" height="904" alt="image" src="https://github.com/user-attachments/assets/9fb49541-8c3d-4116-a7e1-b188750f632c" />

after:
<img width="1212" height="908" alt="image" src="https://github.com/user-attachments/assets/28ef6638-b902-4153-a88e-f70d11c0f6b5" />

Pester v5:

<img width="1228" height="922" alt="image" src="https://github.com/user-attachments/assets/2d32c23d-fecc-40b0-b36e-7b3bc6b09ffd" />


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
