### PR TITLE
fix(scoop-update): Import versions.ps1 in parallel bucket sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+- **scoop-update:** Import `versions.ps1` in the parallel bucket sync to fix `currentdir` failing with `NO_JUNCTION` enabled ([#6735](https://github.com/ScoopInstaller/Scoop/issues/6735))
 - **scoop-update:** `scoop update -f` on an `@version` pin now upgrades to the bucket HEAD ([#6730](https://github.com/ScoopInstaller/Scoop/issues/6730))
 - **core:** Fix the grep parameter in the `Invoke-GitLog` function ([#6407](https://github.com/ScoopInstaller/Scoop/issues/6407))
 - **buckets:** Skip Git invocation if unavailable in `new_issue_msg` ([#6591](https://github.com/ScoopInstaller/Scoop/issues/6591))

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -189,6 +189,7 @@ function Sync-Bucket {
         $buckets | Where-Object { $_.valid } | ForEach-Object -ThrottleLimit 5 -Parallel {
             . "$using:PSScriptRoot\..\lib\core.ps1"
             . "$using:PSScriptRoot\..\lib\buckets.ps1"
+            . "$using:PSScriptRoot\..\lib\versions.ps1" # 'currentdir' (indirectly)
 
             $name = $_.name
             $bucketLoc = $_.path


### PR DESCRIPTION
﻿#### Description
Dot-source `lib\versions.ps1` inside the `-Parallel` script block in `Sync-Bucket`.

#### Motivation and Context
When `NO_JUNCTION` is enabled, `Invoke-Git` -> `Get-HelperPath` -> `Get-AppFilePath` -> `currentdir` calls `Select-CurrentVersion`, which is defined in `versions.ps1` and not loaded in the parallel runspace. `scoop update` fails under PowerShell 7 with `The term 'Select-CurrentVersion' is not recognized`.

- Closes #6733

#### How Has This Been Tested?
Reproduced the error with `NO_JUNCTION = true` in a runspace loading only `core.ps1` + `buckets.ps1`; verified it is gone after adding the import. `Scoop-00File` and `Scoop-00Linting` Pester suites pass.

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
