### PR TITLE
fix(scoop-update): Fix updating apps installed from a local manifest path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug Fixes
 
 - **scoop-update:** Import `versions.ps1` in the parallel bucket sync to fix `currentdir` failing with `NO_JUNCTION` enabled ([#6735](https://github.com/ScoopInstaller/Scoop/issues/6735))
+- **scoop-update:** Fix updating apps installed from a local manifest path ([#6736](https://github.com/ScoopInstaller/Scoop/issues/6736))
 - **scoop-update:** `scoop update -f` on an `@version` pin now upgrades to the bucket HEAD ([#6730](https://github.com/ScoopInstaller/Scoop/issues/6730))
 - **core:** Fix the grep parameter in the `Invoke-GitLog` function ([#6407](https://github.com/ScoopInstaller/Scoop/issues/6407))
 - **buckets:** Skip Git invocation if unavailable in `new_issue_msg` ([#6591](https://github.com/ScoopInstaller/Scoop/issues/6591))

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -280,7 +280,7 @@ function update($app, $global, $force = $false, $quiet = $false, $independent, $
             $manifest = manifest $app $null $url
         }
     } else {
-        if ($null -eq $bucket) { $bucket = 'main' }
+        if ($null -eq $bucket -and !$url) { $bucket = 'main' }
         $manifest = manifest $app $bucket $url
     }
     $version = $manifest.version


### PR DESCRIPTION
#### Description
Only default `$bucket` to `'main'` in `update()` when the install info carries no `url`, so `manifest()` resolves local-path/URL installs from their recorded url instead of a non-existent `main/<app>` manifest.

#### Motivation and Context
Regression from #6730: apps installed from an external manifest path failed `scoop update <app>` with `No manifest available` because the default `'main'` bucket shadowed the install url.

- Closes #6734

#### How Has This Been Tested?
Installed 7zip (renamed `7zlocal`) from a local manifest path, bumped the manifest version, reproduced `ERROR No manifest available` on develop, then verified `scoop update 7zlocal` upgrades 26.03 -> 99.99 with the fix. `Scoop-00File` and `Scoop-00Linting` Pester suites pass.

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
