### PR TITLE
fix(scoop-update): `-f` upgrades `@version` pins to the bucket HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+- **scoop-update:** `scoop update -f` on an `@version` pin now upgrades to the bucket HEAD ([#6730](https://github.com/ScoopInstaller/Scoop/issues/6730))
 - **core:** Fix the grep parameter in the `Invoke-GitLog` function ([#6407](https://github.com/ScoopInstaller/Scoop/issues/6407))
 - **buckets:** Skip Git invocation if unavailable in `new_issue_msg` ([#6591](https://github.com/ScoopInstaller/Scoop/issues/6591))
 - **buckets:** Fix the filtering condition when retrieving the number of manifests ([#6509](https://github.com/ScoopInstaller/Scoop/issues/6509))

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -43,7 +43,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
             return
         }
     }
-    Write-Output "Installing '$app' ($version) [$architecture]$(if ($bucket) { " from '$bucket' bucket" } else { " from '$url'" })"
+    Write-Output "Installing '$app' ($version) [$architecture]$(if ($bucket) { " from '$bucket' bucket" } elseif ($url -like (usermanifestsdir) + '\*') { ' from generated manifest' } else { " from '$url'" })"
 
     $dir = ensure (versiondir $app $version $global)
     $original_dir = $dir # keep reference to real (not linked) directory

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -40,8 +40,9 @@ function Get-Manifest($app) {
         $app = appname_from_url $url
         $manifest = url_manifest $url
     } else {
-        # Check if the manifest is already installed
-        if (installed $app) {
+        # 'bucket/app' form is an explicit bucket request; honor it instead of
+        # reading install.json (which may carry a stale pin from a prior install)
+        if ($app -notmatch '^[^/]+/' -and (installed $app)) {
             $global = installed $app $true
             $ver = Select-CurrentVersion -AppName $app -Global:$global
             if (!$ver) {
@@ -78,42 +79,46 @@ function Get-Manifest($app) {
             if ($bucket) {
                 $manifest = manifest $app $bucket
             } else {
-                $matched_buckets = @()
-                foreach ($tekcub in Get-LocalBucket) {
-                    $current_manifest = manifest $app $tekcub
-                    if (!$manifest -and $current_manifest) {
-                        $manifest = $current_manifest
-                        $bucket = $tekcub
+                $manifest, $bucket = Find-AppBucket $app
+                if (!$manifest) {
+                    # couldn't find app in buckets: check if it's a local path
+                    if (Test-Path $app) {
+                        $url = Convert-Path $app
+                        $app = appname_from_url $url
+                        $manifest = parse_json $url
+                    } else {
+                        if (($app -match '\\/') -or $app.EndsWith('.json')) { $url = $app }
+                        $app = appname_from_url $app
                     }
-                    if ($current_manifest) {
-                        $matched_buckets += $tekcub
-                    }
-                }
-            }
-            if (!$manifest) {
-                # couldn't find app in buckets: check if it's a local path
-                if (Test-Path $app) {
-                    $url = Convert-Path $app
-                    $app = appname_from_url $url
-                    $manifest = parse_json $url
-                } else {
-                    if (($app -match '\\/') -or $app.EndsWith('.json')) { $url = $app }
-                    $app = appname_from_url $app
                 }
             }
         }
     }
 
-    if ($matched_buckets.Length -gt 1) {
-        warn "Multiple buckets contain manifest '$app', the current selection is '$bucket/$app'."
-    }
-
     return $app, $manifest, $bucket, $url
 }
 
+function Find-AppBucket($app) {
+    $matched_buckets = @()
+    $manifest = $null
+    foreach ($tekcub in Get-LocalBucket) {
+        $current_manifest = parse_json (manifest_path $app $tekcub)
+        if (!$current_manifest) { continue }
+        $matched_buckets += $tekcub
+        if (!$manifest) { $manifest = $current_manifest }
+    }
+    if ($matched_buckets.Length -gt 1) {
+        warn "Multiple buckets contain manifest '$app', the current selection is '$($matched_buckets[0])/$app'."
+    }
+    return $manifest, $matched_buckets[0]
+}
+
 function manifest($app, $bucket, $url) {
-    if ($url) { return url_manifest $url }
-    parse_json (manifest_path $app $bucket)
+    # bucket HEAD wins; url is only the source for URL/pinned installs
+    if ($bucket) { return parse_json (manifest_path $app $bucket) }
+    $manifest = if ($url -match '^(ht|f)tps?://|\\\\') { url_manifest $url }
+    if (!$manifest -and $url) { $manifest = parse_json $url } # local path or failed remote
+    $manifest
 }
 
 function save_installed_manifest($app, $bucket, $dir, $url) {
@@ -303,7 +308,7 @@ function generate_user_manifest($app, $bucket, $version) {
     }
 
     # Try historical providers via orchestrator
-    info "Attempting to find historical manifest for '$app' ($version)"
+    info "Resolving historical manifest for '$app' ($version)"
     $historicalResult = Find-HistoricalManifest $app $bucket $version
     if ($historicalResult) { return $historicalResult.path }
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -276,7 +276,7 @@ function update($app, $global, $force = $false, $quiet = $false, $independent, $
             $manifest = $scanned
             $url = $null
         } else {
-            $manifest = manifest $app 'main' $url
+            $manifest = manifest $app $null $url
         }
     } else {
         if ($null -eq $bucket) { $bucket = 'main' }
@@ -380,7 +380,7 @@ function update($app, $global, $force = $false, $quiet = $false, $independent, $
         # add bucket name it was installed from
         $app = "$bucket/$app"
     }
-    if ($install.url -and !$pin_broken) {
+    if ($install.url -and (!$pin_broken -or !$bucket)) {
         # use the url of the install json if the application was installed through url
         $app = $install.url
     }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -258,7 +258,7 @@ function Sync-Bucket {
     }
 }
 
-function update($app, $global, $quiet = $false, $independent, $suggested, $use_cache = $true, $check_hash = $true) {
+function update($app, $global, $force = $false, $quiet = $false, $independent, $suggested, $use_cache = $true, $check_hash = $true) {
     $old_version = Select-CurrentVersion -AppName $app -Global:$global
     $old_manifest = installed_manifest $app $old_version $global
     $install = install_info $app $old_version $global
@@ -266,12 +266,22 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     # re-use architecture, bucket and url from first install
     $architecture = Format-ArchitectureString $install.architecture
     $bucket = $install.bucket
-    if ($null -eq $bucket) {
-        $bucket = 'main'
-    }
     $url = $install.url
 
-    $manifest = manifest $app $bucket $url
+    # -f on an @version pin re-resolves against the bucket HEAD
+    $pin_broken = $force -and $null -eq $bucket -and $url
+    if ($pin_broken) {
+        $scanned, $bucket = Find-AppBucket $app
+        if ($scanned) {
+            $manifest = $scanned
+            $url = $null
+        } else {
+            $manifest = manifest $app 'main' $url
+        }
+    } else {
+        if ($null -eq $bucket) { $bucket = 'main' }
+        $manifest = manifest $app $bucket $url
+    }
     $version = $manifest.version
     $is_nightly = $version -eq 'nightly'
     if ($is_nightly) {
@@ -370,7 +380,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
         # add bucket name it was installed from
         $app = "$bucket/$app"
     }
-    if ($install.url) {
+    if ($install.url -and !$pin_broken) {
         # use the url of the install json if the application was installed through url
         $app = $install.url
     }
@@ -380,7 +390,6 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     } else {
         # Also add missing dependencies
         $apps = @(Get-Dependency $app $architecture) -ne $app
-        ensure_none_failed $apps
         $apps.Where({ !(installed $_) }) + $app | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
     }
 }
@@ -429,10 +438,16 @@ if (-not ($apps -or $all)) {
         $apps | ForEach-Object {
             ($app, $global) = $_
             $status = app_status $app $global
+            # -f on an @version pin upgrades to the bucket HEAD; the target
+            # version is resolved (and warned) by update(), not guessed here
+            $ver = Select-CurrentVersion -AppName $app -Global:$global
+            $pin = install_info $app $ver $global
+            $is_pin = $force -and !$pin.bucket -and $pin.url
             if ($status.installed -and ($force -or $status.outdated)) {
                 if (!$status.hold) {
                     $outdated += applist $app $global
-                    Write-Host -f yellow ("$app`: $($status.version) -> $($status.latest_version){0}" -f ('', ' (global)')[$global])
+                    $latest = if ($is_pin) { 'HEAD (forced)' } else { $status.latest_version }
+                    Write-Host -f yellow ("$app`: $($status.version) -> $latest{0}" -f ('', ' (global)')[$global])
                 } else {
                     warn "'$app' is held to version $($status.version)"
                 }
@@ -462,7 +477,7 @@ if (-not ($apps -or $all)) {
 
     $suggested = @{}
     # $outdated is a list of ($app, $global) tuples
-    $outdated | ForEach-Object { update @_ $quiet $independent $suggested $use_cache $check_hash }
+    $outdated | ForEach-Object { update @_ $force $quiet $independent $suggested $use_cache $check_hash }
 }
 
 exit 0

--- a/test/Scoop-Manifest.Tests.ps1
+++ b/test/Scoop-Manifest.Tests.ps1
@@ -72,7 +72,7 @@ Describe 'Manifest Validator' -Tag 'Validator' {
     }
 
     It 'Scoop.Validator is available' {
-            ([System.Management.Automation.PSTypeName]'Scoop.Validator').Type | Should -Be 'Scoop.Validator'
+        ([System.Management.Automation.PSTypeName]'Scoop.Validator').Type | Should -Be 'Scoop.Validator'
     }
     It 'fails with broken schema' {
         $validator = New-Object Scoop.Validator("$PSScriptRoot/fixtures/manifest/broken_schema.json", $true)
@@ -104,7 +104,7 @@ Describe 'Find-HistoricalManifestInCache' -Tag 'Scoop' {
 
     It 'returns manifest text and version when cache has exact match' {
         $tempUM = Join-Path $env:TEMP 'ScoopTestsUM'
-        Mock get_config -ParameterFilter { $name -in @('use_sqlite_cache','use_git_history') } { $true }
+        Mock get_config -ParameterFilter { $name -in @('use_sqlite_cache', 'use_git_history') } { $true }
         Mock Get-ScoopDBItem {
             $dt = New-Object System.Data.DataTable
             [void]$dt.Columns.Add('manifest')
@@ -191,7 +191,7 @@ Describe 'Find-HistoricalManifestInGit' -Tag 'Scoop' {
 
 Describe 'Find-HistoricalManifest (orchestrator)' -Tag 'Scoop' {
     It 'returns $null when both cache and git miss' {
-        Mock get_config -ParameterFilter { $name -in @('use_sqlite_cache','use_git_history') } { $true }
+        Mock get_config -ParameterFilter { $name -in @('use_sqlite_cache', 'use_git_history') } { $true }
         Mock Find-HistoricalManifestInCache { $null }
         Mock Find-HistoricalManifestInGit { $null }
         $result = Find-HistoricalManifest 'foo' 'main' '1.0.0'
@@ -212,16 +212,16 @@ Describe 'Write-ManifestToUserCache' -Tag 'Scoop' {
 
 Describe 'generate_user_manifest (history-aware)' -Tag 'Scoop' {
     It 'returns manifest_path when versions match' {
-        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version='1.0.0' }, 'main', $null }
+        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version = '1.0.0' }, 'main', $null }
         Mock manifest_path { 'C:\path\foo.json' }
         $p = generate_user_manifest 'foo' 'main' '1.0.0'
         $p | Should -Be 'C:\path\foo.json'
     }
 
     It 'prefers history orchestrator hit (cache) when enabled' {
-        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version='2.0.0' }, 'main', $null }
-        Mock get_config -ParameterFilter { $name -in @('use_sqlite_cache','use_git_history') } { $true }
-        Mock Find-HistoricalManifest { @{ path = 'C:\cache\foo.json'; version = '1.0.0'; source='sqlite_exact_match' } }
+        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version = '2.0.0' }, 'main', $null }
+        Mock get_config -ParameterFilter { $name -in @('use_sqlite_cache', 'use_git_history') } { $true }
+        Mock Find-HistoricalManifest { @{ path = 'C:\cache\foo.json'; version = '1.0.0'; source = 'sqlite_exact_match' } }
 
         Mock info {}
         Mock warn {}
@@ -232,9 +232,9 @@ Describe 'generate_user_manifest (history-aware)' -Tag 'Scoop' {
     }
 
     It 'falls back to git history when cache misses' {
-        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version='2.0.0' }, 'main', $null }
-        Mock get_config -ParameterFilter { $name -in @('use_sqlite_cache','use_git_history') } { $true }
-        Mock Find-HistoricalManifest { @{ path = 'C:\git\foo.json'; version = '1.0.0'; source='git_manifest:hash' } }
+        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version = '2.0.0' }, 'main', $null }
+        Mock get_config -ParameterFilter { $name -in @('use_sqlite_cache', 'use_git_history') } { $true }
+        Mock Find-HistoricalManifest { @{ path = 'C:\git\foo.json'; version = '1.0.0'; source = 'git_manifest:hash' } }
         Mock info {}
         Mock warn {}
         $p = generate_user_manifest 'foo' 'main' '1.0.0'
@@ -245,7 +245,7 @@ Describe 'generate_user_manifest (history-aware)' -Tag 'Scoop' {
 
     It 'uses autoupdate when no history found and autoupdate exists' {
         $umdir = Join-Path $env:TEMP 'ScoopTestsUM'
-        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version='2.0.0'; autoupdate=@{} }, 'main', $null }
+        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version = '2.0.0'; autoupdate = @{} }, 'main', $null }
         Mock get_config -ParameterFilter { $name -eq 'use_sqlite_cache' } { $false }
         Mock Find-HistoricalManifest { $null }
 
@@ -260,7 +260,7 @@ Describe 'generate_user_manifest (history-aware)' -Tag 'Scoop' {
 
     It 'returns $null when autoupdate fails (caller surfaces the error)' {
         $umdir = Join-Path $env:TEMP 'ScoopTestsUM'
-        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version='2.0.0'; autoupdate=@{} }, 'main', $null }
+        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version = '2.0.0'; autoupdate = @{} }, 'main', $null }
         Mock get_config -ParameterFilter { $name -eq 'use_sqlite_cache' } { $false }
         Mock Find-HistoricalManifest { $null }
         Mock ensure {}
@@ -275,7 +275,7 @@ Describe 'generate_user_manifest (history-aware)' -Tag 'Scoop' {
     }
 
     It 'aborts when no history and no autoupdate' {
-        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version='2.0.0' }, 'main', $null }
+        Mock Get-Manifest -ParameterFilter { $app -eq 'main/foo' } { 'foo', [pscustomobject]@{ version = '2.0.0' }, 'main', $null }
         Mock get_config -ParameterFilter { $name -eq 'use_sqlite_cache' } { $false }
         Mock Find-HistoricalManifest { $null }
 
@@ -286,3 +286,31 @@ Describe 'generate_user_manifest (history-aware)' -Tag 'Scoop' {
     }
 }
 
+Describe 'manifest bucket auto-discovery' -Tag 'Scoop' {
+    It 'discovers bucket for bare app name' {
+        Mock Get-LocalBucket { @('main') }
+        Mock manifest_path { 'C:\fake.json' }
+        Mock parse_json { @{ version = '1.0.0' } }
+        Mock warn {}
+        $m, $b = Find-AppBucket 'foo'
+        $b | Should -Be 'main'
+        $m.version | Should -Be '1.0.0'
+    }
+
+    It 'returns $null when app not found in any bucket' {
+        Mock Get-LocalBucket { @('main') }
+        Mock manifest_path { 'C:\nonexistent.json' }
+        Mock parse_json { $null }
+        Mock warn {}
+        $m, $b = Find-AppBucket 'foo'
+        $m | Should -BeNullOrEmpty
+        $b | Should -BeNullOrEmpty
+    }
+
+    It 'url used when bucket is null' {
+        Mock url_manifest { @{ version = '1.0.0' } }
+        $m = manifest 'foo' $null 'https://example.com/foo.json'
+        $m.version | Should -Be '1.0.0'
+        Should -Invoke url_manifest -Times 1
+    }
+}


### PR DESCRIPTION
#### Description

`Get-Manifest` previously read `install.json` first whenever the app looked "installed", which silently shadowed explicit `bucket/app` lookups with a stale pin URL. `scoop update -f` on an `@version` install reused the pinned URL and reinstalled the same pinned version instead of upgrading to the bucket HEAD.

This change makes the explicit `bucket/app` form take precedence over the installed-app branch in `Get-Manifest`, lets `scoop update -f` re-resolve pins against the bucket HEAD, and surfaces the workspace URL as `from generated manifest` in the install banner instead of the raw path.

#### Motivation and Context

Two related gaps in version-pin handling:

1. `Get-Manifest 'bucket/app'` entered the installed-check branch and read `install.json` (which carries the workspace URL on a pin), so the caller's bucket intent was lost.
2. `scoop update -f` on a pinned `@version` install would log `pin -> HEAD (forced)` but reinstall the same pinned version because the install.json's URL was reused for the new `install_app` call.

The fix is purely in resolution logic; no installer, uninstaller, or cleanup behavior is changed.

#### How Has This Been Tested?

- `./test/bin/test.ps1` full suite: 169/169.
- `./test/bin/test.ps1 -TestPath test/Scoop-Manifest.Tests.ps1`: 32/32, including new `Find-AppBucket` and `manifest()` priority cases.
- `PSScriptAnalyzer` clean across `.`, `bin`, `lib`, `libexec`, `test`.

End-to-end smoke on `7zip`:

- `scoop install 7zip@26.01` -> `Installing '7zip' (26.01) [64bit] from generated manifest`, `install.json` records `{"url": "workspace/7zip.json"}`.
- `scoop update 7zip` (no `-f`) -> `7zip: 26.01 (latest version)`, pin preserved.
- `scoop update 7zip -f` -> `7zip: 26.01 -> HEAD (forced)` -> `Installing '7zip' (26.03) [64bit] from 'main' bucket`, `install.json` rewritten to `{"bucket": "main", "architecture": "64bit"}`. Single install, single `Multiple buckets` warning.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
